### PR TITLE
fix: move providerProps inside HMSRoomProvider

### DIFF
--- a/packages/react-sdk/src/primitives/HmsRoomProvider.ts
+++ b/packages/react-sdk/src/primitives/HmsRoomProvider.ts
@@ -1,4 +1,4 @@
-import React, { createContext, PropsWithChildren, useContext, useEffect, useState } from 'react';
+import React, { createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
 import create from 'zustand';
 import {
   HMSActions,
@@ -32,7 +32,6 @@ export interface HMSRoomProviderProps {
  */
 const HMSContext = createContext<HMSContextProviderProps | null>(null);
 
-let providerProps: HMSContextProviderProps;
 /**
  * top level wrapper for using react sdk hooks. This doesn't have any mandatory arguments, if you are already
  * initialising the sdk on your side, you can pass in the primitives from there as well to use hooks for
@@ -49,7 +48,8 @@ export const HMSRoomProvider: React.FC<PropsWithChildren<HMSRoomProviderProps>> 
   isHMSStatsOn = false,
   leaveOnUnload = true,
 }) => {
-  if (!providerProps) {
+  const providerProps: HMSContextProviderProps = useMemo(() => {
+    let providerProps: HMSContextProviderProps;
     // adding a dummy function for setstate and destroy because zustan'd create expects them
     // to be present but we don't expose them from the store.
     const errFn = () => {
@@ -104,7 +104,9 @@ export const HMSRoomProvider: React.FC<PropsWithChildren<HMSRoomProviderProps>> 
       version: React.version,
       sdkVersion: process.env.REACT_SDK_VERSION,
     });
-  }
+
+    return providerProps;
+  }, [actions, store, notifications, stats, isHMSStatsOn]);
 
   useEffect(() => {
     if (isBrowser && leaveOnUnload) {
@@ -117,7 +119,7 @@ export const HMSRoomProvider: React.FC<PropsWithChildren<HMSRoomProviderProps>> 
     }
 
     return () => {};
-  }, [leaveOnUnload]);
+  }, [leaveOnUnload, providerProps]);
 
   return React.createElement(HMSContext.Provider, { value: providerProps }, children);
 };


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1504" title="WEB-1504" target="_blank">WEB-1504</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Move providerProps from outside component with useMemo inside HMSRoomProvider</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- Before (Join room button in second room got disabled as soon as first room was joined)
![image](https://user-images.githubusercontent.com/123355266/216969978-66eabff2-66db-4f54-81c8-f23aa20b2a76.png)

- After (Can join in both rooms)
![image](https://user-images.githubusercontent.com/123355266/216969737-7f54fa21-4eb7-4ce6-a44d-931e1471734c.png)


### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
