### PR TITLE
fix: add stats for nerds keyboard input

### DIFF
--- a/apps/100ms-web/src/components/Input/KeyboardInputManager.js
+++ b/apps/100ms-web/src/components/Input/KeyboardInputManager.js
@@ -32,6 +32,15 @@ export class KeyboardInputManager {
     }
   };
 
+  #toggleStatsForNerds = () => {
+    const uiSettings = this.#store.getState(selectAppData(APP_DATA.uiSettings));
+    const statsEnabled = uiSettings.showStatsOnTiles;
+    this.#actions.setAppData(APP_DATA.uiSettings, {
+      ...uiSettings,
+      showStatsOnTiles: !statsEnabled,
+    });
+  };
+
   #toggleHlsStats = () => {
     this.#actions.setAppData(
       APP_DATA.hlsStats,
@@ -60,6 +69,7 @@ export class KeyboardInputManager {
       this.#hideSidepane();
     } else if (SHORTCUT_STATS_FOR_NERDS) {
       this.#toggleHlsStats();
+      this.#toggleStatsForNerds();
     }
   };
 


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1760" title="WEB-1760" target="_blank">WEB-1760</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Add keyboard shortcut for stats for nerds</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
