### PR TITLE
fix: notification count showing wrong

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Notifications/Notifications.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Notifications/Notifications.jsx
@@ -60,7 +60,7 @@ export function Notifications() {
 
         console.debug('Metadata updated', notification.data);
         if (!subscribedNotifications.METADATA_UPDATED) return;
-        ToastBatcher.showToast({ notification });
+        ToastBatcher.showToast({ notification, type: 'RAISE_HAND' });
         break;
       case HMSNotificationTypes.NAME_UPDATED:
         console.log(notification.data.id + ' changed their name to ' + notification.data.name);

--- a/packages/roomkit-react/src/Prebuilt/components/Toast/ToastConfig.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Toast/ToastConfig.jsx
@@ -109,7 +109,7 @@ export const ToastConfig = {
       };
     },
   },
-  METADATA_UPDATED: {
+  RAISE_HAND: {
     single: notification => {
       return {
         title: `${notification.data?.name} raised hand`,
@@ -118,10 +118,11 @@ export const ToastConfig = {
       };
     },
     multiple: notifications => {
+      const count = new Set(notifications.map(notification => notification.data?.id)).size;
       return {
-        title: `${notifications[notifications.length - 1].data?.name} and ${
-          notifications.length - 1
-        } others raised hand`,
+        title: `${notifications[notifications.length - 1].data?.name} ${
+          count > 1 ? `${count} and others` : ''
+        } raised hand`,
         icon: <HandIcon />,
         action: <HandRaiseAction isSingleHandRaise={false} />,
       };


### PR DESCRIPTION
<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2186" title="WEB-2186" target="_blank">WEB-2186</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>raising hand from Flutter to Web: notification is showing user+x notification if user raised hand x no. of time </td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20prebuilt%20ORDER%20BY%20created%20DESC" title="prebuilt">prebuilt</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- https://100ms.atlassian.net/jira/software/projects/WEB/issues/WEB-2192
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
