### PR TITLE
fix: screenshare tile controls showing in beam

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/layouts/SidePane.tsx
+++ b/packages/roomkit-react/src/Prebuilt/layouts/SidePane.tsx
@@ -38,6 +38,14 @@ const SidePane = ({
     return null;
   }
 
+  const tileLayout = {
+    hideParticipantNameOnTile: tileProps.hide_participant_name_on_tile,
+    roundedVideoTile: tileProps.rounded_video_tile,
+    hideAudioMuteOnTile: tileProps.hide_audio_mute_on_tile,
+    hideMetadataOnTile: tileProps.hide_metadata_on_tile,
+    objectFit: tileProps.video_object_fit,
+  };
+
   const mwebStreamingChat = isMobile && sidepane === SIDE_PANE_OPTIONS.CHAT && elements?.chat?.is_overlay;
 
   return (
@@ -59,8 +67,7 @@ const SidePane = ({
           width="100%"
           height={225}
           rootCSS={{ p: 0, alignSelf: 'start', flexShrink: 0 }}
-          objectFit="contain"
-          {...tileProps}
+          {...tileLayout}
         />
       )}
       {!!ViewComponent && (


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2187" title="WEB-2187" target="_blank">WEB-2187</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>during screen share .. tile for peer sharing screen has mute icon and other elements visible in streaming</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20prebuilt%20ORDER%20BY%20created%20DESC" title="prebuilt">prebuilt</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
