### PR TITLE
fix: select height in picking closest layer

### DIFF
--- a/packages/hms-video-web/src/media/tracks/trackUtils.ts
+++ b/packages/hms-video-web/src/media/tracks/trackUtils.ts
@@ -17,7 +17,8 @@ export const getClosestLayer = (
   videoElementDimensions: { width: number; height: number },
 ): HMSPreferredSimulcastLayer => {
   let closestLayer: HMSPreferredSimulcastLayer = HMSSimulcastLayer.HIGH;
-  const maxDimension = videoElementDimensions.width >= videoElementDimensions.height ? 'width' : 'height';
+  // when both width and height are equal pick height to select a better quality
+  const maxDimension = videoElementDimensions.width > videoElementDimensions.height ? 'width' : 'height';
   const layers = [...simulcastLayers].sort((a, b) => layerToIntMapping[a.layer] - layerToIntMapping[b.layer]);
   const videoDimesion = videoElementDimensions[maxDimension];
   for (let i = 0; i < layers.length; i++) {


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1591" title="WEB-1591" target="_blank">WEB-1591</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Layer picked is not the closest layer Eg: tile size was 328*328 but layer picked was 320*180 but it should be 640*360</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Subtask" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />
        Subtask
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
