### PR TITLE
fix: padding in role change modal's cancel button

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/RoleChangeModal.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/RoleChangeModal.jsx
@@ -158,7 +158,7 @@ export const RoleChangeModal = ({ peerId, onOpenChange }) => {
           )}
           <Flex justify="center" align="center" css={{ width: '100%', gap: '$md' }}>
             <Box css={{ width: '50%' }}>
-              <Dialog.Close css={{ width: '100%' }} asChild>
+              <Dialog.Close css={{ width: '100%', p: '$4 $8' }} asChild>
                 <Button variant="standard" outlined css={{ width: '100%' }} data-testid="cancel_button">
                   Cancel
                 </Button>


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1847" title="WEB-1847" target="_blank">WEB-1847</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>different sizes of cancel & change button on role change modal</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
