### PR TITLE
fix: screenshare track showing video track

### DIFF
--- a/packages/hms-video-web/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-web/src/media/tracks/HMSLocalVideoTrack.ts
@@ -344,6 +344,7 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
     return newSettings;
   };
 
+  // eslint-disable-next-line complexity
   private handleSettingsChange = async (settings: HMSVideoTrackSettings) => {
     const stream = this.stream as HMSLocalStream;
     const hasPropertyChanged = generateHasPropertyChanged(settings, this.settings);
@@ -352,10 +353,14 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
     }
 
     if (hasPropertyChanged('width') || hasPropertyChanged('height') || hasPropertyChanged('advanced')) {
-      const track = await this.replaceTrackWith(settings);
-      await this.replaceSender(track, this.enabled);
-      this.nativeTrack = track;
-      this.videoHandler.updateSinks();
+      if (this.source === 'video') {
+        const track = await this.replaceTrackWith(settings);
+        await this.replaceSender(track, this.enabled);
+        this.nativeTrack = track;
+        this.videoHandler.updateSinks();
+      } else {
+        await this.nativeTrack.applyConstraints(settings.toConstraints());
+      }
     }
   };
 


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2094" title="WEB-2094" target="_blank">WEB-2094</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Peer's video shows-up on screenshare after role change</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
