### PR TITLE
fix: chat text color, mweb leave

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Chat/ChatBody.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Chat/ChatBody.jsx
@@ -14,7 +14,7 @@ import {
   useHMSActions,
   useHMSStore,
 } from '@100mslive/react-sdk';
-import { CopyIcon, PinIcon, VerticalMenuIcon } from '@100mslive/react-icons';
+import { PinIcon, VerticalMenuIcon } from '@100mslive/react-icons';
 import { Dropdown } from '../../../Dropdown';
 import { IconButton } from '../../../IconButton';
 import { Box, Flex } from '../../../Layout';
@@ -22,7 +22,6 @@ import { Text } from '../../../Text';
 import { config as cssConfig, styled } from '../../../Theme';
 import { Tooltip } from '../../../Tooltip';
 import emptyChat from '../../images/empty-chat.svg';
-import { ToastManager } from '../Toast/ToastManager';
 import { useRoomLayoutConferencingScreen } from '../../provider/roomLayoutProvider/hooks/useRoomLayoutScreen';
 import { useSetPinnedMessage } from '../hooks/useSetPinnedMessage';
 
@@ -127,10 +126,9 @@ const getMessageType = ({ roles, receiver }) => {
   }
   return receiver ? 'private' : '';
 };
-const ChatActions = ({ onPin, showPinAction, messageContent }) => {
+const ChatActions = ({ onPin, showPinAction }) => {
   const [open, setOpen] = useState(false);
-  const isMobile = useMedia(cssConfig.media.md);
-  if (!isMobile && !showPinAction) {
+  if (!showPinAction) {
     return null;
   }
 
@@ -155,8 +153,7 @@ const ChatActions = ({ onPin, showPinAction, messageContent }) => {
               Pin Message
             </Text>
           </Dropdown.Item>
-          {isMobile && showPinAction ? <Dropdown.ItemSeparator css={{ my: 0 }} /> : null}
-          {isMobile ? (
+          {/* {isMobile ? (
             <Dropdown.Item
               data-testid="copy_message_btn"
               onClick={() => {
@@ -178,7 +175,7 @@ const ChatActions = ({ onPin, showPinAction, messageContent }) => {
                 Copy Message
               </Text>
             </Dropdown.Item>
-          ) : null}
+          ) : null} */}
         </Dropdown.Content>
       </Dropdown.Portal>
     </Dropdown.Root>
@@ -205,6 +202,7 @@ const ChatMessage = React.memo(({ index, style = {}, message, setRowHeight, onPi
   }, [index, setRowHeight]);
   const isMobile = useMedia(cssConfig.media.md);
   const { elements } = useRoomLayoutConferencingScreen();
+  const isOverlay = elements?.chat?.is_overlay && isMobile;
   const hmsActions = useHMSActions();
   const localPeerId = useHMSStore(selectLocalPeerID);
   const permissions = useHMSStore(selectPermissions);
@@ -234,7 +232,7 @@ const ChatMessage = React.memo(({ index, style = {}, message, setRowHeight, onPi
         css={{
           flexWrap: 'wrap',
           // Theme independent color, token should not be used for transparent chat
-          bg: messageType ? (isMobile ? 'rgba(0, 0, 0, 0.64)' : '$surface_default') : undefined,
+          bg: messageType ? (isOverlay ? 'rgba(0, 0, 0, 0.64)' : '$surface_default') : undefined,
           r: messageType ? '$1' : undefined,
           px: messageType ? '$4' : '$2',
           py: messageType ? '$4' : 0,
@@ -245,7 +243,7 @@ const ChatMessage = React.memo(({ index, style = {}, message, setRowHeight, onPi
       >
         <Text
           css={{
-            color: '$on_surface_high',
+            color: isOverlay ? '#FFF' : '$on_surface_high',
             fontWeight: '$semiBold',
             display: 'inline-flex',
             alignItems: 'center',
@@ -256,17 +254,17 @@ const ChatMessage = React.memo(({ index, style = {}, message, setRowHeight, onPi
         >
           <Flex align="baseline">
             {message.senderName === 'You' || !message.senderName ? (
-              <SenderName as="span" variant="sm">
+              <SenderName as="span" variant="sm" css={{ color: isOverlay ? '#FFF' : '$on_surface_high' }}>
                 {message.senderName || 'Anonymous'}
               </SenderName>
             ) : (
               <Tooltip title={message.senderName} side="top" align="start">
-                <SenderName as="span" variant="sm">
+                <SenderName as="span" variant="sm" css={{ color: isOverlay ? '#FFF' : '$on_surface_high' }}>
                   {message.senderName}
                 </SenderName>
               </Tooltip>
             )}
-            {!isMobile ? (
+            {!isOverlay ? (
               <Text
                 as="span"
                 variant="xs"
@@ -285,9 +283,7 @@ const ChatMessage = React.memo(({ index, style = {}, message, setRowHeight, onPi
             receiver={message.recipientPeer}
             roles={message.recipientRoles}
           />
-          {!isMobile ? (
-            <ChatActions onPin={onPin} showPinAction={showPinAction} messageContent={message.message} />
-          ) : null}
+          {!isOverlay ? <ChatActions onPin={onPin} showPinAction={showPinAction} /> : null}
         </Text>
         <Text
           variant="sm"
@@ -297,6 +293,7 @@ const ChatMessage = React.memo(({ index, style = {}, message, setRowHeight, onPi
             wordBreak: 'break-word',
             whiteSpace: 'pre-wrap',
             userSelect: 'all',
+            color: isOverlay ? '#FFF' : '$on_surface_high',
           }}
           onClick={e => e.stopPropagation()}
         >

--- a/packages/roomkit-react/src/Prebuilt/components/Leave/MwebLeaveRoom.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Leave/MwebLeaveRoom.tsx
@@ -1,6 +1,8 @@
 import React, { Fragment, useState } from 'react';
 import { ConferencingScreen } from '@100mslive/types-prebuilt';
+// @ts-ignore: No implicit Any
 import { selectIsConnectedToRoom, selectPermissions, useHMSStore, useRecordingStreaming } from '@100mslive/react-sdk';
+// @ts-ignore: No implicit Any
 import { ExitIcon, StopIcon } from '@100mslive/react-icons';
 import { Box } from '../../../Layout';
 import { Sheet } from '../../../Sheet';
@@ -90,6 +92,8 @@ export const MwebLeaveRoom = ({
           onClick={() => {
             if (screenType === 'hls_live_streaming') {
               setShowLeaveRoomAlert(true);
+            } else {
+              leaveRoom({ endstream: false });
             }
           }}
         >


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2195" title="WEB-2195" target="_blank">WEB-2195</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>mWeb - Chat not readable in light mode</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

Changes:

- Commented out copy message
- fixed leave room for mweb
- overlay chat messages should be base white