### PR TITLE
fix: sticky top, standard button tokens

### DIFF
--- a/packages/roomkit-react/src/Button/Button.tsx
+++ b/packages/roomkit-react/src/Button/Button.tsx
@@ -139,12 +139,12 @@ const StyledButton = styled('button', {
   variants: {
     variant: {
       standard: getButtonVariants(
-        '$secondary_default',
-        '$secondary_bright',
-        '$secondary_dim',
-        '$secondary_disabled',
-        '$on_secondary_high',
-        '$on_secondary_low',
+        '$surface_brighter',
+        '$surface_bright',
+        '$surface_default',
+        '$surface_dim',
+        '$on_surface_high',
+        '$on_surface_low',
       ),
       danger: getButtonVariants(
         '$alert_error_default',

--- a/packages/roomkit-react/src/Prebuilt/components/Chat/useEmojiPickerStyles.js
+++ b/packages/roomkit-react/src/Prebuilt/components/Chat/useEmojiPickerStyles.js
@@ -18,6 +18,7 @@ export const useEmojiPickerStyles = showing => {
             font-family: var(--hms-ui-fonts-sans);
           }
           .sticky {
+            top: 0.25rem;
             background-color: var(--hms-ui-colors-surface_bright);
             margin-top: 0.5rem;
           }


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2235" title="WEB-2235" target="_blank">WEB-2235</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>emojis header is merging with search bar</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20prebuilt%20ORDER%20BY%20created%20DESC" title="prebuilt">prebuilt</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<img width="348" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/03c7e1b8-6a9d-4cbf-8f90-77c2862ac9ca">

<img width="259" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/18b22c89-d4b0-4c30-ab8a-c0d406c0f252">
