### PR TITLE
refactor(sdk): log setMaxBitrate fail as warning

### DIFF
--- a/packages/hms-video-web/src/transport/index.ts
+++ b/packages/hms-video-web/src/transport/index.ts
@@ -652,7 +652,7 @@ export default class HMSTransport implements ITransport {
         .then(() => {
           HMSLogger.d(TAG, `Setting maxBitrate for ${track.source} ${track.type} to ${maxBitrate} kpbs`);
         })
-        .catch(error => HMSLogger.e(TAG, 'Failed setting maxBitrate', error));
+        .catch(error => HMSLogger.w(TAG, 'Failed setting maxBitrate', error));
     }
 
     HMSLogger.d(TAG, `✅ publishTrack: trackId=${track.trackId}`, `${track}`, this.callbacks);


### PR DESCRIPTION
it fails in nodejs env everytime, creating lot of noise if log level is set to error. Setting log level to none risks losing on actual errors

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
