### PR TITLE
fix(app): no video in large peer tile of side pane WEB-879

### DIFF
--- a/apps/100ms-web/src/components/VideoTile.jsx
+++ b/apps/100ms-web/src/components/VideoTile.jsx
@@ -14,6 +14,7 @@ import {
   selectPeerNameByID,
   selectAudioTrackByPeerID,
   selectTrackByID,
+  selectVideoTrackByPeerID,
 } from "@100mslive/react-sdk";
 import {
   MicOffIcon,
@@ -27,7 +28,10 @@ import { UI_SETTINGS } from "../common/constants";
 import { useUISettings } from "./AppData/useUISettings";
 
 const Tile = ({ peerId, trackId, showStatsOnTiles, width, height, index }) => {
-  const track = useHMSStore(selectTrackByID(trackId));
+  const trackSelector = trackId
+    ? selectTrackByID(trackId)
+    : selectVideoTrackByPeerID(peerId);
+  const track = useHMSStore(trackSelector);
   const peerName = useHMSStore(selectPeerNameByID(peerId));
   const audioTrack = useHMSStore(selectAudioTrackByPeerID(peerId));
   const localPeerID = useHMSStore(selectLocalPeerID);


### PR DESCRIPTION
### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- Use default selector on null trackId
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
