### PR TITLE
fix: show roundtriptime in ms

### DIFF
--- a/apps/100ms-web/src/components/StatsForNerds.jsx
+++ b/apps/100ms-web/src/components/StatsForNerds.jsx
@@ -210,11 +210,13 @@ const LocalPeerStats = () => {
       />
       <StatsRow
         label="Round Trip Time"
-        value={(
-          ((stats.publish?.currentRoundTripTime || "") +
-            (stats.subscribe?.currentRoundTripTime || "")) /
-          2
-        ).toFixed(3)}
+        value={`${
+          (
+            ((stats.publish?.currentRoundTripTime || 0) +
+              (stats.subscribe?.currentRoundTripTime || 0)) /
+            2
+          ).toFixed(3) * 1000
+        } ms`}
       />
     </Flex>
   );
@@ -253,7 +255,10 @@ const TrackStats = ({ trackID, layer, local }) => {
           )}
         </>
       )}
-      <StatsRow label="Round Trip Time" value={stats.roundTripTime} />
+      <StatsRow
+        label="Round Trip Time"
+        value={`${stats.roundTripTime * 1000} ms`}
+      />
     </Flex>
   );
 };


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1542" title="WEB-1542" target="_blank">WEB-1542</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Missing unit for round trip time</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
