### PR TITLE
fix: default value for videoTileProps

### DIFF
--- a/apps/100ms-web/src/views/ActiveSpeakerView.jsx
+++ b/apps/100ms-web/src/views/ActiveSpeakerView.jsx
@@ -10,6 +10,7 @@ export const ActiveSpeakerView = ({
   isChatOpen,
   toggleChat,
   isParticipantListOpen,
+  videoTileProps = () => ({}),
 }) => {
   const peers = useHMSStore(selectPeers);
   const localPeer = useHMSStore(selectLocalPeer);
@@ -42,6 +43,7 @@ export const ActiveSpeakerView = ({
         hideSidePane={!showSidePane}
         isParticipantListOpen={isParticipantListOpen}
         totalPeers={1}
+        videoTileProps={videoTileProps}
       />
       {showSidePane && (
         <GridSidePaneView
@@ -50,6 +52,7 @@ export const ActiveSpeakerView = ({
           toggleChat={toggleChat}
           isParticipantListOpen={isParticipantListOpen}
           totalPeers={peers.length - 1}
+          videoTileProps={videoTileProps}
         />
       )}
     </Fragment>

--- a/apps/100ms-web/src/views/components/gridView.jsx
+++ b/apps/100ms-web/src/views/components/gridView.jsx
@@ -28,7 +28,7 @@ export const GridCenterView = ({
   isParticipantListOpen,
   hideSidePane,
   totalPeers,
-  videoTileProps,
+  videoTileProps = () => ({}),
 }) => {
   return (
     <div
@@ -83,7 +83,7 @@ export const GridSidePaneView = ({
   toggleChat,
   isParticipantListOpen,
   totalPeers,
-  videoTileProps,
+  videoTileProps = () => ({}),
 }) => {
   const isMobile = isMobileDevice();
   const rowCount = isMobile ? 1 : undefined;

--- a/apps/100ms-web/src/views/mainGridView.jsx
+++ b/apps/100ms-web/src/views/mainGridView.jsx
@@ -11,7 +11,7 @@ export const MainGridView = ({
   isChatOpen,
   toggleChat,
   isParticipantListOpen,
-  videoTileProps,
+  videoTileProps = () => ({}),
 }) => {
   const {
     maxTileCount,

--- a/apps/100ms-web/src/views/screenShareView.jsx
+++ b/apps/100ms-web/src/views/screenShareView.jsx
@@ -21,7 +21,7 @@ export const ScreenShareView = ({
   isChatOpen,
   toggleChat,
   isParticipantListOpen,
-  videoTileProps,
+  videoTileProps = () => ({}),
 }) => {
   const peers = useHMSStore(selectPeers);
   const localPeer = useHMSStore(selectLocalPeer);
@@ -88,7 +88,7 @@ export const SidePane = ({
   smallTilePeers,
   isParticipantListOpen,
   totalPeers,
-  videoTileProps,
+  videoTileProps = () => ({}),
 }) => {
   // The main peer's screenshare is already being shown in center view
   const shouldShowScreenFn = useCallback(
@@ -129,7 +129,7 @@ const ScreenShareComponent = ({
   amIPresenting,
   peerPresenting,
   peerSharingPlaylist,
-  videoTileProps,
+  videoTileProps = () => ({}),
 }) => {
   const hmsActions = useHMSActions();
   const screenshareTrack = useHMSStore(
@@ -197,7 +197,7 @@ const SmallTilePeersView = ({
   isChatOpen,
   smallTilePeers,
   shouldShowScreenFn,
-  videoTileProps,
+  videoTileProps = () => ({}),
 }) => {
   return (
     <div className="w-1/2 md:w-full relative md:flex-1">
@@ -223,7 +223,7 @@ const SmallTilePeersView = ({
 const LargeTilePeerView = ({
   peerScreenSharing,
   isChatOpen,
-  videoTileProps,
+  videoTileProps = () => ({}),
 }) => {
   const isMobile = isMobileDevice();
   return (


### PR DESCRIPTION
### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- Fix ActiveSpeakerView not having videoTileProps by providing default value of videoTileProps in every component.
- Add stats(from videoTileProps) in ActiveSpeakerView.

### Choose one of these(put a 'x' in the bracket):

- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
