### PR TITLE
fix: set initConfig on headless join

### DIFF
--- a/packages/hms-video-web/src/transport/index.ts
+++ b/packages/hms-video-web/src/transport/index.ts
@@ -297,6 +297,7 @@ export default class HMSTransport implements ITransport {
     return flags.includes(flag);
   }
 
+  // eslint-disable-next-line complexity
   async join(
     authToken: string,
     peerId: string,
@@ -304,6 +305,10 @@ export default class HMSTransport implements ITransport {
     initEndpoint = 'https://prod-init.100ms.live/init',
     autoSubscribeVideo = false,
   ): Promise<void> {
+    if (!this.initConfig) {
+      const initConfig = await this.connect(authToken, initEndpoint, peerId);
+      this.initConfig = initConfig as InitConfig;
+    }
     const isServerHandlingDegradation = this.isFlagEnabled(InitFlags.FLAG_SERVER_SUB_DEGRADATION);
     this.setTransportStateForJoin();
     this.joinParameters = new JoinParameters(


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-786" title="WEB-786" target="_blank">WEB-786</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>sub degradation flag not send on headless join</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a>, <a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20server-side-subscribe-degradation%20ORDER%20BY%20created%20DESC" title="server-side-subscribe-degradation">server-side-subscribe-degradation</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
