### PR TITLE
feat(sdk): video only mode for screenshare

### DIFF
--- a/packages/hms-video-store/src/core/IHMSActions.ts
+++ b/packages/hms-video-store/src/core/IHMSActions.ts
@@ -59,9 +59,13 @@ export interface IHMSActions {
    * The store will be populated with the incoming track, and the subscriber(or
    * react component if our hook is used) will be notified/rerendered
    * @param enabled boolean
-   * @param audioOnly boolean To publish only audio from screenshare
+   * @param config it can also be boolean to ensure backward compatibility where it stands
+   * for audioOnly flag
    */
-  setScreenShareEnabled(enabled: boolean, audioOnly?: boolean): Promise<void>;
+  setScreenShareEnabled(
+    enabled: boolean,
+    config?: { audioOnly?: boolean; videoOnly?: boolean } | boolean,
+  ): Promise<void>;
 
   /**
    * You can use the addTrack method to add an auxiliary track(canvas capture, electron screen-share, etc...)

--- a/packages/hms-video-store/src/core/hmsSDKStore/HMSSDKActions.ts
+++ b/packages/hms-video-store/src/core/hmsSDKStore/HMSSDKActions.ts
@@ -208,9 +208,16 @@ export class HMSSDKActions implements IHMSActions {
       });
   }
 
-  async setScreenShareEnabled(enabled: boolean, audioOnly?: boolean) {
+  async setScreenShareEnabled(enabled: boolean, config?: { audioOnly?: boolean; videoOnly?: boolean } | boolean) {
+    const sdkConfig = { audioOnly: false, videoOnly: false };
+    if (typeof config === 'object') {
+      Object.assign(sdkConfig, config);
+    } else if (typeof config === 'boolean') {
+      // for backward compatibility
+      sdkConfig.audioOnly = config;
+    }
     if (enabled) {
-      await this.startScreenShare(audioOnly);
+      await this.startScreenShare(sdkConfig);
     } else {
       await this.stopScreenShare();
     }
@@ -606,10 +613,10 @@ export class HMSSDKActions implements IHMSActions {
     });
   }
 
-  private async startScreenShare(audioOnly?: boolean) {
+  private async startScreenShare(config?: { audioOnly: boolean; videoOnly: boolean }) {
     const isScreenShared = this.store.getState(selectIsLocalScreenShared);
     if (!isScreenShared) {
-      await this.sdk.startScreenShare(() => this.syncRoomState('screenshareStopped'), audioOnly);
+      await this.sdk.startScreenShare(() => this.syncRoomState('screenshareStopped'), config);
       this.syncRoomState('startScreenShare');
     } else {
       this.logPossibleInconsistency("start screenshare is called while it's on");

--- a/packages/hms-video-web/src/interfaces/hms.ts
+++ b/packages/hms-video-web/src/interfaces/hms.ts
@@ -15,6 +15,7 @@ import { RTMPRecordingConfig } from './rtmp-recording-config';
 import { HMSHLS, HMSRecording, HMSRTMP } from './room';
 import { HMSWebrtcInternals } from '../rtc-stats/HMSWebrtcInternals';
 import { HLSConfig } from './hls-config';
+import { ScreenShareConfig } from './track-settings';
 
 export default interface HMS {
   preview(config: HMSConfig, listener: HMSPreviewListener): Promise<void>;
@@ -57,7 +58,7 @@ export default interface HMS {
   sendGroupMessage(message: string, roles: HMSRole[], type?: string): Promise<HMSMessage>;
   sendDirectMessage(message: string, peer: HMSPeer, type?: string): Promise<HMSMessage>;
 
-  startScreenShare(onStop: () => void, audioOnly: boolean): Promise<void>;
+  startScreenShare(onStop: () => void, config: ScreenShareConfig): Promise<void>;
   stopScreenShare(): Promise<void>;
 
   addTrack(track: MediaStreamTrack, source: HMSTrackSource): Promise<void>;

--- a/packages/hms-video-web/src/interfaces/track-settings.ts
+++ b/packages/hms-video-web/src/interfaces/track-settings.ts
@@ -25,3 +25,8 @@ export interface HMSVideoTrackSettings {
   deviceId?: string;
   advanced?: Array<MediaTrackConstraintSet>;
 }
+
+export interface ScreenShareConfig {
+  audioOnly: boolean;
+  videoOnly: boolean;
+}

--- a/packages/hms-video-web/src/media/settings/HMSTrackSettings.ts
+++ b/packages/hms-video-web/src/media/settings/HMSTrackSettings.ts
@@ -47,13 +47,13 @@ export class HMSTrackSettingsBuilder {
 
 export class HMSTrackSettings implements IAnalyticsPropertiesProvider {
   readonly video: HMSVideoTrackSettings | null;
-  readonly audio: HMSAudioTrackSettings | null;
+  readonly audio: HMSAudioTrackSettings | null | undefined;
   readonly screen: HMSVideoTrackSettings | null;
   readonly simulcast: boolean;
 
   constructor(
     video: HMSVideoTrackSettings | null,
-    audio: HMSAudioTrackSettings | null,
+    audio: HMSAudioTrackSettings | null | undefined,
     simulcast: boolean,
     screen: HMSVideoTrackSettings | null = null,
   ) {

--- a/packages/hms-video-web/src/sdk/LocalTrackManager.ts
+++ b/packages/hms-video-web/src/sdk/LocalTrackManager.ts
@@ -187,20 +187,23 @@ export class LocalTrackManager {
     return nativeTracks;
   }
 
-  async getLocalScreen(videosettings: HMSVideoTrackSettings, audioSettings: HMSAudioTrackSettings) {
-    const audioConstraints: MediaTrackConstraints = audioSettings.toConstraints();
-    // remove advanced constraints as it not supported for screenshare audio
-    delete audioConstraints.advanced;
+  async getLocalScreen(videosettings: HMSVideoTrackSettings, audioSettings?: HMSAudioTrackSettings) {
     const constraints = {
       video: videosettings.toConstraints(),
-      audio: {
+    } as MediaStreamConstraints;
+    if (audioSettings) {
+      const audioConstraints: MediaTrackConstraints = audioSettings.toConstraints();
+      // remove advanced constraints as it not supported for screenshare audio
+      delete audioConstraints.advanced;
+      constraints.audio = {
         ...audioConstraints,
         autoGainControl: false,
         noiseSuppression: false,
+        // @ts-ignore
         googAutoGainControl: false,
         echoCancellation: false,
-      },
-    } as MediaStreamConstraints;
+      };
+    }
     let stream;
     try {
       // @ts-ignore [https://github.com/microsoft/TypeScript/issues/33232]

--- a/packages/hms-video-web/src/transport/index.ts
+++ b/packages/hms-video-web/src/transport/index.ts
@@ -269,7 +269,7 @@ export default class HMSTransport implements ITransport {
 
   async getLocalScreen(
     videoSettings: HMSVideoTrackSettings,
-    audioSettings: HMSAudioTrackSettings,
+    audioSettings?: HMSAudioTrackSettings,
   ): Promise<Array<HMSLocalTrack>> {
     try {
       return await this.localTrackManager.getLocalScreen(videoSettings, audioSettings);


### PR DESCRIPTION
Tested (SS with TAB)

`actions.setScreenShareEnabled(true)` -> can hear audio, video from the tab
`actions.setScreenShareEnabled(true, false)`  -> can hear audio, video from the tab
`actions.setScreenShareEnabled(true, true)` -> can hear audio no video

`actions.setScreenShareEnabled(true, {audioOnly: true})` -> can hear audio no video
`actions.setScreenShareEnabled(true, {videoOnly: true}) `-> can see video no audio
`actions.setScreenShareEnabled(true, {audioOnly: true, videoOnly: true})` -> start tab share but stops