### PR TITLE
fix(sdk): join retry - set isTerminal only on retry, error message in HMSException

### DIFF
--- a/packages/hms-video-web/src/transport/index.ts
+++ b/packages/hms-video-web/src/transport/index.ts
@@ -730,12 +730,16 @@ export default class HMSTransport implements ITransport {
       const hmsError =
         error instanceof HMSException
           ? error
-          : ErrorFactory.WebsocketMethodErrors.ServerErrors(500, HMSAction.JOIN, `Default join WS error`);
-      hmsError.isTerminal = false;
+          : ErrorFactory.WebsocketMethodErrors.ServerErrors(
+              500,
+              HMSAction.JOIN,
+              `Websocket join error - ${(error as Error).message}`,
+            );
       const shouldRetry = parseInt(`${hmsError.code / 100}`) === 5 || hmsError.code === 429;
 
-      this.joinRetryCount = 0;
       if (shouldRetry) {
+        this.joinRetryCount = 0;
+        hmsError.isTerminal = false;
         const task = async () => {
           this.joinRetryCount++;
           return await this.negotiateJoin({ name, data, autoSubscribeVideo, serverSubDegrade, isWebRTC });


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-972" title="WEB-972" target="_blank">WEB-972</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>add retry count to client.join.success event</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
