### PR TITLE
ci: add build artifacts in github actions

### DIFF
--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: yarn packages cache
         uses: actions/cache@v2
-        if: github.event.inputs.env != 'prod' || github.event.inputs.env == 'staging'
+        if: github.event.inputs.env != 'prod' || github.event.inputs.env != 'staging'
         with:
           path: |
             node_modules


### PR DESCRIPTION
<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1384" title="WEB-1384" target="_blank">WEB-1384</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Update github action workflows to have artifacts for easy revert and deployment</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- Added changes in GitHub actions flow to create build artifacts.
- Easy to revert and upload any artifacts.
- Permission is required to move from stage to prod.
- Dev/QA workflow - https://github.com/100mslive/web-sdks/actions/runs/3590712165
- Staging/Prod workflow - https://github.com/100mslive/web-sdks/actions/runs/3590713662
- Artifact size - 25MB approx
- Artifact expiry time - 90 days.