### PR TITLE
fix: saving brand logo url is not reflecting on preview component

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Header/HeaderComponents.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Header/HeaderComponents.jsx
@@ -45,7 +45,8 @@ export const Logo = () => {
     if (hideImage) {
       setHideImage(false);
     }
-  }, [hideImage, logo]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [logo]);
 
   if (isConnected && isMobile) {
     return null;


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/SS-3222" title="SS-3222" target="_blank">SS-3222</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>saving brand logo url is not reflecting on preview component</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20SS%20AND%20labels%20%3D%20prebuilt%20ORDER%20BY%20created%20DESC" title="prebuilt">prebuilt</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
