### PR TITLE
fix: screenshare layout for 1080

### DIFF
--- a/apps/100ms-web/src/layouts/screenShareView.jsx
+++ b/apps/100ms-web/src/layouts/screenShareView.jsx
@@ -18,7 +18,7 @@ import VideoTile from "../components/VideoTile";
 
 const ScreenShareView = () => {
   // for smaller screen we will show sidebar in bottom
-  const mediaQueryLg = cssConfig.media.lg;
+  const mediaQueryLg = cssConfig.media.xl;
   const showSidebarInBottom = useMedia(mediaQueryLg);
   const peers = useHMSStore(selectPeers);
   const localPeerID = useHMSStore(selectLocalPeerID);
@@ -57,7 +57,7 @@ const ScreenShareView = () => {
           overflow: "hidden",
           p: "$4 $8",
           flex: "0 0 20%",
-          "@lg": {
+          "@xl": {
             flex: "1 1 0",
           },
         }}
@@ -103,7 +103,6 @@ export const SidePane = ({
 };
 
 const ScreenShareComponent = ({
-  showStats,
   amIPresenting,
   peerPresenting,
   peerSharingPlaylist,
@@ -118,7 +117,7 @@ const ScreenShareComponent = ({
         css={{
           mx: "$8",
           flex: "3 1 0",
-          "@lg": {
+          "@xl": {
             flex: "2 1 0",
             display: "flex",
             alignItems: "center",
@@ -135,7 +134,7 @@ const ScreenShareComponent = ({
       css={{
         flex: "3 1 0",
         mx: "$8",
-        "@lg": { ml: "$4", maxHeight: "80%" },
+        "@xl": { ml: "$4", maxHeight: "80%", minHeight: 0 },
       }}
     >
       {peerPresenting &&


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1492" title="WEB-1492" target="_blank">WEB-1492</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Layout breaking for 1080p for beam</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
