### PR TITLE
fix:preview tile dimensions

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
@@ -167,7 +167,7 @@ const PreviewJoin = ({
             flexDirection: 'column',
           }}
         >
-          <PreviewTile name={name} error={previewError} aspectRatio={aspectRatio} />
+          <PreviewTile name={name} error={previewError} />
         </Flex>
       ) : null}
       <Box css={{ w: '100%', maxWidth: `${aspectRatio * 360}px` }}>
@@ -194,15 +194,7 @@ const Container = styled('div', {
   px: '$10',
 });
 
-export const PreviewTile = ({
-  name,
-  error,
-  aspectRatio,
-}: {
-  name: string;
-  error?: boolean;
-  aspectRatio: number | string;
-}) => {
+export const PreviewTile = ({ name, error }: { name: string; error?: boolean }) => {
   const localPeer = useHMSStore(selectLocalPeer);
   const { isLocalAudioEnabled, toggleAudio } = useAVToggle();
   const isVideoOn = useHMSStore(selectIsLocalVideoEnabled);
@@ -210,6 +202,10 @@ export const PreviewTile = ({
   const trackSelector = selectVideoTrackByID(localPeer?.videoTrack);
   const track = useHMSStore(trackSelector);
   const showMuteIcon = !isLocalAudioEnabled || !toggleAudio;
+  const videoTrack = useHMSStore(selectVideoTrackByID(localPeer?.videoTrack));
+  const isMobile = useMedia(cssConfig.media.md);
+  const aspectRatio =
+    videoTrack?.width && videoTrack?.height ? videoTrack.width / videoTrack.height : isMobile ? 9 / 16 : 16 / 9;
 
   return (
     <StyledVideoTile.Container


### PR DESCRIPTION
<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2242" title="WEB-2242" target="_blank">WEB-2242</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>mic/cam ctas not aligining with video on preview</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20immediate-fix%20ORDER%20BY%20created%20DESC" title="immediate-fix">immediate-fix</a>, <a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20prebuilt%20ORDER%20BY%20created%20DESC" title="prebuilt">prebuilt</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

<img width="1764" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/c00a789b-e80b-4921-9c85-880e61365414">

<br />

<img width="1760" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/6554be8f-da5b-4c7d-ba4b-3c24e6284c1a">

<br />

<img width="520" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/0bb9018e-eae7-42c0-b2f2-52c59db51a66">
