### PR TITLE
feat(sdk): add random delay in retry signal join

### DIFF
--- a/packages/hms-video-web/src/signal/jsonrpc/index.ts
+++ b/packages/hms-video-web/src/signal/jsonrpc/index.ts
@@ -28,6 +28,7 @@ import Message from '../../sdk/models/HMSMessage';
 import { HMSException } from '../../error/HMSException';
 import { Queue } from '../../utils/queue';
 import { isPageHidden } from '../../utils/support';
+import { sleep } from '../../utils/timer-utils';
 
 export default class JsonRpcSignal implements ISignal {
   readonly TAG = '[ SIGNAL ]: ';
@@ -412,6 +413,9 @@ export default class JsonRpcSignal implements ISignal {
         if (!shouldRetry) {
           break;
         }
+
+        const delay = (2 + Math.random() * 2) * 1000;
+        await sleep(delay);
       }
     }
     HMSLogger.e(`Sending join over WS failed after ${MAX_RETRIES} retries`, params);


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-968" title="WEB-968" target="_blank">WEB-968</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>change retry delay from 2 seconds to 2 seconds + random value from 0-2 seconds</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20hls-scaling%20ORDER%20BY%20created%20DESC" title="hls-scaling">hls-scaling</a>, <a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
