### PR TITLE
fix: hide pip option for mac safari and ios

### DIFF
--- a/apps/100ms-web/src/common/constants.js
+++ b/apps/100ms-web/src/common/constants.js
@@ -178,6 +178,8 @@ export const HLS_TIMED_METADATA_DOC_URL =
 
 export const REMOTE_STOP_SCREENSHARE_TYPE = "REMOTE_STOP_SCREENSHARE";
 
+export const isSafari =
+  parsedUserAgent.getBrowser()?.name?.toLowerCase() === "safari";
 export const isIOS = parsedUserAgent.getOS()?.name?.toLowerCase() === "ios";
 export const isMacOS =
   parsedUserAgent.getOS()?.name?.toLowerCase() === "mac os";

--- a/apps/100ms-web/src/components/PIP/PIPManager.js
+++ b/apps/100ms-web/src/components/PIP/PIPManager.js
@@ -4,6 +4,7 @@ import {
   dummyChangeInCanvas,
   resetPIPCanvasColors,
 } from "./pipUtils";
+import { isIOS, isMacOS, isSafari } from "../../common/constants";
 const MAX_NUMBER_OF_TILES_IN_PIP = 4;
 const DEFAULT_FPS = 30;
 const DEFAULT_CANVAS_WIDTH = 480;
@@ -51,7 +52,9 @@ class PipManager {
    * check if PIP is supported in this browser env
    */
   isSupported() {
-    return !!document.pictureInPictureEnabled;
+    return (
+      !!document.pictureInPictureEnabled && !isIOS && !(isMacOS && isSafari)
+    );
   }
 
   /**


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1628" title="WEB-1628" target="_blank">WEB-1628</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Hide picture-in-picture option for mac safari and iOS</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
