### PR TITLE
fix: handle no peers field sent in room state

### DIFF
--- a/packages/hms-video-web/src/notification-manager/managers/PeerListManager.ts
+++ b/packages/hms-video-web/src/notification-manager/managers/PeerListManager.ts
@@ -64,7 +64,12 @@ export class PeerListManager {
       // we can't process the peers yet we don't know enough about them(role info)
       return;
     }
-    const roomPeers = roomState.peers || {};
+    const roomPeers = roomState.peers;
+    if (roomPeers === null || roomPeers === undefined) {
+      // room state doesn't say anything about the peers, if there are no peers,
+      // empty object would come instead
+      return;
+    }
     // we don't get tracks inside the peer object in room state, we're adding
     // an empty value here so rest of the code flow can ignore this change, the below
     // can be changed when tracks will be sent as a separate object in future


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-953" title="WEB-953" target="_blank">WEB-953</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>handle no peers field sent in room state</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

it shouldn't lead to peer list getting cleared

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
