### PR TITLE
fix(sdk): decrement sinkcount only if video was attached

### DIFF
--- a/packages/hms-video-web/src/media/tracks/HMSVideoTrack.ts
+++ b/packages/hms-video-web/src/media/tracks/HMSVideoTrack.ts
@@ -33,9 +33,11 @@ export class HMSVideoTrack extends HMSTrack {
    * @param videoElement
    */
   removeSink(videoElement: HTMLVideoElement) {
-    videoElement.srcObject = null;
-    if (this.sinkCount > 0) {
-      this.sinkCount--;
+    if (videoElement.srcObject !== null) {
+      videoElement.srcObject = null;
+      if (this.sinkCount > 0) {
+        this.sinkCount--;
+      }
     }
   }
 


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-822" title="WEB-822" target="_blank">WEB-822</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>multiple video element freezes the tile- calls remove sink </td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
