### PR TITLE
feat(sdk): ability to choose between screenshare modal tabs

### DIFF
--- a/apps/100ms-web/src/components/ScreenshareHintModal.jsx
+++ b/apps/100ms-web/src/components/ScreenshareHintModal.jsx
@@ -14,7 +14,10 @@ export const ScreenShareHintModal = ({ onClose }) => {
             variant="primary"
             onClick={() => {
               hmsActions
-                .setScreenShareEnabled(true, { audioOnly: true })
+                .setScreenShareEnabled(true, {
+                  audioOnly: true,
+                  displaySurface: "browser",
+                })
                 .catch(console.error);
               onClose();
             }}

--- a/packages/hms-video-web/src/interfaces/track-settings.ts
+++ b/packages/hms-video-web/src/interfaces/track-settings.ts
@@ -44,6 +44,14 @@ export interface HMSScreenShareConfig {
    */
   videoOnly?: boolean;
   /**
+   * preselect the relevant tab in screenshare menu
+   * browser - for preferring a browser tab
+   * window - for application window
+   * monitor - for full screen
+   * @default monitor
+   */
+  displaySurface?: 'browser' | 'monitor' | 'window';
+  /**
    * show the current tab first in supported browser, throws
    * error if user doesn't select current tab for sharing.
    * @default false

--- a/packages/hms-video-web/src/sdk/LocalTrackManager.ts
+++ b/packages/hms-video-web/src/sdk/LocalTrackManager.ts
@@ -156,7 +156,7 @@ export class LocalTrackManager {
     const config = await this.getOrDefaultScreenshareConfig(partialConfig);
     const { video: videoSettings, audio: audioSettings } = this.getScreenshareSettings(config.videoOnly);
     const constraints = {
-      video: videoSettings.toConstraints(),
+      video: { ...videoSettings.toConstraints(), displaySurface: config.displaySurface },
       preferCurrentTab: config.preferCurrentTab,
       selfBrowserSurface: config.selfBrowserSurface,
       surfaceSwitching: config.surfaceSwitching,
@@ -527,6 +527,7 @@ export class LocalTrackManager {
         selfBrowserSurface: 'exclude', // don't give self tab in options
         surfaceSwitching: 'include', // give option to switch tabs while sharing
         systemAudio: 'exclude', // system audio share leads to echo in windows
+        displaySurface: 'monitor',
       },
       partialConfig || {},
     );


### PR DESCRIPTION
<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1174" title="WEB-1174" target="_blank">WEB-1174</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>implement region capture for screenshare with iframe ability in webapp for e.g.</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- https://developer.chrome.com/docs/web-platform/screen-sharing-controls/#displaySurface
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
