### PR TITLE
fix: match brb and mute indicator dimensions

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/VideoTile.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/VideoTile.jsx
@@ -167,7 +167,7 @@ const Tile = ({
   );
 };
 
-const metaStyles = { top: '$4', left: '$4', width: '$14', height: '$14' };
+const metaStyles = { top: '$4', left: '$4', width: '$13', height: '$13' };
 
 const heightAnimation = value =>
   keyframes({


### PR DESCRIPTION
### Before

![image](https://github.com/100mslive/web-sdks/assets/57426646/69a5c9af-96bc-4edc-b88c-99ff9c86cd60)

### After
<img width="347" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/f1eea54e-fd19-4fb4-b44c-7efb60c7833a">

