### PR TITLE
fix(app): preview tile size changing when video enabled

### DIFF
--- a/apps/100ms-web/src/components/Preview.jsx
+++ b/apps/100ms-web/src/components/Preview.jsx
@@ -139,7 +139,11 @@ const PreviewTile = ({ name }) => {
         aspectRatio: width / height,
         width: "unset",
         height: "min(360px, 60vh)",
-        "@sm": { maxWidth: "90%" },
+        "@sm": {
+          height: "unset",
+          width: "min(360px, 90%)",
+          maxWidth: "90%",
+        },
       }}
       ref={borderAudioRef}
     >


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-257" title="WEB-257" target="_blank">WEB-257</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Bug-Safari: Video tile size on preview page is not consistent when camera is ON and OFF</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a>, <a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20web-sdk%20ORDER%20BY%20created%20DESC" title="web-sdk">web-sdk</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
