### PR TITLE
fix: changeName noop when name is same

### DIFF
--- a/packages/hms-video-web/src/transport/index.ts
+++ b/packages/hms-video-web/src/transport/index.ts
@@ -585,9 +585,12 @@ export default class HMSTransport implements ITransport {
     }
   }
   async changeName(name: string) {
-    await this.signal.updatePeer({
-      name: name,
-    });
+    const peer = this.store.getLocalPeer();
+    if (peer && peer.name !== name) {
+      await this.signal.updatePeer({
+        name: name,
+      });
+    }
   }
 
   async changeMetadata(metadata: string) {


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1333" title="WEB-1333" target="_blank">WEB-1333</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>changeName throwing error when called with same name again</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- HMSTransport check if name is different. If not, noop.

### Choose one of these(put a 'x' in the bracket):

- [x] The change doesn't require a change to the documentation.

### Implementation note, gotchas, related work and Future TODOs (optional)
