### PR TITLE
feat(sdk): add roomId to http client events

### DIFF
--- a/packages/hms-video-web/src/analytics/AnalyticsEvent.ts
+++ b/packages/hms-video-web/src/analytics/AnalyticsEvent.ts
@@ -27,6 +27,7 @@ export default class AnalyticsEvent implements ISignalParamsProvider<SignalEvent
     token?: string;
     peerId?: string;
     sessionId?: string;
+    roomId?: string;
   } = {};
   timestamp: number;
   event_id: string;

--- a/packages/hms-video-web/src/analytics/AnalyticsEventsService.ts
+++ b/packages/hms-video-web/src/analytics/AnalyticsEventsService.ts
@@ -64,6 +64,7 @@ export class AnalyticsEventsService {
   private sendClientEventOnHTTP(event: AnalyticsEvent) {
     event.metadata.sessionId = this.store.getRoom().sessionId;
     event.metadata.token = this.store.getConfig()?.authToken;
+    event.metadata.roomId = this.store.getRoom().id;
     HTTPAnalyticsTransport.sendEvent(event);
   }
 }

--- a/packages/hms-video-web/src/analytics/HTTPAnalyticsTransport.ts
+++ b/packages/hms-video-web/src/analytics/HTTPAnalyticsTransport.ts
@@ -15,6 +15,7 @@ interface ClientEventBody {
   event_id: string;
   peer_id?: string;
   session_id?: string;
+  room_id?: string;
   timestamp: number;
   payload: Record<string, any>;
   agent: string;
@@ -43,6 +44,7 @@ class ClientAnalyticsTransport implements IAnalyticsTransportProvider {
       event_id: String(event.timestamp),
       peer_id: event.metadata.peerId,
       session_id: event.metadata.sessionId,
+      room_id: event.metadata.roomId,
       timestamp: Date.now(),
       agent: userAgent,
       device_id: event.device_id,


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-438" title="WEB-438" target="_blank">WEB-438</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>way to send terminal events, preview stage failures to HTTP eventsApi</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
