### PR TITLE
feat: add hasNext to usePaginatedParticipants hook

### DIFF
--- a/packages/react-sdk/src/hooks/usePaginatedParticipants.ts
+++ b/packages/react-sdk/src/hooks/usePaginatedParticipants.ts
@@ -11,6 +11,7 @@ export interface usePaginatedParticipantsResult {
    * this function is to be called when loadPeers is called atleast once. This will fetch the next batch of peers
    */
   loadMorePeers: Promise<void>;
+  hasNext: () => boolean;
   // list of peers loaded
   peers: HMSPeer[];
   // total number of peers matching the input options at the time of the request
@@ -48,6 +49,7 @@ export const usePaginatedParticipants = (options: HMSPeerListIteratorOptions) =>
         });
         setTotal(iterator.current.getTotal());
       }),
+    hasNext: () => iterator.current.hasNext(),
     total,
     peers: Object.values(peers),
   };

--- a/packages/roomkit-react/src/Prebuilt/components/Footer/PaginatedParticipants.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Footer/PaginatedParticipants.tsx
@@ -68,14 +68,13 @@ const VirtualizedParticipantItem = React.memo(
 );
 
 export const PaginatedParticipants = ({ roleName, onBack }: { roleName: string; onBack: () => void }) => {
-  const { peers, total, loadPeers, loadMorePeers } = usePaginatedParticipants({ role: roleName, limit: 20 });
+  const { peers, total, hasNext, loadPeers, loadMorePeers } = usePaginatedParticipants({ role: roleName, limit: 20 });
   const [search, setSearch] = useState<string>('');
   const filteredPeers = peers.filter(p => p.name?.toLowerCase().includes(search));
   const isConnected = useHMSStore(selectIsConnectedToRoom);
   const [ref, { width }] = useMeasure<HTMLDivElement>();
   const height = ROW_HEIGHT * (filteredPeers.length + 1);
   const resetSidePane = useSidepaneReset();
-  const hasNext = total > peers.length;
 
   useEffect(() => {
     loadPeers();
@@ -111,7 +110,7 @@ export const PaginatedParticipants = ({ roleName, onBack }: { roleName: string; 
         <Box css={{ flex: '1 1 0', overflowY: 'auto', overflowX: 'hidden', mr: '-$10' }}>
           <VariableSizeList
             itemSize={index => (index === filteredPeers.length + 1 ? 16 : ROW_HEIGHT)}
-            itemData={{ peerList: filteredPeers, hasNext, loadMorePeers, isConnected: isConnected === true }}
+            itemData={{ peerList: filteredPeers, hasNext: hasNext(), loadMorePeers, isConnected: isConnected === true }}
             itemKey={itemKey}
             itemCount={filteredPeers.length + 1}
             width={width}


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2313" title="WEB-2313" target="_blank">WEB-2313</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Include hasNext in paginated peerlist hook</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
