### PR TITLE
fix: use peer count only from session-info

### DIFF
--- a/packages/hms-video-web/src/notification-manager/managers/RoomUpdateManager.ts
+++ b/packages/hms-video-web/src/notification-manager/managers/RoomUpdateManager.ts
@@ -82,10 +82,10 @@ export class RoomUpdateManager {
 
   private handlePreviewRoomState(notification: PeriodicRoomState) {
     const { room } = notification;
-    this.onRoomState(room, notification.peer_count);
+    this.onRoomState(room);
   }
 
-  private onRoomState(roomNotification: RoomState, peerCount?: number) {
+  private onRoomState(roomNotification: RoomState) {
     const { recording, streaming, session_id, started_at, name } = roomNotification;
     const room = this.store.getRoom();
     if (!room) {
@@ -93,7 +93,6 @@ export class RoomUpdateManager {
       return;
     }
 
-    room.peerCount = peerCount;
     room.name = name;
     room.recording.server.running = !!recording?.sfu.enabled;
     room.recording.browser.running = !!recording?.browser.enabled;


### PR DESCRIPTION
### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- https://100ms.atlassian.net/browse/WEB-2298
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
