### PR TITLE
fix: show end room only when permission is granted

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Leave/DesktopLeaveRoom.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Leave/DesktopLeaveRoom.tsx
@@ -29,6 +29,7 @@ export const DesktopLeaveRoom = ({
   const permissions = useHMSStore(selectPermissions);
   const { isStreamingOn } = useRecordingStreaming();
   const showStream = screenType !== 'hls_live_streaming' && isStreamingOn;
+  const endSessionOrStreamAllowed = (permissions?.hlsStreaming && showStream) || permissions?.endRoom;
 
   useDropdownList({ open: open || showEndStreamAlert || showLeaveRoomAlert, name: 'LeaveRoom' });
 
@@ -38,7 +39,7 @@ export const DesktopLeaveRoom = ({
 
   return (
     <Fragment>
-      {screenType !== 'hls_live_streaming' && (permissions?.hlsStreaming || permissions?.endRoom) ? (
+      {screenType !== 'hls_live_streaming' && endSessionOrStreamAllowed ? (
         <Flex>
           <LeaveIconButton
             key="LeaveRoom"
@@ -92,7 +93,7 @@ export const DesktopLeaveRoom = ({
                   css={{ p: 0 }}
                 />
               </Dropdown.Item>
-              {permissions?.endRoom || permissions?.hlsStreaming ? (
+              {endSessionOrStreamAllowed ? (
                 <Dropdown.Item
                   css={{
                     bg: '$alert_error_dim',
@@ -147,7 +148,7 @@ export const DesktopLeaveRoom = ({
             <EndSessionContent
               setShowEndStreamAlert={setShowEndStreamAlert}
               leaveRoom={isStreamingOn ? leaveRoom : endRoom}
-              isStreamingOn={isStreamingOn}
+              showStream={showStream}
               isModal
             />
           </Dialog.Content>

--- a/packages/roomkit-react/src/Prebuilt/components/Leave/EndSessionContent.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Leave/EndSessionContent.tsx
@@ -8,12 +8,12 @@ export const EndSessionContent = ({
   setShowEndStreamAlert,
   leaveRoom,
   isModal = false,
-  isStreamingOn = false,
+  showStream = false,
 }: {
   setShowEndStreamAlert: (value: boolean) => void;
   leaveRoom: (args: { endstream: boolean }) => void;
   isModal?: boolean;
-  isStreamingOn: boolean;
+  showStream: boolean;
 }) => {
   return (
     <Box>
@@ -26,7 +26,7 @@ export const EndSessionContent = ({
       >
         <AlertTriangleIcon style={{ marginRight: '0.5rem' }} />
         <Text variant="lg" css={{ color: 'inherit', fontWeight: '$semiBold' }}>
-          End {isStreamingOn ? 'Stream' : 'Session'}
+          End {showStream ? 'Stream' : 'Session'}
         </Text>
         {isModal ? null : (
           <Box css={{ color: '$on_surface_high', ml: 'auto' }} onClick={() => setShowEndStreamAlert(false)}>
@@ -35,7 +35,7 @@ export const EndSessionContent = ({
         )}
       </Flex>
       <Text variant="sm" css={{ color: '$on_surface_medium', mb: '$8', mt: '$4' }}>
-        The {isStreamingOn ? 'stream' : 'session'} will end for everyone. You can't undo this action.
+        The {showStream ? 'stream' : 'session'} will end for everyone. You can't undo this action.
       </Text>
       <Flex align="center" justify="between" css={{ w: '100%', gap: '$8' }}>
         <Button
@@ -56,7 +56,7 @@ export const EndSessionContent = ({
           id="stopStream"
           data-testid="stop_stream_btn"
         >
-          End {isStreamingOn ? 'Stream' : 'Session'}
+          End {showStream ? 'Stream' : 'Session'}
         </Button>
       </Flex>
     </Box>

--- a/packages/roomkit-react/src/Prebuilt/components/Leave/MwebLeaveRoom.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Leave/MwebLeaveRoom.tsx
@@ -30,6 +30,7 @@ export const MwebLeaveRoom = ({
   const permissions = useHMSStore(selectPermissions);
   const { isStreamingOn } = useRecordingStreaming();
   const showStream = screenType !== 'hls_live_streaming' && isStreamingOn;
+  const endSessionOrStreamAllowed = (permissions?.hlsStreaming && showStream) || permissions?.endRoom;
 
   useDropdownList({ open, name: 'LeaveRoom' });
 
@@ -70,7 +71,7 @@ export const MwebLeaveRoom = ({
               css={{ pt: 0, mt: '$10', color: '$on_surface_low', '&:hover': { color: '$on_surface_high' } }}
             />
 
-            {permissions?.endRoom || permissions?.hlsStreaming ? (
+            {endSessionOrStreamAllowed ? (
               <LeaveCard
                 title={showStream ? 'End Stream' : 'End Session'}
                 subtitle={`The will end the ${
@@ -111,8 +112,8 @@ export const MwebLeaveRoom = ({
         <Sheet.Content css={{ bg: '$surface_dim', p: '$10', pb: '$12' }}>
           <EndSessionContent
             setShowEndStreamAlert={setShowEndStreamAlert}
-            leaveRoom={isStreamingOn ? leaveRoom : endRoom}
-            isStreamingOn={isStreamingOn}
+            leaveRoom={showStream ? leaveRoom : endRoom}
+            showStream={showStream}
           />
         </Sheet.Content>
       </Sheet.Root>


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2262" title="WEB-2262" target="_blank">WEB-2262</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>End room without permission leads to leave screen with cam/mic turned on</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
