### PR TITLE
fix: enter should not submit on mweb

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/MoreSettings/ChangeNameContent.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/MoreSettings/ChangeNameContent.jsx
@@ -27,6 +27,7 @@ export const ChangeNameContent = ({
           color: '$on_surface_high',
           fontWeight: '$semiBold',
           display: 'flex',
+          pb: '$4',
           '@md': { px: '$8', borderBottom: '1px solid $border_default' },
         }}
       >
@@ -55,7 +56,7 @@ export const ChangeNameContent = ({
           required
           data-testid="change_name_field"
           onKeyDown={async e => {
-            if (e.key === 'Enter' && currentName.trim().length > 0 && currentName !== localPeerName) {
+            if (e.key === 'Enter' && currentName.trim().length > 0 && currentName !== localPeerName && !isMobile) {
               e.preventDefault();
               changeName();
             }

--- a/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewForm.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewForm.tsx
@@ -49,7 +49,7 @@ const PreviewForm = ({
           autoFocus
           autoComplete="name"
           onKeyDown={e => {
-            if (e.key === 'Enter' && name.trim().length > 0) {
+            if (e.key === 'Enter' && name.trim().length > 0 && !isMobile) {
               e.preventDefault();
               onJoin();
             }


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2138" title="WEB-2138" target="_blank">WEB-2138</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>mWeb - Closing keypad after typing name on preview screen is making user Join room</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20prebuilt%20ORDER%20BY%20created%20DESC" title="prebuilt">prebuilt</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
