### PR TITLE
fix: show vote count to creator on poll end without local response

### DIFF
--- a/apps/100ms-web/src/components/Polls/Voting/QuestionCard.jsx
+++ b/apps/100ms-web/src/components/Polls/Voting/QuestionCard.jsx
@@ -35,6 +35,7 @@ const TextArea = styled("textarea", {
 export const QuestionCard = ({
   pollID,
   isQuiz,
+  startedBy,
   pollState,
   index,
   totalQuestions,
@@ -54,12 +55,15 @@ export const QuestionCard = ({
   const localPeerResponse = responses?.find(
     response => response.peer?.peerid === localPeerID
   );
+  const isLocalPeerCreator = localPeerID === startedBy;
   const localPeerRoleName = useHMSStore(selectLocalPeerRoleName);
+  const roleCanViewResponse =
+    !rolesThatCanViewResponses ||
+    rolesThatCanViewResponses.length === 0 ||
+    rolesThatCanViewResponses.includes(localPeerRoleName || "");
   const showVoteCount =
-    localPeerResponse &&
-    (!rolesThatCanViewResponses ||
-      rolesThatCanViewResponses.length === 0 ||
-      rolesThatCanViewResponses.includes(localPeerRoleName || ""));
+    roleCanViewResponse &&
+    (localPeerResponse || (isLocalPeerCreator && pollState === "stopped"));
 
   const isLive = pollState === "started";
   const canRespond = isLive && !localPeerResponse;

--- a/apps/100ms-web/src/components/Polls/Voting/StandardVoting.jsx
+++ b/apps/100ms-web/src/components/Polls/Voting/StandardVoting.jsx
@@ -17,6 +17,7 @@ export const StandardView = ({ poll }) => {
         <QuestionCard
           pollID={poll.id}
           isQuiz={poll.type === "quiz"}
+          startedBy={poll.startedBy}
           pollState={poll.state}
           key={`${question.text}-${index}`}
           index={question.index}

--- a/apps/100ms-web/src/components/Polls/Voting/TimedVoting.jsx
+++ b/apps/100ms-web/src/components/Polls/Voting/TimedVoting.jsx
@@ -17,6 +17,7 @@ export const TimedView = ({ poll }) => {
     <QuestionCard
       pollID={poll.id}
       isQuiz={poll.type === "quiz"}
+      startedBy={poll.startedBy}
       pollState={poll.state}
       index={activeQuestion.index}
       text={activeQuestion.text}


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1848" title="WEB-1848" target="_blank">WEB-1848</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>vote count not shown to poll creator after poll is ended</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20polls%20ORDER%20BY%20created%20DESC" title="polls">polls</a>, <a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
