### PR TITLE
fix: color tokens for attribute box

### DIFF
--- a/packages/roomkit-react/src/VideoTile/StyledVideoTile.tsx
+++ b/packages/roomkit-react/src/VideoTile/StyledVideoTile.tsx
@@ -58,7 +58,7 @@ const Info = styled('div', {
 const AttributeBox = styled('div', {
   position: 'absolute',
   top: '$4',
-  color: '$on_primary_high',
+  color: '$on_secondary_high',
   bg: '$secondary_dim',
   borderRadius: '$round',
   width: '$14',


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2278" title="WEB-2278" target="_blank">WEB-2278</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Update color token for status elements on tile</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
