### PR TITLE
refactor: rm default radius from dropdown trigger

### DIFF
--- a/apps/100ms-web/src/components/MoreSettings/MoreSettings.jsx
+++ b/apps/100ms-web/src/components/MoreSettings/MoreSettings.jsx
@@ -54,9 +54,6 @@ export const MoreSettings = () => {
           <IconButton
             css={{
               mx: "$4",
-              '&[data-state="open"]': {
-                borderRadius: "$0",
-              },
             }}
           >
             <Tooltip title="More Options">

--- a/packages/react-ui/src/Dropdown/Dropdown.tsx
+++ b/packages/react-ui/src/Dropdown/Dropdown.tsx
@@ -8,7 +8,6 @@ const DropdownTrigger = styled(Trigger, {
   appearance: 'none !important',
   '&[data-state="open"]': {
     backgroundColor: '$menuBg',
-    borderRadius: '$1',
   },
   '&:focus': {
     outline: 'none',


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-733" title="WEB-733" target="_blank">WEB-733</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>dropdown trigger styles</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
