### PR TITLE
fix: hls not playing if joined before the stream started

### DIFF
--- a/apps/100ms-web/src/controllers/hls/HLSController.js
+++ b/apps/100ms-web/src/controllers/hls/HLSController.js
@@ -16,9 +16,9 @@ export class HLSController {
     this.hlsUrl = hlsUrl;
     this.hls = new Hls(this.getHLSConfig());
     this.videoRef = videoRef;
+    this.handleErrors();
     this.hls.loadSource(hlsUrl);
     this.hls.attachMedia(videoRef.current);
-    this.handleErrors();
     this.handleHLSTimedMetadataParsing();
     this.ControllerEvents = [
       HLS_TIMED_METADATA_LOADED,


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1399" title="WEB-1399" target="_blank">WEB-1399</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>HLS player not playing when hls viewer already joined</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
