### PR TITLE
fix: wrong options in inset tile

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/InsetTile.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/InsetTile.tsx
@@ -14,6 +14,7 @@ import { AudioVideoToggle } from './AudioVideoToggle';
 import VideoTile from './VideoTile';
 // @ts-ignore: No implicit Any
 import { useSetAppDataByKey } from './AppData/useUISettings';
+import { useVideoTileContext } from './hooks/useVideoTileLayout';
 // @ts-ignore: No implicit Any
 import { APP_DATA } from '../common/constants';
 
@@ -45,6 +46,7 @@ export const InsetTile = () => {
   const [minimised, setMinimised] = useSetAppDataByKey(APP_DATA.minimiseInset);
   const videoTrack = useHMSStore(selectVideoTrackByID(localPeer?.videoTrack));
   const isAllowedToPublish = useHMSStore(selectIsAllowedToPublish);
+  const videoTileProps = useVideoTileContext();
   let aspectRatio = isMobile ? defaultMobileAspectRatio : desktopAspectRatio;
   if (videoTrack?.width && videoTrack?.height && !isMobile) {
     aspectRatio = videoTrack.width / videoTrack.height;
@@ -117,6 +119,7 @@ export const InsetTile = () => {
             containerCSS={{ background: '$surface_default' }}
             canMinimise
             isDragabble
+            {...videoTileProps}
           />
         )}
       </Box>


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2176" title="WEB-2176" target="_blank">WEB-2176</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>no option to remove tile from spotlight</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20prebuilt%20ORDER%20BY%20created%20DESC" title="prebuilt">prebuilt</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
