### PR TITLE
fix: prevent chat copy, paste, and cut event from propagating

### DIFF
--- a/apps/100ms-web/src/components/Chat/ChatFooter.jsx
+++ b/apps/100ms-web/src/components/Chat/ChatFooter.jsx
@@ -128,6 +128,9 @@ export const ChatFooter = ({ role, peerId, onSend, children }) => {
         }}
         autoComplete="off"
         aria-autocomplete="none"
+        onPaste={e => e.stopPropagation()}
+        onCut={e => e.stopPropagation()}
+        onCopy={e => e.stopPropagation()}
       />
       <EmojiPicker
         onSelect={emoji => {


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1444" title="WEB-1444" target="_blank">WEB-1444</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>chat paste not working when whiteboard is opened</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
