### PR TITLE
fix: name overflow wrap anywhere, time as span

### DIFF
--- a/apps/100ms-web/src/components/Chat/ChatBody.jsx
+++ b/apps/100ms-web/src/components/Chat/ChatBody.jsx
@@ -176,11 +176,11 @@ const ChatMessage = React.memo(({ message, autoMarginTop = false }) => {
           width: "100%",
         }}
       >
-        {message.senderName === "You" ? (
-          <SenderName>{message.senderName}</SenderName>
+        {message.senderName === "You" || !message.senderName ? (
+          <SenderName>{message.senderName || "Anonymous"}</SenderName>
         ) : (
           <Tooltip title={message.senderName} side="top" align="start">
-            <SenderName>{message.senderName || "Anonymous"}</SenderName>
+            <SenderName>{message.senderName}</SenderName>
           </Tooltip>
         )}
         <Text


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1168" title="WEB-1168" target="_blank">WEB-1168</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>clip long name in chat box</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- name on chat `overflow-wrap: anywhere`
- make time indicator a span and a child of name

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
