### PR TITLE
feat(sdk): cancel network request on join/leave

### DIFF
--- a/packages/hms-video-web/src/sdk/index.ts
+++ b/packages/hms-video-web/src/sdk/index.ts
@@ -265,7 +265,7 @@ export class HMSSdk implements HMSInterface {
       this.transport
         .connect(config.authToken, config.initEndpoint || 'https://prod-init.100ms.live/init', this.localPeer!.peerId)
         .then((initConfig: InitConfig | void) => {
-          if (initConfig) {
+          if (initConfig && this.listener?.onNetworkQuality) {
             this.networkTestManager.start(initConfig.config?.networkHealth);
           }
         })
@@ -304,6 +304,7 @@ export class HMSSdk implements HMSInterface {
     if (this.sdkState.isPreviewInProgress) {
       throw ErrorFactory.GenericErrors.NotReady(HMSAction.JOIN, "Preview is in progress, can't join");
     }
+    this.networkTestManager.stop();
     const { roomId, userId, role } = decodeJWT(config.authToken);
     this.localPeer?.audioTrack?.destroyAudioLevelMonitor();
     this.listener = listener;
@@ -393,6 +394,7 @@ export class HMSSdk implements HMSInterface {
     const room = this.store.getRoom();
     if (room) {
       const roomId = room.id;
+      this.networkTestManager.stop();
       HMSLogger.d(this.TAG, `⏳ Leaving room ${roomId}`);
       // browsers often put limitation on amount of time a function set on window onBeforeUnload can take in case of
       // tab refresh or close. Therefore prioritise the leave action over anything else, if tab is closed/refreshed


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-738" title="WEB-738" target="_blank">WEB-738</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>handle join/leave call while preview network check before timeout happens</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
