### PR TITLE
fix: tooltip covered by peername

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Connection/TileConnection.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Connection/TileConnection.jsx
@@ -47,7 +47,6 @@ const Wrapper = styled('div', {
   backgroundColor: '$background_dim',
   borderRadius: '$1',
   maxWidth: '85%',
-  zIndex: 1,
   '& p,span': {
     p: '$2 $3',
   },


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1979" title="WEB-1979" target="_blank">WEB-1979</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>tool tip on end room is overlapping with peer name.</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20prebuilt%20ORDER%20BY%20created%20DESC" title="prebuilt">prebuilt</a>, <a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Before and after
<img width="185" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/62cf9af3-33fc-4efd-9a3d-b5cda6683668">
<br /> <br />

![image](https://github.com/100mslive/web-sdks/assets/57426646/dbb62b90-748e-4bdb-b1f6-9d0cf4ddbf8f)
