### PR TITLE
feat: handle sub/pub degradation of remote video

### DIFF
--- a/packages/hms-video-web/src/media/tracks/HMSRemoteVideoTrack.ts
+++ b/packages/hms-video-web/src/media/tracks/HMSRemoteVideoTrack.ts
@@ -103,22 +103,21 @@ export class HMSRemoteVideoTrack extends HMSVideoTrack {
    * @returns {boolean} isDegraded - returns true if degraded
    * */
   setLayerFromServer(layerUpdate: VideoTrackLayerUpdate) {
-    const isDegraded = layerUpdate.subscriber_degraded;
-    // TODO: remove && check later when degraded status handling is updated. This is to keep in sink with android and ios
-    this._degraded = isDegraded && layerUpdate.current_layer === HMSSimulcastLayer.NONE;
-    this._degradedAt = isDegraded ? new Date() : this._degradedAt;
+    this._degraded =
+      layerUpdate.expected_layer !== layerUpdate.current_layer && layerUpdate.current_layer === HMSSimulcastLayer.NONE;
+    this._degradedAt = this._degraded ? new Date() : this._degradedAt;
     const currentLayer = layerUpdate.current_layer;
     HMSLogger.d(
       `[Remote Track] ${this.logIdentifier} ${this.stream.id} - layer update from sfu`,
       `currLayer=${layerUpdate.current_layer}, preferredLayer=${layerUpdate.expected_layer}`,
       `sub_degraded=${layerUpdate.subscriber_degraded}`,
       `pub_degraded=${layerUpdate.publisher_degraded}`,
-      `isDegraded=${isDegraded}`,
+      `isDegraded=${this._degraded}`,
     );
     // No need to send preferLayer update, as server has done it already
     (this.stream as HMSRemoteStream).setVideoLayerLocally(currentLayer, this.logIdentifier, 'setLayerFromServer');
     this.pushInHistory(`sfuLayerUpdate-${currentLayer}`);
-    return isDegraded;
+    return this._degraded;
   }
 
   /**


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1448" title="WEB-1448" target="_blank">WEB-1448</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Handle publish degradation in the isDegraded flag </td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
