### PR TITLE
fix: don't show layers when video disabled/degrade

### DIFF
--- a/apps/100ms-web/src/components/TileMenu.jsx
+++ b/apps/100ms-web/src/components/TileMenu.jsx
@@ -127,7 +127,7 @@ const SimulcastLayers = ({ trackId }) => {
   const track = useHMSStore(selectTrackByID(trackId));
   const actions = useHMSActions();
   const bg = useDropdownSelection();
-  if (!track?.layerDefinitions) {
+  if (!track?.layerDefinitions || track.degraded || !track.enabled) {
     return null;
   }
   return (


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1287" title="WEB-1287" target="_blank">WEB-1287</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>simulcast layers ui appears even for streams which doesnt have video track</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a>, <a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20simulcast%20ORDER%20BY%20created%20DESC" title="simulcast">simulcast</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
