### PR TITLE
fix: move hand raise to footer for roles without av permissions

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Footer/Footer.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Footer/Footer.tsx
@@ -94,7 +94,7 @@ export const Footer = ({
       >
         {isMobile ? (
           <>
-            {screenType === 'hls_live_streaming' || noAVPermissions ? <RaiseHand /> : null}
+            {noAVPermissions ? <RaiseHand /> : null}
             {elements?.chat && <ChatToggle />}
             <MoreSettings elements={elements} screenType={screenType} />
           </>

--- a/packages/roomkit-react/src/Prebuilt/components/MoreSettings/SplitComponents/MwebOptions.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/MoreSettings/SplitComponents/MwebOptions.tsx
@@ -161,7 +161,7 @@ export const MwebOptions = ({
               </ActionTile.Root>
             )}
 
-            {screenType !== 'hls_live_streaming' && !noAVPermissions ? (
+            {!noAVPermissions ? (
               <ActionTile.Root
                 active={isHandRaised}
                 onClick={() => {


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2204" title="WEB-2204" target="_blank">WEB-2204</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Prebuilt - Handraise state and position needs change</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20immediate-fix%20ORDER%20BY%20created%20DESC" title="immediate-fix">immediate-fix</a>, <a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20prebuilt%20ORDER%20BY%20created%20DESC" title="prebuilt">prebuilt</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
