### PR TITLE
fix: remove video border radius when tileOffset is 0

### DIFF
--- a/apps/100ms-web/src/components/VideoTile.jsx
+++ b/apps/100ms-web/src/components/VideoTile.jsx
@@ -87,12 +87,7 @@ const Tile = ({ peerId, trackId, width, height, visible = true }) => {
               ? undefined
               : borderAudioRef
           }
-          css={{
-            ...(isHeadless &&
-              Number(headlessConfig?.tileOffset) === 0 && {
-                "border-radius": 0,
-              }),
-          }}
+          noRadius={isHeadless && Number(headlessConfig?.tileOffset) === 0}
         >
           {showStatsOnTiles && isTileBigEnoughToShowStats ? (
             <VideoTileStats
@@ -114,6 +109,7 @@ const Tile = ({ peerId, trackId, width, height, visible = true }) => {
                 track?.facingMode !== "environment"
               }
               degraded={isVideoDegraded}
+              noRadius={isHeadless && Number(headlessConfig?.tileOffset) === 0}
               data-testid="participant_video_tile"
             />
           ) : null}

--- a/packages/react-ui/src/Video/Video.tsx
+++ b/packages/react-ui/src/Video/Video.tsx
@@ -29,6 +29,11 @@ export const StyledVideo = styled('video', {
         zIndex: -100,
       },
     },
+    noRadius: {
+      true: {
+        borderRadius: 0,
+      },
+    },
   },
   defaultVariants: {
     mirror: false,

--- a/packages/react-ui/src/VideoTile/StyledVideoTile.tsx
+++ b/packages/react-ui/src/VideoTile/StyledVideoTile.tsx
@@ -25,6 +25,11 @@ const Container = styled('div', {
         background: 'transparent',
       },
     },
+    noRadius: {
+      true: {
+        borderRadius: 0,
+      },
+    },
   },
 });
 


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1618" title="WEB-1618" target="_blank">WEB-1618</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Remove video border radius when offset is 0</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
