### PR TITLE
feat: show loader while virtual background is getting added

### DIFF
--- a/apps/100ms-web/src/plugins/VirtualBackground/VirtualBackground.jsx
+++ b/apps/100ms-web/src/plugins/VirtualBackground/VirtualBackground.jsx
@@ -9,7 +9,7 @@ import {
   useHMSStore,
 } from "@100mslive/react-sdk";
 import { VirtualBackgroundIcon } from "@100mslive/react-icons";
-import { Tooltip } from "@100mslive/react-ui";
+import { Loading, Tooltip } from "@100mslive/react-ui";
 import IconButton from "../../IconButton";
 import { getRandomVirtualBackground } from "./vbutils";
 
@@ -18,6 +18,7 @@ export const VirtualBackground = () => {
   const hmsActions = useHMSActions();
   const isAllowedToPublish = useHMSStore(selectIsAllowedToPublish);
   const role = useHMSStore(selectLocalPeerRole);
+  const [isVBLoading, setIsVBLoading] = useState(false);
   const [isVBSupported, setIsVBSupported] = useState(false);
   const localPeerVideoTrackID = useHMSStore(selectLocalVideoTrackID);
   const isVBPresent = useHMSStore(selectIsLocalVideoPluginPresent("HMSVB"));
@@ -45,6 +46,7 @@ export const VirtualBackground = () => {
   }, [hmsActions, localPeerVideoTrackID]);
 
   async function addPlugin() {
+    setIsVBLoading(true);
     try {
       await createPlugin();
       window.HMS.virtualBackground = pluginRef.current;
@@ -57,6 +59,7 @@ export const VirtualBackground = () => {
     } catch (err) {
       console.error("add virtual background plugin failed", err);
     }
+    setIsVBLoading(false);
   }
 
   async function removePlugin() {
@@ -71,15 +74,22 @@ export const VirtualBackground = () => {
   }
 
   return (
-    <Tooltip title={`Turn ${!isVBPresent ? "on" : "off"} virtual background`}>
+    <Tooltip
+      title={
+        isVBLoading
+          ? "Adding virtual background"
+          : `Turn ${!isVBPresent ? "on" : "off"} virtual background`
+      }
+    >
       <IconButton
         active={!isVBPresent}
+        disabled={isVBLoading}
         onClick={() => {
           !isVBPresent ? addPlugin() : removePlugin();
         }}
         data-testid="virtual_bg_btn"
       >
-        <VirtualBackgroundIcon />
+        {isVBLoading ? <Loading /> : <VirtualBackgroundIcon />}
       </IconButton>
     </Tooltip>
   );


### PR DESCRIPTION
<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1532" title="WEB-1532" target="_blank">WEB-1532</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Add loader while vb is getting added</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- ![image](https://user-images.githubusercontent.com/123355266/221514414-5449dccd-cbcc-4a68-9a2a-984967289411.png)
- ![image](https://user-images.githubusercontent.com/123355266/221514349-2c88d0c5-5dd6-43fd-b19b-abd669969b03.png)
- ![image](https://user-images.githubusercontent.com/123355266/221514270-e3e3aa02-3e77-48ed-bd25-c21a8ec0584f.png)


### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
