### PR TITLE
fix: show proper errors on preview screen on token failure

### DIFF
--- a/apps/100ms-web/src/components/PreviewScreen.jsx
+++ b/apps/100ms-web/src/components/PreviewScreen.jsx
@@ -165,9 +165,9 @@ const convertPreviewError = error => {
     };
   } else if (error.message && error.message === "code not found") {
     return {
-      title: "Room does not exist",
+      title: "Room code does not exist",
       body: ErrorWithSupportLink(
-        "We could not find a room corresponding to this link."
+        "We could not find a room code corresponding to this link."
       ),
     };
   } else if (error.response && error.response.status === 404) {


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1556" title="WEB-1556" target="_blank">WEB-1556</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>error thrown from the method should mention what happened and why api failed</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Subtask" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />
        Subtask
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
