### PR TITLE
fix: dont send poll start on reconnection

### DIFF
--- a/packages/hms-video-web/src/notification-manager/managers/PollsManager.ts
+++ b/packages/hms-video-web/src/notification-manager/managers/PollsManager.ts
@@ -32,6 +32,10 @@ export class PollsManager {
   private async handlePollStart(notification: PollStartNotification) {
     const polls: HMSPoll[] = [];
     for (const pollParams of notification.polls) {
+      if (this.store.getPoll(pollParams.poll_id)) {
+        return;
+      }
+
       const questions = await this.transport.getPollQuestions({ poll_id: pollParams.poll_id, index: 0, count: 50 });
       const poll: HMSPoll = {
         id: pollParams.poll_id,


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1872" title="WEB-1872" target="_blank">WEB-1872</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>User is able to vote again after network disconnection</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
