### PR TITLE
fix: bottom tiles in prominent layout

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/SecondaryTiles.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/SecondaryTiles.tsx
@@ -15,7 +15,7 @@ export const SecondaryTiles = ({ peers, onPageChange, onPageSize }: LayoutProps)
 
   useEffect(() => {
     if (pageSize > 0) {
-      onPageSize?.(pageSize + 1); // include screenshare peer as well for page size
+      onPageSize?.(pageSize);
     }
   }, [pageSize, onPageSize]);
 

--- a/packages/roomkit-react/src/Prebuilt/components/VideoLayouts/ProminenceLayout.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/VideoLayouts/ProminenceLayout.tsx
@@ -34,8 +34,7 @@ const SecondarySection = ({ tiles, children }: React.PropsWithChildren<{ tiles: 
               trackId={tile.track?.id}
               rootCSS={{
                 padding: 0,
-                flex: '1 1 0',
-                maxWidth: 'max-content',
+                flex: '0 0 25%',
               }}
               containerCSS={{
                 width: 'unset',


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2059" title="WEB-2059" target="_blank">WEB-2059</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>bottom tile view below screen share is not consistent</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20prebuilt%20ORDER%20BY%20created%20DESC" title="prebuilt">prebuilt</a>, <a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
