### PR TITLE
fix: fix ui center being black in active speaker

### DIFF
--- a/apps/100ms-web/src/layouts/ActiveSpeakerView.jsx
+++ b/apps/100ms-web/src/layouts/ActiveSpeakerView.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useRef } from "react";
 import {
   selectPeers,
   useHMSStore,


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-906" title="WEB-906" target="_blank">WEB-906</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>active speaker showing blank center just after joining</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

happens if there hasn't been any dominant speaker### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
