### PR TITLE
fix: replace word-break break-all with break-word

### DIFF
--- a/apps/100ms-web/src/components/Chat/ChatBody.jsx
+++ b/apps/100ms-web/src/components/Chat/ChatBody.jsx
@@ -89,7 +89,7 @@ const URL_REGEX =
 
 const Link = styled("a", {
   color: "$brandDefault",
-  wordBreak: "break-all",
+  wordBreak: "break-word",
   "&:hover": {
     textDecoration: "underline",
   },

--- a/apps/100ms-web/src/components/Notifications/InitErrorModal.jsx
+++ b/apps/100ms-web/src/components/Notifications/InitErrorModal.jsx
@@ -34,7 +34,7 @@ export const InitErrorModal = ({ notification }) => {
       onOpenChange={setShowModal}
       title={info.title}
     >
-      <Text variant="sm" css={{ wordBreak: "break-all" }}>
+      <Text variant="sm" css={{ wordBreak: "break-word" }}>
         {info.description} Current URL - {window.location.href}
       </Text>
     </ErrorDialog>


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1213" title="WEB-1213" target="_blank">WEB-1213</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>replace word-break: break-all to break-word for better browser support</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- replace word-break break-all with break-word

### Choose one of these(put a 'x' in the bracket):

- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
