### PR TITLE
fix: stats for nerds ui

### DIFF
--- a/apps/100ms-web/src/components/Settings/DeviceSettings.jsx
+++ b/apps/100ms-web/src/components/Settings/DeviceSettings.jsx
@@ -6,23 +6,17 @@ import {
   selectLocalVideoTrackID,
   selectIsLocalVideoEnabled,
 } from "@100mslive/react-sdk";
-import {
-  ChevronDownIcon,
-  ChevronUpIcon,
-  MicOnIcon,
-  SpeakerIcon,
-  VideoOnIcon,
-} from "@100mslive/react-icons";
+import { MicOnIcon, SpeakerIcon, VideoOnIcon } from "@100mslive/react-icons";
 import {
   Button,
   Text,
   Flex,
   Dropdown,
   Box,
-  textEllipsis,
   StyledVideoTile,
   Video,
 } from "@100mslive/react-ui";
+import { DialogDropdownTrigger } from "../../primitives/DropdownTrigger";
 
 /**
  * wrap the button on click of whom settings should open, this component will take care of the rest,
@@ -132,15 +126,8 @@ const DeviceSelector = ({
           }}
         >
           <Dropdown.Root open={open} onOpenChange={setOpen}>
-            <Dropdown.Trigger
-              asChild
-              data-testid={`${title}_selector`}
+            <DialogDropdownTrigger
               css={{
-                border: "1px solid $borderLight",
-                bg: "$surfaceLight",
-                r: "$1",
-                p: "$6 $9",
-                zIndex: 10,
                 ...(children
                   ? {
                       flex: "1 1 0",
@@ -148,32 +135,12 @@ const DeviceSelector = ({
                     }
                   : {}),
               }}
-            >
-              <Flex
-                css={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  color: "$textHighEmp",
-                  w: "100%",
-                }}
-              >
-                {icon}
-                <Text
-                  css={{
-                    color: "inherit",
-                    ...textEllipsis("90%"),
-                    flex: "1 1 0",
-                    mx: "$6",
-                  }}
-                >
-                  {
-                    devices.find(({ deviceId }) => deviceId === selection)
-                      ?.label
-                  }
-                </Text>
-                {open ? <ChevronUpIcon /> : <ChevronDownIcon />}
-              </Flex>
-            </Dropdown.Trigger>
+              icon={icon}
+              title={
+                devices.find(({ deviceId }) => deviceId === selection)?.label
+              }
+              open={open}
+            />
             <Dropdown.Content
               align="start"
               sideOffset={8}

--- a/apps/100ms-web/src/components/StatsForNerds.jsx
+++ b/apps/100ms-web/src/components/StatsForNerds.jsx
@@ -12,11 +12,12 @@ import {
   Box,
   Flex,
   Switch,
-  Select,
+  Dropdown,
   Label,
   HorizontalDivider,
 } from "@100mslive/react-ui";
 import { AppContext } from "./context/AppContext";
+import { DialogDropdownTrigger } from "../primitives/DropdownTrigger";
 
 export const StatsForNerds = ({ onOpenChange }) => {
   const tracksWithLabels = useTracksWithLabel();
@@ -29,6 +30,7 @@ export const StatsForNerds = ({ onOpenChange }) => {
   );
   const [selectedStat, setSelectedStat] = useState("local-peer");
   const { showStatsOnTiles, setShowStatsOnTiles } = useContext(AppContext);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     if (
@@ -43,13 +45,11 @@ export const StatsForNerds = ({ onOpenChange }) => {
     <Dialog.Root defaultOpen onOpenChange={onOpenChange}>
       <Dialog.Content
         css={{
-          width: "min(500px, 100%)",
-          bg: "$surfaceDefault",
-          border: "solid $space$px $borderDefault",
+          width: "min(500px, 95%)",
         }}
       >
         {/* Title */}
-        <Dialog.Title>
+        <Dialog.Title css={{ p: "$4 0" }}>
           <Flex justify="between">
             <Flex align="center" css={{ mb: "$1" }}>
               <Text variant="h6" inline>
