### PR TITLE
fix: Make header/footer active on reconnecting spinner

### DIFF
--- a/apps/100ms-web/src/components/Notifications/ReconnectNotifications.jsx
+++ b/apps/100ms-web/src/components/Notifications/ReconnectNotifications.jsx
@@ -4,7 +4,7 @@ import {
   HMSNotificationTypes,
   useHMSNotifications,
 } from "@100mslive/react-sdk";
-import { Dialog, Flex, Loading, Text } from "@100mslive/react-ui";
+import { Box, Dialog, Flex, Loading, Text } from "@100mslive/react-ui";
 import { ToastConfig } from "../Toast/ToastConfig";
 import { ToastManager } from "../Toast/ToastManager";
 
@@ -30,11 +30,24 @@ export const ReconnectNotifications = () => {
       setOpen(true);
     }
   }, [notification]);
+  useEffect(() => {
+    const conferenceEle = document.getElementById("conferencing");
+    if (conferenceEle) {
+      conferenceEle.style.pointerEvents = open ? "none" : "unset";
+    }
+  }, [open]);
   if (!open) return null;
   return (
-    <Dialog.Root open={open} modal={true}>
+    <Dialog.Root open={open} modal={false}>
       <Dialog.Portal container={document.getElementById("conferencing")}>
-        <Dialog.Overlay />
+        <Box
+          css={{
+            position: "absolute",
+            pointerEvents: "none",
+            backgroundColor: "rgba(0, 0, 0, 0.5);",
+            inset: 0,
+          }}
+        />
         <Dialog.Content
           css={{
             width: "fit-content",


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1638" title="WEB-1638" target="_blank">WEB-1638</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>show a reconnecting spinner on the web app instead of “you are disconnected” dialog</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
