### PR TITLE
fix: update layer only on track updates

### DIFF
--- a/packages/hms-video-store/src/core/hmsSDKStore/HMSSDKActions.ts
+++ b/packages/hms-video-store/src/core/hmsSDKStore/HMSSDKActions.ts
@@ -68,6 +68,7 @@ import {
   selectRoomState,
   selectTrackByID,
   selectTracksMap,
+  selectVideoTrackByID,
 } from '../selectors';
 
 // import { ActionBatcher } from './sdkUtils/ActionBatcher';
@@ -144,6 +145,11 @@ export class HMSSDKActions implements IHMSActions {
         //@ts-ignore
         if (layer === HMSSimulcastLayer.NONE) {
           HMSLogger.w(`layer ${HMSSimulcastLayer.NONE} will be ignored`);
+          return;
+        }
+        const alreadyInSameState = this.store.getState(selectVideoTrackByID(trackId))?.preferredLayer === layer;
+        if (alreadyInSameState) {
+          HMSLogger.w(`preferred layer is already ${layer}`);
           return;
         }
         this.setState(draftStore => {


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1383" title="WEB-1383" target="_blank">WEB-1383</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>(simulcast) Mismatch in stats for nerds resolution and selected resolution UI </td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a>, <a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20simulcast%20ORDER%20BY%20created%20DESC" title="simulcast">simulcast</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
