### PR TITLE
fix: hls streaming stuck on loader when destinations disabled

### DIFF
--- a/apps/100ms-web/src/components/Streaming/HLSStreaming.jsx
+++ b/apps/100ms-web/src/components/Streaming/HLSStreaming.jsx
@@ -53,13 +53,13 @@ const StartHLS = () => {
             : undefined,
         });
       } catch (error) {
+        setHLSStarted(false);
         if (error.message.includes("invalid input")) {
           await startHLS([
             { meetingURL: recordingUrl || getDefaultMeetingUrl() },
           ]);
           return;
         }
-        setHLSStarted(false);
         setError(error.message);
       }
     },


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1445" title="WEB-1445" target="_blank">WEB-1445</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>show UI error if destinations disabled and user start hls</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
