### PR TITLE
fix: hide dots in pagination when there are more

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Pagination.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Pagination.tsx
@@ -38,20 +38,20 @@ export const Pagination = ({
       <StyledPagination.Chevron disabled={disableLeft} onClick={prevPage}>
         <ChevronLeftIcon width={16} height={16} style={{ cursor: disableLeft ? 'not-allowed' : 'pointer' }} />
       </StyledPagination.Chevron>
-      <StyledPagination.Dots>
-        {numPages <= 5
-          ? [...Array(numPages)].map((_, i) => (
-              <StyledPagination.Dot
-                key={i}
-                active={page === i}
-                onClick={e => {
-                  e.stopPropagation();
-                  onPageChange(i);
-                }}
-              />
-            ))
-          : null}
-      </StyledPagination.Dots>
+      {numPages <= 5 ? (
+        <StyledPagination.Dots>
+          {[...Array(numPages)].map((_, i) => (
+            <StyledPagination.Dot
+              key={i}
+              active={page === i}
+              onClick={e => {
+                e.stopPropagation();
+                onPageChange(i);
+              }}
+            />
+          ))}
+        </StyledPagination.Dots>
+      ) : null}
       <StyledPagination.Chevron disabled={disableRight} onClick={nextPage}>
         <ChevronRightIcon width={16} height={16} style={{ cursor: disableRight ? 'not-allowed' : 'pointer' }} />
       </StyledPagination.Chevron>


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-1820" title="WEB-1820" target="_blank">WEB-1820</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>tiles pagination broken on ui</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20qa-test%20ORDER%20BY%20created%20DESC" title="qa-test">qa-test</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
