### PR TITLE
fix: web-2052 not getting correct end stream message for hls viewer

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/layouts/HLSView.jsx
+++ b/packages/roomkit-react/src/Prebuilt/layouts/HLSView.jsx
@@ -3,7 +3,7 @@ import { useFullscreen, useToggle } from 'react-use';
 import { HLSPlaybackState, HMSHLSPlayer, HMSHLSPlayerEvents } from '@100mslive/hls-player';
 import screenfull from 'screenfull';
 import { selectAppData, selectHLSState, useHMSActions, useHMSStore } from '@100mslive/react-sdk';
-import { ExpandIcon, RadioIcon, ShrinkIcon } from '@100mslive/react-icons';
+import { ColoredHandIcon, ExpandIcon, RadioIcon, ShrinkIcon } from '@100mslive/react-icons';
 import { HlsStatsOverlay } from '../components/HlsStatsOverlay';
 import { HMSVideoPlayer } from '../components/HMSVideo';
 import { FullScreenButton } from '../components/HMSVideo/FullscreenButton';
@@ -26,6 +26,7 @@ const HLSView = () => {
   const hlsState = useHMSStore(selectHLSState);
   const enablHlsStats = useHMSStore(selectAppData(APP_DATA.hlsStats));
   const hmsActions = useHMSActions();
+  const [streamEnded, setStreamEnded] = useState(false);
   const { themeType } = useTheme();
   let [hlsStatsState, setHlsStatsState] = useState(null);
   const hlsUrl = hlsState.variants[0]?.url;
@@ -55,6 +56,15 @@ const HLSView = () => {
     return () => {
       videoEl?.removeEventListener('playing', hideLoader);
       videoEl?.removeEventListener('waiting', showLoader);
+    };
+  }, []);
+
+  useEffect(() => {
+    const videoElem = videoRef.current;
+    const setStreamEndedCallback = () => setStreamEnded(true);
+    videoElem?.addEventListener('ended', setStreamEndedCallback);
+    return () => {
+      videoElem?.removeEventListener('ended', setStreamEndedCallback);
     };
   }, []);
 
@@ -179,7 +189,7 @@ const HLSView = () => {
       {hlsStatsState?.url && enablHlsStats ? (
         <HlsStatsOverlay hlsStatsState={hlsStatsState} onClose={sfnOverlayClose} />
       ) : null}
-      {hlsUrl && hlsState.running ? (
+      {hlsUrl && !streamEnded ? (
         <Flex
           id="hls-player-container"
           align="center"
@@ -281,13 +291,13 @@ const HLSView = () => {
       ) : (
         <Flex align="center" justify="center" direction="column" css={{ size: '100%', px: '$10' }}>
           <Flex css={{ c: '$on_surface_high', r: '$round', bg: '$surface_default', p: '$2' }}>
-            <RadioIcon height={56} width={56} />
+            {streamEnded ? <ColoredHandIcon height={56} width={56} /> : <RadioIcon height={56} width={56} />}
           </Flex>
           <Text variant="h5" css={{ c: '$on_surface_high', mt: '$10', mb: 0, textAlign: 'center' }}>
-            Stream yet to start
+            {streamEnded ? 'Stream has ended' : 'Stream yet to start'}
           </Text>
           <Text variant="md" css={{ textAlign: 'center', mt: '$4', c: '$on_surface_medium' }}>
-            Sit back and relax
+            {streamEnded ? 'Have a nice day!' : 'Sit back and relax'}
           </Text>
         </Flex>
       )}


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2052" title="WEB-2052" target="_blank">WEB-2052</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>not getting correct end stream message</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20prebuilt%20ORDER%20BY%20created%20DESC" title="prebuilt">prebuilt</a>, <a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
