### PR TITLE
fix(app): increase reconnecting toast duration

### DIFF
--- a/apps/100ms-web/src/components/Notifications/ReconnectNotifications.jsx
+++ b/apps/100ms-web/src/components/Notifications/ReconnectNotifications.jsx
@@ -25,7 +25,7 @@ export const ReconnectNotifications = () => {
       LogRocket.track("Reconnecting");
       notificationId = ToastManager.replaceToast(
         notificationId,
-        ToastConfig.RECONNECTING.single()
+        ToastConfig.RECONNECTING.single(notification.data.message)
       );
     }
   }, [notification]);

--- a/apps/100ms-web/src/components/Toast/ToastConfig.js
+++ b/apps/100ms-web/src/components/Toast/ToastConfig.js
@@ -135,10 +135,10 @@ export const ToastConfig = {
     },
   },
   RECONNECTING: {
-    single: () => {
+    single: message => {
       return {
         title: `You are offline for now. while we try to reconnect, please check
-        your internet connection.
+        your internet connection. ${message}.
       `,
         icon: <PoorConnectivityIcon />,
         variant: "warning",


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1220" title="WEB-1220" target="_blank">WEB-1220</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Show Ice connection toasts for longer duration</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- increased to 30s so toast will stay until retry succeeds or app is tore down
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
