### PR TITLE
fix: send publisher.stats event on leave, SFN not working

### DIFF
--- a/packages/hms-video-web/src/analytics/publish-stats/index.ts
+++ b/packages/hms-video-web/src/analytics/publish-stats/index.ts
@@ -33,13 +33,13 @@ export class PublishStatsAnalytics {
     this.startLoop().catch(e => HMSLogger.e('[PublishStatsAnalytics]', e.message));
   }
 
-  stop() {
+  stop = () => {
     if (this.shouldSendEvent) {
       this.sendEvent();
     }
     this.eventBus.statsUpdate.unsubscribe(this.handleStatsUpdate);
     this.shouldSendEvent = false;
-  }
+  };
 
   private async startLoop() {
     while (this.shouldSendEvent) {
@@ -67,9 +67,9 @@ export class PublishStatsAnalytics {
     };
   }
 
-  private sendEvent() {
+  private sendEvent = () => {
     this.eventBus.analytics.publish(AnalyticsEventFactory.publishStats(this.toAnalytics()));
-  }
+  };
 
   private handleStatsUpdate = (hmsStats: HMSWebrtcStats) => {
     const localTracksStats = hmsStats.getLocalTrackStats();


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1640" title="WEB-1640" target="_blank">WEB-1640</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Client publish side metrics</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