@@ -71,22 +71,56 @@ export const StatsForNerds = ({ onOpenChange }) => {
           </Text>
         </Flex>
         {/* Select */}
-        <Flex direction="column" css={{ gap: "$4", mb: "$12" }}>
+        <Flex
+          direction="column"
+          css={{
+            gap: "$4",
+            mb: "$12",
+            position: "relative",
+            minWidth: 0,
+            "[data-radix-popper-content-wrapper]": {
+              w: "100%",
+              minWidth: "0 !important",
+              mt: "$4",
+              transform: "translateY($space$20) !important",
+              zIndex: 11,
+            },
+          }}
+        >
           <Label variant="body2">Stats For</Label>
-          <Select.Root data-testid="dialog_select_Stats For">
-            <Select.DefaultDownIcon />
-            <Select.Select
-              onChange={e => setSelectedStat(e.target.value)}
-              value={selectedStat}
-              css={{ width: "100%" }}
+          <Dropdown.Root
+            data-testid="dialog_select_Stats For"
+            open={open}
+            onOpenChange={setOpen}
+          >
+            <DialogDropdownTrigger
+              title={
+                statsOptions.find(({ id }) => id === selectedStat)?.label ||
+                "Select Stats"
+              }
+              open={open}
+            />
+            <Dropdown.Content
+              align="start"
+              sideOffset={8}
+              css={{ w: "100%" }}
+              portalled={false}
             >
               {statsOptions.map(option => (
-                <option value={option["id"]} key={option["id"]}>
-                  {option["label"]}
-                </option>
+                <Dropdown.Item
+                  key={option.id}
+                  onClick={() => {
+                    setSelectedStat(option.id);
+                  }}
+                  css={{
+                    bg: option.id === selectedStat ? "$primaryDark" : undefined,
+                  }}
+                >
+                  {option.label}
+                </Dropdown.Item>
               ))}
-            </Select.Select>
-          </Select.Root>
+            </Dropdown.Content>
+          </Dropdown.Root>
         </Flex>
         {/* Stats */}
         {selectedStat === "local-peer" ? (
@@ -180,7 +214,7 @@ const TrackStats = ({ trackID }) => {
 };
 
 const StatsRow = ({ label, value }) => (
-  <Box css={{ bg: "$surfaceLight", w: "47%", p: "$8", r: "$3" }}>
+  <Box css={{ bg: "$surfaceLight", w: "calc(50% - $6)", p: "$8", r: "$3" }}>
     <Text
       variant="overline"
       css={{

--- a/apps/100ms-web/src/primitives/DropdownTrigger.jsx
+++ b/apps/100ms-web/src/primitives/DropdownTrigger.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { ChevronDownIcon, ChevronUpIcon } from "@100mslive/react-icons";
+import { Text, Flex, Dropdown, textEllipsis } from "@100mslive/react-ui";
+
+const DialogDropdownTrigger = ({ title, css, open, icon }) => {
+  return (
+    <Dropdown.Trigger
+      asChild
+      data-testid={`${title}_selector`}
+      css={{
+        border: "1px solid $borderLight",
+        bg: "$surfaceLight",
+        r: "$1",
+        p: "$6 $9",
+        zIndex: 10,
+        ...css,
+      }}
+    >
+      <Flex
+        css={{
+          display: "flex",
+          justifyContent: "space-between",
+          color: "$textHighEmp",
+          w: "100%",
+        }}
+      >
+        {icon}
+        <Text
+          css={{
+            color: "inherit",
+            ...textEllipsis("90%"),
+            flex: "1 1 0",
+            mx: "$6",
+          }}
+        >
+          {title}
+        </Text>
+        {open ? <ChevronUpIcon /> : <ChevronDownIcon />}
+      </Flex>
+    </Dropdown.Trigger>
+  );
+};
+
+export { DialogDropdownTrigger };

--- a/packages/react-ui/src/Dropdown/Dropdown.tsx
+++ b/packages/react-ui/src/Dropdown/Dropdown.tsx
@@ -53,6 +53,7 @@ const DropdownContent = styled(Content, {
   py: '$4',
   backgroundColor: '$surfaceLight',
   overflowY: 'auto',
+  boxShadow: '0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23)',
 });
 
 const DropdownLabel = styled(Label, {

--- a/packages/react-ui/src/Modal/DialogContent.tsx
+++ b/packages/react-ui/src/Modal/DialogContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { CrossIcon } from '@100mslive/react-icons';
 import { styled } from '../Theme';
@@ -24,6 +24,8 @@ export const StyledDialogContent = styled(DialogPrimitive.Content, {
   position: 'fixed',
   top: '50%',
   left: '50%',
+  border: '$space$px solid $borderDefault',
+  boxShadow: '0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23)',
   transform: 'translate(-50%, -50%)',
   zIndex: 999,
   padding: '$12',
@@ -43,7 +45,7 @@ export const DialogTitle = styled(DialogPrimitive.Title, {
   padding: '$4',
 });
 
-export const DialogDefaultCloseIcon = ({ ...props }: any) => (
+export const DialogDefaultCloseIcon = (props: ComponentProps<typeof IconButton>) => (
   <DialogClose asChild>
     <IconButton {...props}>
       <CrossIcon />


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1078" title="WEB-1078" target="_blank">WEB-1078</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>[Mobile Web] Stats for Nerds Screen appears broken</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Subtask" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />
        Subtask
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
