### PR TITLE
fix: render tile only after width/height available

### DIFF
--- a/apps/100ms-web/src/components/VideoList.jsx
+++ b/apps/100ms-web/src/components/VideoList.jsx
@@ -45,8 +45,11 @@ const List = ({
                   transition: "left 0.3s ease-in-out",
                 }}
               >
-                {tiles.map((tile, i) =>
-                  tile.track?.source === "screen" ? (
+                {tiles.map(tile => {
+                  if (tile.width === 0 || tile.height === 0) {
+                    return null;
+                  }
+                  return tile.track?.source === "screen" ? (
                     <ScreenshareTile
                       key={tile.track.id}
                       width={tile.width}
@@ -62,8 +65,8 @@ const List = ({
                       trackId={tile.track?.id}
                       visible={pageNo === page}
                     />
-                  )
-                )}
+                  );
+                })}
               </StyledVideoList.View>
             ))
           : null}


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1335" title="WEB-1335" target="_blank">WEB-1335</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>UI broken when rejoining  in load test</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
