### PR TITLE
fix(web-app): detach screenshare properly on audio-only-mode

### DIFF
--- a/packages/react-sdk/src/hooks/useVideo.ts
+++ b/packages/react-sdk/src/hooks/useVideo.ts
@@ -33,8 +33,10 @@ export const useVideo = ({ trackId, attach }: useVideoInput): useVideoOutput => 
 
   const setRefs = useCallback(
     node => {
-      videoRef.current = node;
-      inViewRef(node);
+      if (node) {
+        videoRef.current = node;
+        inViewRef(node);
+      }
     },
     [inViewRef],
   );


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-35" title="WEB-35" target="_blank">WEB-35</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>(web) audio only mode in UI</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details
- [WEB-35](https://100ms.atlassian.net/browse/WEB-35)

### Choose one of these(put a 'x' in the bracket):

- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.
