### PR TITLE
fix: slack message only on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,10 +27,10 @@ jobs:
         if: github.event.inputs.publishFlag == 'latest' && success()
         id: slack # IMPORTANT: reference this step ID value in future Slack steps
         env: 
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEPLOY_NOTIF_CHANNEL_ID }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEPLOY_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
-          channel_id: ${{ secrets.SLACK_DEPLOY_NOTIF_CHANNEL_ID }}
+          channel_id: ${{ secrets.SLACK_DEPLOY_PROD_CHANNEL_ID }}
           status: Start
           color: warning
 
@@ -48,11 +48,11 @@ jobs:
       - name: Notify slack publish
         if: github.event.inputs.publishFlag == 'latest' && success()
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEPLOY_NOTIF_CHANNEL_ID }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEPLOY_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
           message_id: ${{ steps.slack.outputs.message_id }}
-          channel_id: ${{ secrets.SLACK_DEPLOY_NOTIF_CHANNEL_ID }}
+          channel_id: ${{ secrets.SLACK_DEPLOY_PROD_CHANNEL_ID }}
           status: Publishing
           color: "#bada55"
 
@@ -68,21 +68,21 @@ jobs:
       - name: Notify slack success
         if: github.event.inputs.publishFlag == 'latest' && success()
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEPLOY_NOTIF_CHANNEL_ID }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEPLOY_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
           message_id: ${{ steps.slack.outputs.message_id }}
-          channel_id: ${{ secrets.SLACK_DEPLOY_NOTIF_CHANNEL_ID }}
+          channel_id: ${{ secrets.SLACK_DEPLOY_PROD_CHANNEL_ID }}
           status: Success
           color: good
 
       - name: Notify slack fail
         if: github.event.inputs.publishFlag == 'latest' && failure()
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEPLOY_NOTIF_CHANNEL_ID }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEPLOY_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
           message_id: ${{ steps.slack.outputs.message_id }}
-          channel_id: ${{ secrets.SLACK_DEPLOY_NOTIF_CHANNEL_ID }}
+          channel_id: ${{ secrets.SLACK_DEPLOY_PROD_CHANNEL_ID }}
           status: Failed
           color: danger


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1012" title="WEB-1012" target="_blank">WEB-1012</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>notify on slack at the end of publish workflow for latest release</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

- [x] send messages only on `releases`
- [x] change room id to `#deploy-prod`