### PR TITLE
fix: show header only when connected

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Header/ConferencingHeader.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Header/ConferencingHeader.jsx
@@ -9,9 +9,8 @@ import { AudioOutputActions, CamaraFlipActions } from './common';
 export const ConferencingHeader = () => {
   const roomState = useHMSStore(selectRoomState);
   const isMobile = useMedia(cssConfig.media.md);
-  const isPreview = roomState === HMSRoomState.Preview;
-  // no header if there in preview
-  if (isPreview) {
+  // Header should be present only inside the call - not in preview, leave room states
+  if (roomState !== HMSRoomState.Connected) {
     return <></>;
   }
   return (
@@ -35,12 +34,12 @@ export const ConferencingHeader = () => {
         }}
       >
         <StreamActions />
-        {isMobile && (
+        {isMobile ? (
           <>
             <CamaraFlipActions />
             <AudioOutputActions />
           </>
-        )}
+        ) : null}
       </Flex>
     </Flex>
   );


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2016" title="WEB-2016" target="_blank">WEB-2016</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>mweb: switch camera cta after leaving room</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
