### PR TITLE
fix: fix prompt for mweb, browser support

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/MwebLandscapePrompt.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/MwebLandscapePrompt.jsx
@@ -1,24 +1,19 @@
 import React, { useEffect, useState } from 'react';
-import { useMedia } from 'react-use';
 import { RefreshIcon } from '@100mslive/react-icons';
 import { Button } from '../../Button';
 import { Box, Flex } from '../../Layout';
 import { Dialog } from '../../Modal';
 import { Text } from '../../Text';
-import { config as cssConfig } from '../../Theme';
 import { isAndroid, isIOS } from '../common/constants';
 
 export const MwebLandscapePrompt = () => {
   const isMobile = isAndroid || isIOS;
   const [showMwebLandscapePrompt, setShowMwebLandscapePrompt] = useState(false);
-  const isLandscape = useMedia(cssConfig.media.ls);
 
   useEffect(() => {
     const handleResize = () => {
-      alert(`${isLandscape}, ${window.innerHeight}, ${window.innerWidth}`);
-      setShowMwebLandscapePrompt(isMobile && isLandscape);
+      setShowMwebLandscapePrompt(isMobile && window.innerHeight < window.innerWidth);
     };
-
     handleResize();
     window.addEventListener('resize', handleResize);
 


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2190" title="WEB-2190" target="_blank">WEB-2190</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Prompt for mweb landscape</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20go-live-issue%20ORDER%20BY%20created%20DESC" title="go-live-issue">go-live-issue</a>, <a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20WEB%20AND%20labels%20%3D%20prebuilt%20ORDER%20BY%20created%20DESC" title="prebuilt">prebuilt</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

Testing deployments on 
- [ ] Mweb Chrome
- [ ] Safari
- [ ] Brave
- [ ] Chrome