### PR TITLE
feat(web-app): add keyboard shortcut for toggling audio and video

### DIFF
--- a/apps/100ms-web/src/App.js
+++ b/apps/100ms-web/src/App.js
@@ -50,7 +50,7 @@ if (window.location.host.includes("localhost")) {
 document.title = `${appName}'s ${document.title}`;
 
 const hmsReactiveStore = new HMSReactiveStore();
-const keyboardInputManager = KeyboardInputManager(hmsReactiveStore);
+const keyboardInputManager = new KeyboardInputManager(hmsReactiveStore);
 
 export function EdtechComponent({
   roomId = "",

--- a/apps/100ms-web/src/components/AudioVideoToggle.jsx
+++ b/apps/100ms-web/src/components/AudioVideoToggle.jsx
@@ -8,6 +8,18 @@ import {
 import { Tooltip, IconButton } from "@100mslive/react-ui";
 import { useAVToggle } from "@100mslive/react-sdk";
 
+/**
+ * 'navigator.useAgentData.platform' is the recommended way to
+ * 'platform sniff'. Although, it's still not implemented in
+ * Firefox and Safari. So when not available, the deprecated
+ * 'navigator.platform' is used for backward compatibility.
+ */
+let isMacOS = /mac/i.test(
+  navigator.userAgentData
+    ? navigator.userAgentData.platform
+    : navigator.platform
+);
+
 export const AudioVideoToggle = ({ compact = false }) => {
   const { isLocalVideoEnabled, isLocalAudioEnabled, toggleAudio, toggleVideo } =
     useAVToggle();
@@ -15,7 +27,9 @@ export const AudioVideoToggle = ({ compact = false }) => {
     <Fragment>
       {toggleAudio ? (
         <Tooltip
-          title={`Turn ${isLocalAudioEnabled ? "off" : "on"} audio (ctrl + m)`}
+          title={`Turn ${isLocalAudioEnabled ? "off" : "on"} audio (${
+            isMacOS ? "⌘" : "ctrl"
+          } + d)`}
         >
           <IconButton
             css={{ mr: compact ? "$2" : "$4" }}
@@ -29,9 +43,9 @@ export const AudioVideoToggle = ({ compact = false }) => {
       ) : null}
       {toggleVideo ? (
         <Tooltip
-          title={`Turn ${
-            isLocalVideoEnabled ? "off" : "on"
-          } video (ctrl + shift + k)`}
+          title={`Turn ${isLocalVideoEnabled ? "off" : "on"} video (${
+            isMacOS ? "⌘" : "ctrl"
+          } + e)`}
         >
           <IconButton
             css={compact ? { ml: "$2" } : { mx: "$4" }}


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-473" title="WEB-473" target="_blank">WEB-473</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>keyboard shortcut for mute/unmute</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details

-WEB 473

### Choose one of these(put a 'x' in the bracket):

- [X] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note

* I really didn't know where to call unbind shortcuts. @triptu @raviteja83 if you can tell me whats the right place to unbind them, that'd be great
* Currently, the shortcuts all get bound at <AppRoute/> level to make sure that the mute/unmute work on both preview page and Conference page, but this means its gonna be bound even in the Left meeting page. It doesn't break anything at the moment. But on a scalability note, we have to figure out how to only executes shortcuts if it has meaning in the page/component its pressed on.
