### PR TITLE
fix: layers not showing in tile menu when no permissions

### DIFF
--- a/apps/100ms-web/src/components/TileMenu.jsx
+++ b/apps/100ms-web/src/components/TileMenu.jsx
@@ -46,7 +46,7 @@ const TileMenu = ({
   });
   const track = useHMSStore(selectTrackByID(videoTrackID));
   const hideSimulcastLayers =
-    track?.layerDefinitions?.length || track.degraded || !track.enabled;
+    !track?.layerDefinitions?.length || track.degraded || !track.enabled;
   if (
     !(removeOthers || toggleAudio || toggleVideo || setVolume) &&
     hideSimulcastLayers


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1344" title="WEB-1344" target="_blank">WEB-1344</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Simulcast layers not shown when remote peer does not have audio and local peer has no permissions</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
