### PR TITLE
feat: hide audio output when not supported.

### DIFF
--- a/apps/100ms-web/src/components/Settings/DeviceSettings.jsx
+++ b/apps/100ms-web/src/components/Settings/DeviceSettings.jsx
@@ -18,7 +18,7 @@ import {
 } from "@100mslive/react-ui";
 import { DialogDropdownTrigger } from "../../primitives/DropdownTrigger";
 import { useDropdownSelection } from "../hooks/useDropdownSelection";
-import { settingOverflow } from './common.js';
+import { settingOverflow } from "./common.js";
 
 /**
  * wrap the button on click of whom settings should open, this component will take care of the rest,
@@ -32,8 +32,8 @@ const Settings = () => {
   const isVideoOn = useHMSStore(selectIsLocalVideoEnabled);
   // don't show speaker selector where the API is not supported, and use
   // a generic word("Audio") for Mic. In some cases(Chrome Android for e.g.) this changes both mic and speaker keeping them in sync.
-  const shouldShowAudioOutput = 'setSinkId' in HTMLMediaElement.prototype
-  
+  const shouldShowAudioOutput = "setSinkId" in HTMLMediaElement.prototype;
+
   return (
     <Box className={settingOverflow()}>
       {videoInput?.length ? (
@@ -70,7 +70,7 @@ const Settings = () => {
       ) : null}
       {audioInput?.length ? (
         <DeviceSelector
-          title={ shouldShowAudioOutput ? "Microphone" : "Audio" }
+          title={shouldShowAudioOutput ? "Microphone" : "Audio"}
           icon={<MicOnIcon />}
           devices={audioInput}
           selection={selectedDeviceIDs.audioInput}


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-894" title="WEB-894" target="_blank">WEB-894</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Show only audio for microphone and speaker in device settings on mweb.</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- Added audio-only dropdown for mobile view.
- https://100ms.atlassian.net/browse/WEB-894

