### PR TITLE
fix: disable local video for mweb in bg/lockscreen

### DIFF
--- a/packages/hms-video-web/src/media/tracks/HMSLocalAudioTrack.ts
+++ b/packages/hms-video-web/src/media/tracks/HMSLocalAudioTrack.ts
@@ -84,7 +84,7 @@ export class HMSLocalAudioTrack extends HMSAudioTrack {
       const localStream = this.stream as HMSLocalStream;
       // change nativeTrack so plugin can start its work
       await localStream.replaceSenderTrack(prevTrack, this.processedTrack || newTrack);
-      await localStream.replaceStreamTrack(prevTrack, newTrack);
+      localStream.replaceStreamTrack(prevTrack, newTrack);
       this.nativeTrack = newTrack;
       isLevelMonitored && this.initAudioLevelMonitor();
     } catch (e) {

--- a/packages/hms-video-web/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-web/src/media/tracks/HMSLocalVideoTrack.ts
@@ -85,12 +85,12 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
   private handleVisibilityChange = async () => {
     if (document.visibilityState === 'hidden' && this.enabled) {
       this.nativeTrack.enabled = false;
-      this.eventBus.localVideoEnabled.publish({ enabled: false, track: this });
+      this.setEnabled(false);
 
       this.appInBackgroundVideoDisabled = true;
     } else if (document.visibilityState === 'visible' && this.appInBackgroundVideoDisabled) {
       this.nativeTrack.enabled = true;
-      this.eventBus.localVideoEnabled.publish({ enabled: true, track: this });
+      this.setEnabled(true);
       this.appInBackgroundVideoDisabled = false;
     }
   };

--- a/packages/hms-video-web/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-web/src/media/tracks/HMSLocalVideoTrack.ts
@@ -85,9 +85,12 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
   private handleVisibilityChange = async () => {
     if (document.visibilityState === 'hidden' && this.enabled) {
       this.nativeTrack.enabled = false;
+      this.eventBus.localVideoEnabled.publish({ enabled: false, track: this });
+
       this.appInBackgroundVideoDisabled = true;
     } else if (document.visibilityState === 'visible' && this.appInBackgroundVideoDisabled) {
       this.nativeTrack.enabled = true;
+      this.eventBus.localVideoEnabled.publish({ enabled: true, track: this });
       this.appInBackgroundVideoDisabled = false;
     }
   };

--- a/packages/hms-video-web/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-web/src/media/tracks/HMSLocalVideoTrack.ts
@@ -40,7 +40,7 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
    * at the point of writing this comment.
    */
   isCurrentTab = false;
-
+  appInBackgroundVideoDisabled = false;
   /**
    * @internal
    * This is required for handling remote mute/unmute as the published track will not necessarily be same as
@@ -84,7 +84,12 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
 
   private handleVisibilityChange = async () => {
     if (document.visibilityState === 'hidden' && this.enabled) {
-      await this.setEnabled(false);
+      this.nativeTrack.enabled = false;
+      this.appInBackgroundVideoDisabled = true;
+    }
+    else if(document.visibilityState === 'visible' && this.appInBackgroundVideoDisabled){
+      this.nativeTrack.enabled = true;
+      this.appInBackgroundVideoDisabled = false
     }
   };
 

--- a/packages/hms-video-web/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-web/src/media/tracks/HMSLocalVideoTrack.ts
@@ -15,7 +15,8 @@ import { HMSPluginSupportResult, HMSVideoPlugin } from '../../plugins';
 import { HMSVideoPluginsManager } from '../../plugins/video';
 import { LocalTrackManager } from '../../sdk/LocalTrackManager';
 import HMSLogger from '../../utils/logger';
-import { isBrowser, isMobile } from '../../utils/support';
+// import { isBrowser, isMobile } from '../../utils/support';
+import { isBrowser } from '../../utils/support';
 import { getVideoTrack, isEmptyTrack } from '../../utils/track';
 import { HMSVideoTrackSettings, HMSVideoTrackSettingsBuilder } from '../settings';
 import { HMSLocalStream } from '../streams';
@@ -77,7 +78,7 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
     }
     this.pluginsManager = new HMSVideoPluginsManager(this, eventBus);
     this.setFirstTrackId(this.trackId);
-    if (isBrowser && isMobile()) {
+    if (isBrowser) {
       document.addEventListener('visibilitychange', this.handleVisibilityChange);
     }
   }
@@ -92,7 +93,7 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
       await this.setEnabled(true);
       this.appInBackgroundVideoDisabled = false;
     }
-    console.log('ollo', this.nativeTrack, this.setEnabled);
+    console.log('fired', this.appInBackgroundVideoDisabled);
   };
 
   /** @internal */
@@ -206,7 +207,7 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
     await this.pluginsManager.cleanup();
     this.processedTrack?.stop();
     this.isPublished = false;
-    if (isMobile() && isBrowser) {
+    if (isBrowser) {
       document.removeEventListener('visibilitychange', this.handleVisibilityChange);
     }
   }

--- a/packages/hms-video-web/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-web/src/media/tracks/HMSLocalVideoTrack.ts
@@ -85,14 +85,14 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
   private handleVisibilityChange = async () => {
     if (document.visibilityState === 'hidden' && this.enabled) {
       this.nativeTrack.enabled = false;
-      this.setEnabled(false);
-
+      await this.setEnabled(false);
       this.appInBackgroundVideoDisabled = true;
     } else if (document.visibilityState === 'visible' && this.appInBackgroundVideoDisabled) {
       this.nativeTrack.enabled = true;
-      this.setEnabled(true);
+      await this.setEnabled(true);
       this.appInBackgroundVideoDisabled = false;
     }
+    console.log('ollo', this.nativeTrack, this.setEnabled);
   };
 
   /** @internal */

--- a/packages/hms-video-web/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-web/src/media/tracks/HMSLocalVideoTrack.ts
@@ -84,7 +84,6 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
 
   private handleVisibilityChange = async () => {
     if (document.visibilityState === 'hidden' && this.enabled) {
-      // disable local video
       this.eventBus.localVideoEnabled.publish({ enabled: false, track: this });
     }
   };

--- a/packages/hms-video-web/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-web/src/media/tracks/HMSLocalVideoTrack.ts
@@ -77,14 +77,14 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
     }
     this.pluginsManager = new HMSVideoPluginsManager(this, eventBus);
     this.setFirstTrackId(this.trackId);
