### PR TITLE
fix: remove playlist track getting called twice

### DIFF
--- a/packages/hms-video-web/src/playlist-manager/PlaylistManager.ts
+++ b/packages/hms-video-web/src/playlist-manager/PlaylistManager.ts
@@ -382,7 +382,7 @@ export class PlaylistManager
   };
 
   private removeTrack = async (trackId: string) => {
-    await this.sdk.removeTrack(trackId);
+    await this.sdk.removeTrack(trackId, true);
     HMSLogger.d(this.TAG, 'Playlist track removed', trackId);
   };
 }

--- a/packages/hms-video-web/src/sdk/index.ts
+++ b/packages/hms-video-web/src/sdk/index.ts
@@ -642,7 +642,7 @@ export class HMSSdk implements HMSInterface {
     this.listener?.onTrackUpdate(HMSTrackUpdate.TRACK_ADDED, hmsTrack, this.localPeer!);
   }
 
-  async removeTrack(trackId: string) {
+  async removeTrack(trackId: string, internal = false) {
     if (!this.localPeer) {
       throw ErrorFactory.GenericErrors.NotConnected(HMSAction.VALIDATION, 'No local peer present, cannot removeTrack');
     }
@@ -655,10 +655,8 @@ export class HMSSdk implements HMSInterface {
         await track.cleanup();
       }
       // Stop local playback when playlist track is removed
-      if (track.source === 'audioplaylist') {
-        this.playlistManager.stop(HMSPlaylistType.audio);
-      } else if (track.source === 'videoplaylist') {
-        this.playlistManager.stop(HMSPlaylistType.video);
+      if (!internal) {
+        this.stopPlaylist(track);
       }
       this.localPeer.auxiliaryTracks.splice(trackIndex, 1);
       this.listener?.onTrackUpdate(HMSTrackUpdate.TRACK_REMOVED, track, this.localPeer);
@@ -1130,4 +1128,12 @@ export class HMSSdk implements HMSInterface {
   private sendAnalyticsEvent = (event: AnalyticsEvent) => {
     this.analyticsEventsService.queue(event).flush();
   };
+
+  private stopPlaylist(track: HMSLocalTrack) {
+    if (track.source === 'audioplaylist') {
+      this.playlistManager.stop(HMSPlaylistType.audio);
+    } else if (track.source === 'videoplaylist') {
+      this.playlistManager.stop(HMSPlaylistType.video);
+    }
+  }
 }


### PR DESCRIPTION
### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- Playlist stop is getting called twice when stopped which is resulting in the following error log in console
-
<img width="457" alt="image" src="https://user-images.githubusercontent.com/6763261/220067609-e48bbc65-770d-4a67-9f3b-b4df1c7980f4.png">

https://100ms.atlassian.net/browse/WEB-1531

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
