### PR TITLE
fix: close unmute modal on remove or room ended

### DIFF
--- a/apps/100ms-web/src/components/Notifications/TrackUnmuteModal.jsx
+++ b/apps/100ms-web/src/components/Notifications/TrackUnmuteModal.jsx
@@ -12,13 +12,19 @@ export const TrackUnmuteModal = () => {
   const notification = useHMSNotifications(
     HMSNotificationTypes.CHANGE_TRACK_STATE_REQUEST
   );
+  const endedOrRemovedNotification = useHMSNotifications([
+    HMSNotificationTypes.ROOM_ENDED,
+    HMSNotificationTypes.REMOVED_FROM_ROOM,
+  ]);
   const [muteNotification, setMuteNotification] = useState(null);
 
   useEffect(() => {
-    if (notification?.data.enabled) {
+    if (endedOrRemovedNotification?.data.roomEnded) {
+      setMuteNotification(null);
+    } else if (notification?.data.enabled) {
       setMuteNotification(notification.data);
     }
-  }, [notification]);
+  }, [notification, endedOrRemovedNotification]);
 
   if (!muteNotification) {
     return null;


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-926" title="WEB-926" target="_blank">WEB-926</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Mute/unmute popup still present after endroom</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- close mute/unmute request on remove or room ended

### Choose one of these(put a 'x' in the bracket):

- [x] The change doesn't require a change to the documentation.

### Implementation note, gotchas, related work and Future TODOs (optional)
