### PR TITLE
Revert "fix: reset layer to none on new track to avoid black tile"

### DIFF
--- a/packages/hms-video-web/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-web/src/connection/subscribe/subscribeConnection.ts
@@ -99,10 +99,6 @@ export default class HMSSubscribeConnection extends HMSConnection {
       const remote = this.remoteStreams.get(streamId)!;
       const TrackCls = e.track.kind === 'audio' ? HMSRemoteAudioTrack : HMSRemoteVideoTrack;
       const track = new TrackCls(remote, e.track);
-      // reset the simulcast layer to none when new video tracks are added, UI will subscribe when required
-      if (e.track.kind === 'video') {
-        remote.setVideoLayerLocally(HMSSimulcastLayer.NONE, 'addTrack', 'subscribeConnection');
-      }
       track.transceiver = e.transceiver;
       const trackId = getSdpTrackIdForMid(this.remoteDescription, e.transceiver?.mid);
       trackId && track.setSdpTrackId(trackId);


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/LIVE-1637" title="LIVE-1637" target="_blank">LIVE-1637</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Getting black tile for role change from non-simulcast to simulcast and vice-versa</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

Reverts 100mslive/web-sdks#1951