### PR TITLE
refactor: revert leave btn styles

### DIFF
--- a/apps/100ms-web/src/components/LeaveRoom.jsx
+++ b/apps/100ms-web/src/components/LeaveRoom.jsx
@@ -109,6 +109,7 @@ export const LeaveRoom = () => {
 };
 
 const LeaveIconButton = styled(IconButton, {
+  width: "45px",
   mx: "$4",
   bg: "$error",
   "&:not([disabled]):hover": {

--- a/packages/react-ui/src/IconButton/IconButton.tsx
+++ b/packages/react-ui/src/IconButton/IconButton.tsx
@@ -6,7 +6,7 @@ export const IconButton = styled('button', {
   outline: 'none',
   border: 'none',
   padding: '$2',
-  r: '$1',
+  r: '$0',
   cursor: 'pointer',
   backgroundColor: 'transparent',
   color: '$textPrimary',


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-729" title="WEB-729" target="_blank">WEB-729</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>refactor: leave btn according to design</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
