### PR TITLE
fix: move env declaration before yarn build

### DIFF
--- a/apps/100ms-web/Dockerfile
+++ b/apps/100ms-web/Dockerfile
@@ -10,14 +10,6 @@ RUN yarn install
 
 ENV NODE_ENV production
 
-# Build the app
-RUN yarn build
-
-# Bundle static assets with nginx
-FROM nginx:1.23.1-alpine AS production
-# Copy built assets from builder
-COPY --from=builder /100ms-web/build /usr/share/nginx/html
-
 # set environment variables.
 # These are the bare minimum needed for running
 # the app. Feel free to add more as per your needs.
@@ -36,6 +28,14 @@ ENV REACT_APP_ENABLE_STATS_FOR_NERDS='false'
 ENV REACT_APP_PUSHER_APP_KEY=''
 ENV REACT_APP_PUSHER_AUTHENDPOINT=''
 ENV REACT_APP_HEADLESS_JOIN='false'
+
+# Build the app
+RUN yarn build
+
+# Bundle static assets with nginx
+FROM nginx:1.23.1-alpine AS production
+# Copy built assets from builder
+COPY --from=builder /100ms-web/build /usr/share/nginx/html
 
 # Add your nginx.conf
 COPY nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1363" title="WEB-1363" target="_blank">WEB-1363</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>fix github wiki issues</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- move env declaration before `yarn build` command

### Choose one of these(put a 'x' in the bracket):

- [x] The change doesn't require a change to the documentation.

### Implementation note, gotchas, related work and Future TODOs (optional)
