### PR TITLE
fix(web-app): set isPreviewInProgress to false before onPreview()

### DIFF
--- a/packages/hms-video-web/src/sdk/index.ts
+++ b/packages/hms-video-web/src/sdk/index.ts
@@ -268,8 +268,8 @@ export class HMSSdk implements HMSInterface {
         tracks.forEach(track => this.setLocalPeerTrack(track));
         this.localPeer?.audioTrack && this.initPreviewTrackAudioLevelMonitor();
         await this.initDeviceManagers();
-        listener.onPreview(this.store.getRoom(), tracks);
         this.sdkState.isPreviewInProgress = false;
+        listener.onPreview(this.store.getRoom(), tracks);
         resolve();
       };
 


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-798" title="WEB-798" target="_blank">WEB-798</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>fix race condition - preview is in progress should be set to false before onpreview call (reported by frontrow)</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- [WEB-798](https://100ms.atlassian.net/browse/WEB-798)

### Choose one of these(put a 'x' in the bracket):

- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

