### PR TITLE
fix: default endpoint picking logic for auth token

### DIFF
--- a/packages/hms-video-web/src/sdk/index.ts
+++ b/packages/hms-video-web/src/sdk/index.ts
@@ -498,7 +498,7 @@ export class HMSSdk implements HMSInterface {
     tokenRequest: TokenRequest,
     tokenRequestOptions?: TokenRequestOptions,
   ): Promise<TokenResult> {
-    const { endpoint = 'https://auth.100ms.live/v2/room-codes/token/' } = tokenRequestOptions || {};
+    const endpoint = (tokenRequestOptions || {}).endpoint || 'https://auth.100ms.live/v2/room-codes/token/';
     const tokenAPIURL = `${endpoint}${tokenRequest.roomCode}`;
     this.analyticsTimer.start(TimedEvent.GET_TOKEN);
     const response = await fetchWithRetry(


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1514" title="WEB-1514" target="_blank">WEB-1514</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Provide a method in sdk to get the token provided the short code ( for quicker pocs)</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
