### PR TITLE
fix: duplicate tiles in embed

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/layouts/EmbedView.jsx
+++ b/packages/roomkit-react/src/Prebuilt/layouts/EmbedView.jsx
@@ -1,7 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  selectLocalPeerID,
-  selectLocalPeerRoleName,
   selectPeers,
   selectPeerScreenSharing,
   throwErrorHandler,
@@ -25,21 +23,13 @@ export const EmbedView = () => {
 export const EmbebScreenShareView = ({ children }) => {
   const peers = useHMSStore(selectPeers);
 
-  const localPeerID = useHMSStore(selectLocalPeerID);
-  const localPeerRole = useHMSStore(selectLocalPeerRoleName);
   const peerPresenting = useHMSStore(selectPeerScreenSharing);
-  const isPresenterFromMyRole = peerPresenting?.roleName?.toLowerCase() === localPeerRole?.toLowerCase();
-  const amIPresenting = localPeerID === peerPresenting?.id;
-  const showPresenterInSmallTile = amIPresenting || isPresenterFromMyRole;
   const [, setActiveScreenSharePeer] = useSetAppDataByKey(APP_DATA.activeScreensharePeerId);
 
   const smallTilePeers = useMemo(() => {
     const smallTilePeers = peers.filter(peer => peer.id !== peerPresenting?.id);
-    if (showPresenterInSmallTile && peerPresenting) {
-      smallTilePeers.unshift(peerPresenting); // put presenter on first page
-    }
     return smallTilePeers;
-  }, [peers, peerPresenting, showPresenterInSmallTile]);
+  }, [peers, peerPresenting]);
 
   useEffect(() => {
     setActiveScreenSharePeer(peerPresenting?.id);


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2156" title="WEB-2156" target="_blank">WEB-2156</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>seeing local tile twice while sharing pdf</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20prebuilt%20ORDER%20BY%20created%20DESC" title="prebuilt">prebuilt</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
