### PR TITLE
fix(app): show screenshare tile label below tile

### DIFF
--- a/apps/100ms-web/src/components/ScreenshareTile.jsx
+++ b/apps/100ms-web/src/components/ScreenshareTile.jsx
@@ -15,6 +15,15 @@ import screenfull from "screenfull";
 import { UI_SETTINGS } from "../common/constants";
 import { useUISettings } from "./AppData/useUISettings";
 
+const labelStyles = {
+  position: "unset",
+  width: "100%",
+  textAlign: "center",
+  transform: "none",
+  mt: "$2",
+  flexShrink: 0,
+};
+
 const Tile = ({
   peerId,
   showStatsOnTiles,
@@ -44,6 +53,7 @@ const Tile = ({
         <StyledVideoTile.Container
           transparentBg
           ref={fullscreenRef}
+          css={{ flexDirection: "column" }}
           onMouseEnter={() => setIsMouseHovered(true)}
           onMouseLeave={() => {
             setIsMouseHovered(false);
@@ -70,7 +80,7 @@ const Tile = ({
               trackId={track.id}
             />
           ) : null}
-          <StyledVideoTile.Info>{label}</StyledVideoTile.Info>
+          <StyledVideoTile.Info css={labelStyles}>{label}</StyledVideoTile.Info>
           {isMouseHovered && !peer?.isLocal ? (
             <TileMenu
               isScreenshare


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-506" title="WEB-506" target="_blank">WEB-506</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[web] screen presenter text should be below screen</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
