### PR TITLE
fix: only send timed metadata if stream is on

### DIFF
--- a/apps/100ms-web/src/components/EmojiReaction.jsx
+++ b/apps/100ms-web/src/components/EmojiReaction.jsx
@@ -7,6 +7,7 @@ import {
   useCustomEvent,
   useHMSActions,
   useHMSStore,
+  useRecordingStreaming,
 } from "@100mslive/react-sdk";
 import { EmojiIcon } from "@100mslive/react-icons";
 import {
@@ -45,7 +46,7 @@ export const EmojiReaction = () => {
   const roles = useHMSStore(selectAvailableRoleNames);
   const localPeerRole = useHMSStore(selectLocalPeerRoleName);
   const hlsViewerRole = useHLSViewerRole();
-
+  const { isStreamingOn } = useRecordingStreaming();
   const filteredRoles = useMemo(
     () => roles.filter(role => role !== hlsViewerRole),
     [roles, hlsViewerRole]
@@ -63,12 +64,14 @@ export const EmojiReaction = () => {
   const sendReaction = async emojiId => {
     const data = { type: "EMOJI_REACTION", emojiId: emojiId };
     sendEvent(data, { roleNames: filteredRoles });
-    await hmsActions.sendHLSTimedMetadata([
-      {
-        payload: JSON.stringify(data),
-        duration: 2,
-      },
-    ]);
+    if (isStreamingOn) {
+      await hmsActions.sendHLSTimedMetadata([
+        {
+          payload: JSON.stringify(data),
+          duration: 2,
+        },
+      ]);
+    }
   };
   if (localPeerRole === hlsViewerRole) {
     return null;

--- a/apps/100ms-web/src/components/Footer/StreamingFooter.jsx
+++ b/apps/100ms-web/src/components/Footer/StreamingFooter.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Box, Flex, Footer as AppFooter } from "@100mslive/react-ui";
 import { AudioVideoToggle } from "../AudioVideoToggle";
+import { EmojiReaction } from "../EmojiReaction";
 import { StreamActions } from "../Header/StreamActions";
 import { LeaveRoom } from "../LeaveRoom";
 import MetaActions from "../MetaActions";
@@ -64,6 +65,7 @@ export const StreamingFooter = () => {
         </Flex>
       </AppFooter.Center>
       <AppFooter.Right>
+        <EmojiReaction />
         <MetaActions />
         <ChatToggle />
       </AppFooter.Right>


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1571" title="WEB-1571" target="_blank">WEB-1571</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Add a way to send timed metadata from web-app</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
