### PR TITLE
fix: mic indicator showing when audio not enabed for once

### DIFF
--- a/packages/hms-video-web/src/media/tracks/HMSLocalAudioTrack.ts
+++ b/packages/hms-video-web/src/media/tracks/HMSLocalAudioTrack.ts
@@ -114,7 +114,7 @@ export class HMSLocalAudioTrack extends HMSAudioTrack {
     const newSettings = this.buildNewSettings(settings);
 
     if (isEmptyTrack(this.nativeTrack)) {
-      // if it is an empty track or is not enabled, cache the settings for when it is unmuted
+      // if it is an empty track, cache the settings for when it is unmuted
       this.settings = newSettings;
       return;
     }


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1530" title="WEB-1530" target="_blank">WEB-1530</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Browser tab showing indicator that mic is active even when audio disabled</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
