### PR TITLE
fix: video tile not recovering after degradation

### DIFF
--- a/packages/hms-video-web/src/media/streams/stream.test.ts
+++ b/packages/hms-video-web/src/media/streams/stream.test.ts
@@ -14,6 +14,15 @@ describe('HMSRemoteStream', () => {
     stream = new HMSRemoteStream(nativeStream, connection);
   });
 
+  const expectSubscriptionMessage = ({ audio, video }: { audio: boolean; video?: HMSSimulcastLayer }) => {
+    const calls = sendOverApiDataChannel.mock.calls;
+    const args = JSON.parse(calls[calls.length - 1]);
+    expect(args['streamId']).toBe(streamId);
+    expect(args['audio']).toBe(audio);
+    expect(args['video']).toBe(video);
+    expect(args['framerate']).toBe(video);
+  };
+
   // no video is subscribed by default
   it('returns none by default for video, true for audio', () => {
     expect(stream.getSimulcastLayer()).toBe(HMSSimulcastLayer.NONE);
@@ -23,19 +32,24 @@ describe('HMSRemoteStream', () => {
   it('sends data channel message when layer is switched', () => {
     stream.setVideoLayer(HMSSimulcastLayer.HIGH, 'test');
     expect(sendOverApiDataChannel.mock.calls.length).toBe(1);
-    const args = JSON.parse(sendOverApiDataChannel.mock.calls[0][0]);
-    expect(args['streamId']).toBe(streamId);
-    expect(args['video']).toBe(HMSSimulcastLayer.HIGH);
-    expect(args['audio']).toBe(true);
-    expect(args['framerate']).toBe(HMSSimulcastLayer.HIGH);
+    expectSubscriptionMessage({ audio: true, video: HMSSimulcastLayer.HIGH });
   });
 
   it('sends message when audio is disabled', () => {
     stream.setAudio(true);
     expect(sendOverApiDataChannel.mock.calls.length).toBe(0);
     stream.setAudio(false);
-    const args = JSON.parse(sendOverApiDataChannel.mock.calls[0][0]);
-    expect(args['streamId']).toBe(streamId);
-    expect(args['audio']).toBe(false);
+    expectSubscriptionMessage({ audio: false });
+  });
+
+  it('does not send video field for audio subscription but sends audio for video', () => {
+    stream.setAudio(false);
+    expectSubscriptionMessage({ audio: false });
+    stream.setVideoLayer(HMSSimulcastLayer.HIGH, 'test');
+    expectSubscriptionMessage({ audio: false, video: HMSSimulcastLayer.HIGH });
+    stream.setAudio(true);
+    expectSubscriptionMessage({ audio: true });
+    stream.setVideoLayer(HMSSimulcastLayer.MEDIUM, 'test');
+    expectSubscriptionMessage({ audio: true, video: HMSSimulcastLayer.MEDIUM });
   });
 });


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-870" title="WEB-870" target="_blank">WEB-870</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>degraded tracks never recovering</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
