### PR TITLE
fix: show proper error message on get details

### DIFF
--- a/apps/100ms-custom-app/src/App.js
+++ b/apps/100ms-custom-app/src/App.js
@@ -149,7 +149,7 @@ const App = () => {
         if (err.response && err.response.status === 404) {
           error = {
             title: 'Link is invalid',
-            body: err.response.data.msg,
+            body: err.response.data?.msg || 'Please make sure that link is valid.',
           };
         }
         setError(error);


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1565" title="WEB-1565" target="_blank">WEB-1565</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Show proper error message for get details on web</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
