### PR TITLE
fix(sdk): reject join/preview on server error

### DIFF
--- a/packages/hms-video-web/src/events/EventBus.ts
+++ b/packages/hms-video-web/src/events/EventBus.ts
@@ -70,4 +70,6 @@ export class EventBus {
   );
 
   readonly autoplayError = new HMSInternalEvent<HMSException>(HMSEvents.AUTOPLAY_ERROR, this.eventEmitter);
+
+  readonly leave = new HMSInternalEvent<HMSException | undefined>(HMSEvents.LEAVE, this.eventEmitter);
 }

--- a/packages/hms-video-web/src/utils/constants.ts
+++ b/packages/hms-video-web/src/utils/constants.ts
@@ -44,4 +44,5 @@ export const HMSEvents = {
   AUDIO_TRACK_ADDED: 'audio-track-added',
   AUDIO_TRACK_REMOVED: 'audio-track-removed',
   AUTOPLAY_ERROR: 'autoplay-error',
+  LEAVE: 'leave',
 };


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1298" title="WEB-1298" target="_blank">WEB-1298</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>join promise never fulfills in some cases</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- emit leave event to reject join/preview promise
- prevent onError being called twice in case preview/join is in progress

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
