### PR TITLE
feat(types): ensure screen track inheriting video track

### DIFF
--- a/packages/hms-video-store/src/core/hmsSDKStore/HMSSDKActions.ts
+++ b/packages/hms-video-store/src/core/hmsSDKStore/HMSSDKActions.ts
@@ -13,7 +13,6 @@ import {
   HMSTrackID,
   HMSTrackSource,
   HMSVideoTrack,
-  HMSScreenVideoTrack,
   IHMSPlaylistActions,
 } from '../schema';
 import { IHMSActions } from '../IHMSActions';
@@ -38,7 +37,6 @@ import {
   selectTrackByID,
   selectVideoTrackByID,
   selectTracksMap,
-  selectScreenVideoTrackByID,
 } from '../selectors';
 import { HMSLogger } from '../../common/ui-logger';
 import {
@@ -1091,15 +1089,12 @@ export class HMSSDKActions implements IHMSActions {
   private updateVideoLayer(trackID: string, action: string) {
     const sdkTrack = this.hmsSDKTracks[trackID];
     if (sdkTrack && sdkTrack instanceof SDKHMSRemoteVideoTrack) {
-      const storeTrack =
-        sdkTrack.source === 'screen'
-          ? this.store.getState(selectScreenVideoTrackByID(trackID))
-          : this.store.getState(selectVideoTrackByID(trackID));
+      const storeTrack = this.store.getState(selectVideoTrackByID(trackID));
       const hasFieldChanged =
         storeTrack?.layer !== sdkTrack.getSimulcastLayer() || storeTrack?.degraded !== sdkTrack.degraded;
       if (hasFieldChanged) {
         this.setState(draft => {
-          const track = draft.tracks[trackID] as HMSVideoTrack | HMSScreenVideoTrack;
+          const track = draft.tracks[trackID] as HMSVideoTrack;
           track.layer = sdkTrack.getSimulcastLayer();
           track.degraded = sdkTrack.degraded;
         }, action);

--- a/packages/hms-video-store/src/core/selectors/selectorUtils.ts
+++ b/packages/hms-video-store/src/core/selectors/selectorUtils.ts
@@ -1,4 +1,4 @@
-import { HMSPeer, HMSScreenVideoTrack, HMSStore, HMSTrack, HMSTrackID, HMSVideoTrack } from '../schema';
+import { HMSPeer, HMSStore, HMSTrack, HMSTrackID, HMSVideoTrack } from '../schema';
 
 type trackCheck = (track: HMSTrack | undefined) => boolean | undefined;
 
@@ -41,7 +41,7 @@ export function isVideoPlaylist(track: HMSTrack | undefined) {
   return track && track.source === 'videoplaylist';
 }
 
-export function isDegraded(track: HMSVideoTrack | HMSScreenVideoTrack) {
+export function isDegraded(track: HMSVideoTrack) {
   if (track) {
     return Boolean(track?.degraded);
   }

--- a/packages/hms-video-store/src/core/selectors/selectorsByID.ts
+++ b/packages/hms-video-store/src/core/selectors/selectorsByID.ts
@@ -46,7 +46,7 @@ const selectVideoTrackByIDBare = createSelector([selectTracksMap, selectTrackID]
     return null;
   }
   const track = storeTracks[trackID] as HMSVideoTrack;
-  if (track.type === 'video' && track.source !== 'screen') {
+  if (track.type === 'video') {
     return track;
   }
   return null;
@@ -57,7 +57,7 @@ const selectAudioTrackByIDBare = createSelector([selectTracksMap, selectTrackID]
     return null;
   }
   const track = storeTracks[trackID] as HMSAudioTrack;
-  if (track.type === 'audio' && track.source !== 'screen') {
+  if (track.type === 'audio') {
     return track;
   }
   return null;

--- a/packages/hms-video-store/src/test/fixtures.ts
+++ b/packages/hms-video-store/src/test/fixtures.ts
@@ -2,7 +2,7 @@ import { HMSAudioTrack, HMSPeer, HMSVideoTrack, HMSTrackType } from '../core';
 
 let counter = 100;
 type HMSObjectType<T> = T extends 'audio' ? HMSAudioTrack : T extends 'video' ? HMSVideoTrack : HMSVideoTrack;
-export const makeFakeTrack = <T extends HMSTrackType>(type?: HMSTrackType): HMSObjectType<T> => {
+export const makeFakeTrack = <T extends HMSTrackType>(type?: T): HMSObjectType<T> => {
   return {
     enabled: false,
     id: String(counter++),

--- a/packages/hms-video-store/src/test/unit/storeMergeUtils.test.ts
+++ b/packages/hms-video-store/src/test/unit/storeMergeUtils.test.ts
@@ -15,7 +15,7 @@ describe('tracks merge is happening properly', () => {
     draftTracks = {};
     newTracks = {};
     draftTracksCopy = draftTracks;
-    fakeTrack = makeFakeTrack<'video'>();
+    fakeTrack = makeFakeTrack('video');
   });
 
   const expectNoReferenceChange = () => {
@@ -76,8 +76,8 @@ describe('peers merge is happening properly', () => {
     newTracks = {};
     draftPeersCopy = draftPeers;
     fakePeer = makeFakePeer();
-    const audio = makeFakeTrack<'audio'>('audio');
-    const video = makeFakeTrack<'video'>('video');
+    const audio = makeFakeTrack('audio');
+    const video = makeFakeTrack('video');
     const screenshare = makeFakeTrack('video');
     newTracks[audio.id] = audio;
     newTracks[video.id] = video;
@@ -145,7 +145,7 @@ describe('peers merge is happening properly', () => {
   test('replace track does not change peer.videoTrack', () => {
     fakePeer.isLocal = true;
     draftPeers[fakePeer.id] = fakePeer;
-    const newVideo = makeFakeTrack<'video'>('video');
+    const newVideo = makeFakeTrack('video');
     const clonedPeer = { ...fakePeer, videoTrack: newVideo.id };
     const newSDKTrack = {} as SDKTrack;
     newSDKTracks[newVideo.id] = newSDKTrack;


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1175" title="WEB-1175" target="_blank">WEB-1175</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>split HMSTrack in store into different types</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- Fixed the screen share issues.
