### PR TITLE
fix(sdk): dont send leave to biz on peer leave request

### DIFF
--- a/packages/hms-video-web/src/sdk/index.ts
+++ b/packages/hms-video-web/src/sdk/index.ts
@@ -258,7 +258,7 @@ export class HMSSdk implements HMSInterface {
       requestedBy: peer,
     };
     this.listener?.onRemovedFromRoom(request);
-    this.leave();
+    this.internalLeave(false);
   };
 
   async preview(config: HMSConfig, listener: HMSPreviewListener) {
@@ -460,7 +460,11 @@ export class HMSSdk implements HMSInterface {
     }
   }
 
-  async leave() {
+  leave() {
+    return this.internalLeave();
+  }
+
+  private async internalLeave(notifyServer = true) {
     const room = this.store.getRoom();
     if (room) {
       const roomId = room.id;
@@ -470,7 +474,7 @@ export class HMSSdk implements HMSInterface {
       // tab refresh or close. Therefore prioritise the leave action over anything else, if tab is closed/refreshed
       // we would want leave to succeed to stop stucked peer for others. The followup cleanup however is important
       // for cases where uses stays on the page post leave.
-      await this.transport?.leave();
+      await this.transport?.leave(notifyServer);
       this.cleanUp();
       HMSLogger.d(this.TAG, `✅ Left room ${roomId}`);
     }

--- a/packages/hms-video-web/src/signal/jsonrpc/index.ts
+++ b/packages/hms-video-web/src/signal/jsonrpc/index.ts
@@ -181,6 +181,9 @@ export default class JsonRpcSignal implements ISignal {
   }
 
   async close(): Promise<void> {
+    window.removeEventListener('offline', this.offlineListener);
+    window.removeEventListener('online', this.onlineListener);
+
     // For `1000` Refer: https://tools.ietf.org/html/rfc6455#section-7.4.1
     if (this.socket) {
       this.socket.close(1000, 'Normal Close');
@@ -249,8 +252,6 @@ export default class JsonRpcSignal implements ISignal {
 
   leave() {
     this.notify(HMSSignalMethod.LEAVE, { version: '1.0' });
-    window.removeEventListener('offline', this.offlineListener);
-    window.removeEventListener('online', this.onlineListener);
   }
 
   async endRoom(lock: boolean, reason: string) {

--- a/packages/hms-video-web/src/transport/ITransport.ts
+++ b/packages/hms-video-web/src/transport/ITransport.ts
@@ -24,7 +24,7 @@ export interface IFetchAVTrackOptions {
 export default interface ITransport {
   join(authToken: string, peerId: string, customData: any, initEndpoint?: string): Promise<void>;
 
-  leave(): Promise<void>;
+  leave(notifyServer: boolean): Promise<void>;
 
   publish(tracks: Array<HMSLocalTrack>): Promise<void>;
 

--- a/packages/hms-video-web/src/transport/index.ts
+++ b/packages/hms-video-web/src/transport/index.ts
@@ -419,7 +419,7 @@ export default class HMSTransport implements ITransport {
     }
   }
 
-  async leave(): Promise<void> {
+  async leave(notifyServer: boolean): Promise<void> {
     this.retryScheduler.reset();
     this.joinParameters = undefined;
     HMSLogger.d(TAG, 'leaving in transport');
@@ -429,11 +429,13 @@ export default class HMSTransport implements ITransport {
       this.trackDegradationController?.cleanUp();
       await this.publishConnection?.close();
       await this.subscribeConnection?.close();
-      try {
-        this.signal.leave();
-        HMSLogger.d(TAG, 'signal leave done');
-      } catch (err) {
-        HMSLogger.w(TAG, 'failed to send leave on websocket to server', err);
+      if (notifyServer) {
+        try {
+          this.signal.leave();
+          HMSLogger.d(TAG, 'signal leave done');
+        } catch (err) {
+          HMSLogger.w(TAG, 'failed to send leave on websocket to server', err);
+        }
       }
       this.analyticsEventsService.flushFailedClientEvents();
       this.analyticsEventsService.reset();


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1239" title="WEB-1239" target="_blank">WEB-1239</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Dont send leave event post on-peer-leave-request</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

…y server flag

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
