### PR TITLE
HMS-5568: Added fix for vb-background video overlaying

### DIFF
--- a/apps/100ms-web/package.json
+++ b/apps/100ms-web/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@100mslive/hms-noise-suppression": "0.1.6",
     "@100mslive/hms-video-react": "0.3.116-alpha.0",
-    "@100mslive/hms-virtual-background": "1.3.6",
+    "@100mslive/hms-virtual-background": "1.3.7",
     "@100mslive/react-icons": "0.0.5-alpha.0",
     "@100mslive/react-sdk": "0.0.4",
     "@100mslive/react-ui": "0.0.5-alpha.2",


### PR DESCRIPTION
HMS-5568: Added fix for vb-background video overlaying

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- One of the background video was not applying properly because of incorrect width and height being used. 
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
