### PR TITLE
fix: video overflows tile dimensions

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.jsx
@@ -181,11 +181,10 @@ const PreviewTile = ({ name, error }) => {
       css={{
         bg: '$surface_default',
         aspectRatio: 16 / 9,
-        height: 'unset',
         width: 'min(640px, 80vw)',
+        overflow: 'clip',
         '@md': {
           aspectRatio: 9 / 16,
-          height: 'unset',
           width: 'min(275px, 70vw)',
           maxWidth: '100%',
         },


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1975" title="WEB-1975" target="_blank">WEB-1975</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>9:16 aspect ratio is not workoing on web</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20prebuilt%20ORDER%20BY%20created%20DESC" title="prebuilt">prebuilt</a>, <a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<img width="884" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/68650215-69fe-4f00-bcd5-e2da7be585b6">
