### PR TITLE
fix: clear all toasts on room ended, leave

### DIFF
--- a/apps/100ms-web/src/components/LeaveRoom.jsx
+++ b/apps/100ms-web/src/components/LeaveRoom.jsx
@@ -23,6 +23,7 @@ import {
   Text,
   Tooltip,
 } from "@100mslive/react-ui";
+import { ToastManager } from "./Toast/ToastManager";
 import {
   DialogCheckbox,
   DialogContent,
@@ -46,6 +47,7 @@ export const LeaveRoom = () => {
     } else {
       navigate("/leave/" + params.roomId);
     }
+    ToastManager.clearAllToast();
   };
 
   const leaveRoom = () => {

--- a/apps/100ms-web/src/components/Notifications/Notifications.jsx
+++ b/apps/100ms-web/src/components/Notifications/Notifications.jsx
@@ -150,6 +150,7 @@ export function Notifications() {
             "leave"
           );
           navigate(leaveLocation);
+          ToastManager.clearAllToast();
         }, 2000);
         break;
       case HMSNotificationTypes.DEVICE_CHANGE_UPDATE:


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1501" title="WEB-1501" target="_blank">WEB-1501</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Timed metadata toasts not clearing after leaving the room</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
