### PR TITLE
fix: mweb aspect ratio for inset

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/InsetTile.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/InsetTile.tsx
@@ -45,12 +45,10 @@ export const InsetTile = () => {
   const [minimised, setMinimised] = useSetAppDataByKey(APP_DATA.minimiseInset);
   const videoTrack = useHMSStore(selectVideoTrackByID(localPeer?.videoTrack));
   const isAllowedToPublish = useHMSStore(selectIsAllowedToPublish);
-  const aspectRatio =
-    videoTrack?.width && videoTrack?.height
-      ? videoTrack.width / videoTrack.height
-      : isMobile
-      ? defaultMobileAspectRatio
-      : desktopAspectRatio;
+  let aspectRatio = isMobile ? defaultMobileAspectRatio : desktopAspectRatio;
+  if (videoTrack?.width && videoTrack?.height && !isMobile) {
+    aspectRatio = videoTrack.width / videoTrack.height;
+  }
   let height = insetHeightPx;
   let width = height * aspectRatio;
   // Convert to 16/9 in landscape mode with a max width of 240


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2140" title="WEB-2140" target="_blank">WEB-2140</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>mweb : Turning on local video makes inset landscape(16:9) instead of retaining inset aspect ratio</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20prebuilt%20ORDER%20BY%20created%20DESC" title="prebuilt">prebuilt</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
