### PR TITLE
fix: update tile dimensions

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.jsx
@@ -12,18 +12,7 @@ import {
   useRecordingStreaming,
 } from '@100mslive/react-sdk';
 import { MicOffIcon, SettingsIcon } from '@100mslive/react-icons';
-import {
-  Avatar,
-  Box,
-  Flex,
-  flexCenter,
-  styled,
-  StyledVideoTile,
-  Text,
-  useBorderAudioLevel,
-  useTheme,
-  Video,
-} from '../../../';
+import { Avatar, Box, Flex, flexCenter, styled, StyledVideoTile, Text, useBorderAudioLevel, Video } from '../../../';
 import { useHMSPrebuiltContext } from '../../AppContext';
 import IconButton from '../../IconButton';
 import { useRoomLayout } from '../../provider/roomLayoutProvider';
@@ -109,7 +98,7 @@ const PreviewJoin = ({ onJoin, skipPreview, initialName, asRole }) => {
   return roomState === HMSRoomState.Preview ? (
     <Container css={{ h: '100%', pt: '$10', '@md': { justifyContent: 'space-between' } }}>
       {toggleVideo ? null : <Box />}
-      <Flex direction="column" justify="center" css={{ w: '100%', maxWidth: '360px' }}>
+      <Flex direction="column" justify="center" css={{ w: '100%', maxWidth: '640px' }}>
         <Logo />
         <Text
           variant="h4"
@@ -123,7 +112,7 @@ const PreviewJoin = ({ onJoin, skipPreview, initialName, asRole }) => {
         >
           {previewHeader.sub_title}
         </Text>
-        <Flex justify="center" css={{ mt: '$14', mb: '$14', '@md': { mt: '$8', mb: '0' }, gap: '$4' }}>
+        <Flex justify="center" css={{ mt: '$14', '@md': { mt: '$8', mb: '0' }, gap: '$4' }}>
           {isStreamingOn ? (
             <Chip
               content="LIVE"
@@ -140,6 +129,8 @@ const PreviewJoin = ({ onJoin, skipPreview, initialName, asRole }) => {
           align="center"
           justify="center"
           css={{
+            mt: '$14',
+            '@md': { mt: 0 },
             '@sm': { width: '100%' },
             flexDirection: 'column',
           }}
@@ -147,7 +138,7 @@ const PreviewJoin = ({ onJoin, skipPreview, initialName, asRole }) => {
           <PreviewTile name={name} error={previewError} />
         </Flex>
       ) : null}
-      <Box css={{ w: '100%', maxWidth: '360px' }}>
+      <Box css={{ w: '100%', maxWidth: '640px' }}>
         <PreviewControls
           enableJoin={enableJoin}
           savePreferenceAndJoin={savePreferenceAndJoin}
@@ -185,19 +176,17 @@ const PreviewTile = ({ name, error }) => {
   const track = useHMSStore(trackSelector);
   const showMuteIcon = !isLocalAudioEnabled || !toggleAudio;
 
-  const {
-    aspectRatio: { width, height },
-  } = useTheme();
   return (
     <StyledVideoTile.Container
       css={{
         bg: '$surface_default',
-        aspectRatio: width / height,
-        width: 'unset',
-        height: 'min(360px, 60vh)',
-        '@sm': {
+        aspectRatio: 16 / 9,
+        height: 'unset',
+        width: 'min(640px, 80vw)',
+        '@md': {
+          aspectRatio: 9 / 16,
           height: 'unset',
-          width: 'min(360px, 100%)',
+          width: 'min(275px, 70vw)',
           maxWidth: '100%',
         },
       }}


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1951" title="WEB-1951" target="_blank">WEB-1951</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>showing hard coded square video tile on preview screen for live streaming</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20prebuilt%20ORDER%20BY%20created%20DESC" title="prebuilt">prebuilt</a>, <a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<img width="490" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/4882c8ca-404d-4c03-8ba3-5b3252110d36">

![image](https://github.com/100mslive/web-sdks/assets/57426646/5d9cc97a-5cd7-4996-967b-a5dfbcc9110c)
