### PR TITLE
refactor: remove padding from accordion content

### DIFF
--- a/packages/react-ui/src/Accordion/Accordion.tsx
+++ b/packages/react-ui/src/Accordion/Accordion.tsx
@@ -3,6 +3,7 @@ import { keyframes, CSS } from '@stitches/react';
 import * as BaseAccordion from '@radix-ui/react-accordion';
 import { ChevronDownIcon } from '@radix-ui/react-icons';
 import { styled } from '../Theme';
+import { Box } from '../Layout';
 
 const slideDown = keyframes({
   from: { height: 0 },
@@ -67,7 +68,6 @@ const StyledContent = styled(BaseAccordion.Content, {
   fontFamily: '$sans',
   color: '$textMedEmp',
   backgroundColor: '$surfaceDefault',
-  padding: '$8 $9',
 
   '&[data-state="open"]': {
     animation: `${slideDown} 300ms cubic-bezier(0.87, 0, 0.13, 1) forwards`,
@@ -104,6 +104,6 @@ export const AccordionContent: React.FC<PropsWithChildren<BaseAccordion.Accordio
   PropsWithChildren<BaseAccordion.AccordionContentProps>
 >(({ children, ...props }, forwardedRef) => (
   <StyledContent {...props} ref={forwardedRef}>
-    {children}
+    <Box css={{ padding: '$8 $9' }}>{children}</Box>
   </StyledContent>
 ));


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1126" title="WEB-1126" target="_blank">WEB-1126</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Accordion Fix</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
