### PR TITLE
fix(app): blank center space when role is not subscribing to other roles

### DIFF
--- a/apps/100ms-web/src/components/context/appContextUtils.js
+++ b/apps/100ms-web/src/components/context/appContextUtils.js
@@ -127,14 +127,14 @@ export const normalizeAppPolicyConfig = (
     const subscribedRoles =
       rolesMap[roleName].subscribeParams?.subscribeToRoles || [];
 
-    const isNotSubscringOrSubscringToSelf =
+    const isNotSubscribingOrSubscribingToSelf =
       subscribedRoles.length === 0 ||
       (subscribedRoles.length === 1 && subscribedRoles[0] === roleName);
     if (!newConfig[roleName].center) {
       const publishingRoleNames = roleNames.filter(roleName =>
         canPublishAV(rolesMap[roleName])
       );
-      if (isNotSubscringOrSubscringToSelf) {
+      if (isNotSubscribingOrSubscribingToSelf) {
         newConfig[roleName].center = [roleName];
       } else {
         // all other publishing roles apart from local role in center by default
@@ -145,7 +145,7 @@ export const normalizeAppPolicyConfig = (
     }
     // everyone from my role is in sidepane by default if they can publish
     if (!newConfig[roleName].sidepane) {
-      if (isNotSubscringOrSubscringToSelf) {
+      if (isNotSubscribingOrSubscribingToSelf) {
         newConfig[roleName].sidepane = [];
       } else {
         newConfig[roleName].sidepane = canPublishAV(rolesMap[roleName])


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-882" title="WEB-882" target="_blank">WEB-882</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Breakout rooms showing the center as empty when roles are not subscribed</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
