### PR TITLE
fix: show pause button on mweb

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/layouts/HLSView.jsx
+++ b/packages/roomkit-react/src/Prebuilt/layouts/HLSView.jsx
@@ -3,7 +3,7 @@ import { useFullscreen, useMedia, useToggle } from 'react-use';
 import { HLSPlaybackState, HMSHLSPlayer, HMSHLSPlayerEvents } from '@100mslive/hls-player';
 import screenfull from 'screenfull';
 import { selectAppData, selectHLSState, useHMSActions, useHMSStore } from '@100mslive/react-sdk';
-import { ColoredHandIcon, ExpandIcon, RadioIcon, ShrinkIcon } from '@100mslive/react-icons';
+import { ColoredHandIcon, ExpandIcon, PlayIcon, RadioIcon, ShrinkIcon } from '@100mslive/react-icons';
 import { HlsStatsOverlay } from '../components/HlsStatsOverlay';
 import { HMSVideoPlayer } from '../components/HMSVideo';
 import { FullScreenButton } from '../components/HMSVideo/FullscreenButton';
@@ -265,6 +265,24 @@ const HLSView = () => {
             onMouseMove={onHoverHandler}
             onMouseLeave={onHoverHandler}
           >
+            {isMobile && isPaused && (
+              <Box
+                css={{
+                  position: 'absolute',
+                  top: '40%',
+                  left: '50%',
+                  transform: 'translateY(-40%) translateX(-50%)',
+                  padding: '$4 $14',
+                  display: 'inline-flex',
+                  r: '$0',
+                  bg: '$primary_default',
+                }}
+              >
+                <IconButton onClick={async () => await hlsPlayer?.play()} data-testid="play_btn">
+                  <PlayIcon width="60px" height="60px" />
+                </IconButton>
+              </Box>
+            )}
             <Flex
               ref={controlsRef}
               direction="column"


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2207" title="WEB-2207" target="_blank">WEB-2207</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>mweb - hls viewer - stream is getting paused when earphones are removed</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20immediate-fix%20ORDER%20BY%20created%20DESC" title="immediate-fix">immediate-fix</a>, <a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20prebuilt%20ORDER%20BY%20created%20DESC" title="prebuilt">prebuilt</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

![Screenshot_20230913_135129_Brave](https://github.com/100mslive/web-sdks/assets/110378139/7c31c321-3e82-4763-874c-7f01bcba1869)