-    if (isMobile() && isBrowser) {
+    if (isBrowser && isMobile()) {
       document.addEventListener('visibilitychange', this.handleVisibilityChange);
     }
   }
 
   private handleVisibilityChange = async () => {
     if (document.visibilityState === 'hidden' && this.enabled) {
-      this.eventBus.localVideoEnabled.publish({ enabled: false, track: this });
+      await this.setEnabled(false);
     }
   };
 

--- a/packages/hms-video-web/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-web/src/media/tracks/HMSLocalVideoTrack.ts
@@ -86,10 +86,9 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
     if (document.visibilityState === 'hidden' && this.enabled) {
       this.nativeTrack.enabled = false;
       this.appInBackgroundVideoDisabled = true;
-    }
-    else if(document.visibilityState === 'visible' && this.appInBackgroundVideoDisabled){
+    } else if (document.visibilityState === 'visible' && this.appInBackgroundVideoDisabled) {
       this.nativeTrack.enabled = true;
-      this.appInBackgroundVideoDisabled = false
+      this.appInBackgroundVideoDisabled = false;
     }
   };
 


### PR DESCRIPTION
<details open>
  <summary><a href="https://100ms.atlassian.net/browse/LIVE-1593" title="LIVE-1593" target="_blank">LIVE-1593</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Lock screen showing as tile degraded</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>To Do</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td><a href="https://100ms.atlassian.net/issues?jql=project%20%3D%20LIVE%20AND%20labels%20%3D%20customer_issuesv2%20ORDER%20BY%20created%20DESC" title="customer_issuesv2">customer_issuesv2</a></td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- Added an event listener for visibilitychange which disables mweb local video if the app is in background


### Choose one of these(put a 'x' in the bracket):

- [x] The change doesn't require a change to the documentation.
