### PR TITLE
fix: aspect ratio in preview tile for mobile

### DIFF
--- a/apps/100ms-web/src/views/new/Preview.jsx
+++ b/apps/100ms-web/src/views/new/Preview.jsx
@@ -121,7 +121,7 @@ const PreviewTile = ({ name }) => {
   return (
     <StyledVideoTile.Container
       css={{
-        aspectRatio: 1.5,
+        aspectRatio: width / height,
         width: "unset",
         height: "min(360px, 60vh)",
         "@sm": {


### PR DESCRIPTION
Before: at 1.5 aspect ratio

<img width="476" alt="Screenshot 2022-02-22 at 5 57 33 PM" src="https://user-images.githubusercontent.com/61158210/155132442-2fa8b589-23b5-4148-9445-2a625a16ce9d.png">

After:

<img width="699" alt="Screenshot 2022-02-22 at 5 57 57 PM" src="https://user-images.githubusercontent.com/61158210/155132471-857368c7-be89-4696-b696-518e6f472e8f.png">
