### PR TITLE
feat: auto populate meeting url for recording

### DIFF
--- a/apps/100ms-custom-app/src/App.js
+++ b/apps/100ms-custom-app/src/App.js
@@ -41,6 +41,7 @@ const App = () => {
     logo_obj: null,
     logo_url: null,
     logo_name: null,
+    recording_url: '',
     metadataFields: {
       clicks: 0,
       metadata: '',
@@ -271,6 +272,7 @@ const App = () => {
               logo: settings.logo_url || (settings.theme === 'dark' ? logoDark : logoLight),
               headerPresent: String(!!getAuthInfo().userEmail),
               metadata: settings.metadataFields.metadata,
+              recordingUrl: settings.recording_url,
             }}
             getUserToken={getRoomDetails}
           />

--- a/apps/100ms-web/src/App.js
+++ b/apps/100ms-web/src/App.js
@@ -72,6 +72,7 @@ export function EdtechComponent({
     logo = "",
     headerPresent = "false",
     metadata = "",
+    recordingUrl = "",
   },
   getUserToken = defaultGetUserToken,
   policyConfig = envPolicyConfig,
@@ -89,7 +90,7 @@ export function EdtechComponent({
     setThemeType(theme);
   }, [theme]);
 
-  const getUserTokenCallback = useCallback(getUserToken, []);
+  const getUserTokenCallback = useCallback(getUserToken, []); //eslint-disable-line
 
   return (
     <ErrorBoundary>
@@ -128,6 +129,7 @@ export function EdtechComponent({
               <AppRoutes
                 getUserToken={getUserTokenCallback}
                 appDetails={metadata}
+                recordingUrl={recordingUrl}
               />
             </Box>
           </AppContextProvider>
@@ -152,13 +154,13 @@ const RedirectToPreview = () => {
   return <Navigate to={`/preview/${roomId}/${role || ""}`} />;
 };
 
-function AppRoutes({ getUserToken, appDetails }) {
+function AppRoutes({ getUserToken, appDetails, recordingUrl }) {
   return (
     <Router>
       <ToastContainer />
       <Notifications />
       <Confetti />
-      <AppData appDetails={appDetails} />
+      <AppData appDetails={appDetails} recordingUrl={recordingUrl} />
       <KeyboardHandler />
       <Routes>
         <Route

--- a/apps/100ms-web/src/common/constants.js
+++ b/apps/100ms-web/src/common/constants.js
@@ -109,6 +109,7 @@ export const APP_DATA = {
   chatOpen: "chatOpen",
   chatDraft: "chatDraft",
   appConfig: "appConfig",
+  recordingUrl: "recordingUrl",
 };
 export const UI_SETTINGS = {
   isAudioOnly: "isAudioOnly",

--- a/apps/100ms-web/src/components/AppData/AppData.jsx
+++ b/apps/100ms-web/src/components/AppData/AppData.jsx
@@ -10,7 +10,7 @@ export const getAppDetails = appDetails => {
   }
 };
 
-export function AppData({ appDetails }) {
+export function AppData({ appDetails, recordingUrl }) {
   const hmsActions = useHMSActions();
   useEffect(() => {
     const initialAppData = {
@@ -20,10 +20,11 @@ export function AppData({ appDetails }) {
       },
       [APP_DATA.chatOpen]: false,
       [APP_DATA.chatDraft]: "",
+      [APP_DATA.recordingUrl]: recordingUrl,
       [APP_DATA.appConfig]: getAppDetails(appDetails),
     };
     hmsActions.initAppData(initialAppData);
-  }, [hmsActions, appDetails]);
+  }, [hmsActions, appDetails, recordingUrl]);
 
   return null;
 }

--- a/apps/100ms-web/src/components/MoreSettings/RecordingAndRTMPModal.jsx
+++ b/apps/100ms-web/src/components/MoreSettings/RecordingAndRTMPModal.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useState } from "react";
 import {
+  selectAppData,
   selectPermissions,
   useHMSActions,
   useHMSStore,
@@ -16,6 +17,7 @@ import {
 import { ToastManager } from "../Toast/ToastManager";
 import { ResolutionInput } from "./ResolutionInput";
 import {
+  APP_DATA,
   QUERY_PARAM_SKIP_PREVIEW,
   RTMP_RECORD_DEFAULT_RESOLUTION,
   RTMP_RESOLUTION_IGNORED_WARNING_TEXT,
@@ -34,8 +36,10 @@ export const RecordingAndRTMPModal = ({ onOpenChange }) => {
     isStreamingOn,
     isBrowserRecordingOn,
   } = useRecordingStreaming();
-
-  const [meetingURL, setMeetingURL] = useState(defaultMeetingUrl);
+  const recordingUrl = useHMSStore(selectAppData(APP_DATA.recordingUrl));
+  const [meetingURL, setMeetingURL] = useState(
+    recordingUrl || defaultMeetingUrl
+  );
   const [rtmpURL, setRTMPURL] = useState("");
   const [hlsSelected, setHLS] = useState(false);
   const [recordingResolution, setRecordingResolution] = useState(


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-975" title="WEB-975" target="_blank">WEB-975</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Update the default meeting url for HLS / beam recording in web app </td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
