### PR TITLE
fix: mark only some server errors as terminal

### DIFF
--- a/packages/hms-video-web/src/error/ErrorFactory.ts
+++ b/packages/hms-video-web/src/error/ErrorFactory.ts
@@ -29,6 +29,14 @@ export enum HMSAction {
   PREVIEW = 'PREVIEW',
 }
 
+const terminalActions: (HMSSignalMethod | HMSAction)[] = [
+  HMSSignalMethod.JOIN,
+  HMSSignalMethod.OFFER,
+  HMSSignalMethod.ANSWER,
+  HMSSignalMethod.TRICKLE,
+  HMSAction.JOIN,
+];
+
 export const ErrorFactory = {
   WebSocketConnectionErrors: {
     FailedToConnect(action: HMSAction, description = '') {
@@ -317,13 +325,6 @@ export const ErrorFactory = {
 
   WebsocketMethodErrors: {
     ServerErrors(code: number, action: HMSAction | HMSSignalMethod, description: string) {
-      const terminalActions: (HMSSignalMethod | HMSAction)[] = [
-        HMSSignalMethod.JOIN,
-        HMSSignalMethod.OFFER,
-        HMSSignalMethod.ANSWER,
-        HMSSignalMethod.TRICKLE,
-        HMSAction.JOIN,
-      ];
       return new HMSException(code, 'ServerErrors', action, description, description, terminalActions.includes(action));
     },
 


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1451" title="WEB-1451" target="_blank">WEB-1451</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Not all server errors are terminal and should be handled in HMSException</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
