### PR TITLE
fix: align RTMP streaming input fields

### DIFF
--- a/apps/100ms-web/src/components/Streaming/RTMPStreaming.jsx
+++ b/apps/100ms-web/src/components/Streaming/RTMPStreaming.jsx
@@ -283,7 +283,7 @@ const FormLabel = ({ id, children }) => {
 const RTMPForm = ({ rtmpURL, id, streamKey, setRTMPStreams, testId }) => {
   const formRef = useRef(null);
   return (
-    <Flex id={id} direction="column" css={{ mb: "$8" }} ref={formRef}>
+    <Flex id={id} direction="column" css={{ mb: "$8", px: "$8" }} ref={formRef}>
       <FormLabel id="rtmpURL">
         RTMP URL
         <Asterik />


### PR DESCRIPTION
<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1545" title="WEB-1545" target="_blank">WEB-1545</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>RTMP Streaming alignment issue</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- ![image](https://user-images.githubusercontent.com/123355266/222374033-2ee3fc31-535b-4490-aab6-627a663d4003.png)
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
