### PR TITLE
fix(react-sdk): attach/detach video only when required

### DIFF
--- a/packages/react-sdk/src/hooks/useVideo.ts
+++ b/packages/react-sdk/src/hooks/useVideo.ts
@@ -27,7 +27,7 @@ export const useVideo = (trackId: HMSTrackID): React.RefCallback<HTMLVideoElemen
 
   useEffect(() => {
     (async () => {
-      if (videoRef.current && track) {
+      if (videoRef.current && track?.id) {
         if (inView) {
           if (track.enabled) {
             // attach when in view and enabled
@@ -42,7 +42,7 @@ export const useVideo = (trackId: HMSTrackID): React.RefCallback<HTMLVideoElemen
         }
       }
     })();
-  }, [actions, inView, videoRef, track]);
+  }, [actions, inView, videoRef, track?.id, track?.enabled, track?.deviceID, track?.plugins]);
 
   // detach on unmount
   useEffect(() => {


### PR DESCRIPTION

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

potential fix for black tile, when video is toggled,
display enabled becomes toggles first and then enabled.
So there would be a race between attach and detach which can lead to a bad state


### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
