### PR TITLE
fix: update animation, sidepane borders for mweb

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/layouts/SidePane.tsx
+++ b/packages/roomkit-react/src/Prebuilt/layouts/SidePane.tsx
@@ -10,9 +10,9 @@ import VideoTile from '../components/VideoTile';
 import { Box, Flex } from '../../Layout';
 import { config as cssConfig } from '../../Theme';
 import { useRoomLayoutConferencingScreen } from '../provider/roomLayoutProvider/hooks/useRoomLayoutScreen';
+import { translateAcross } from '../../utils';
 // @ts-ignore: No implicit Any
 import { APP_DATA, SIDE_PANE_OPTIONS } from '../common/constants';
-import { translateAcross } from '../../utils';
 
 const SidePane = ({
   screenType,

--- a/packages/roomkit-react/src/utils/animations.ts
+++ b/packages/roomkit-react/src/utils/animations.ts
@@ -12,7 +12,7 @@ export const slideUp = (controller: string) =>
     to: { height: 0 },
   });
 
-export const translateAcross = ({xFrom = '0', yFrom = '0', zFrom = '0', xTo = '0', yTo = '0', zTo = '0'}) =>
+export const translateAcross = ({ xFrom = '0', yFrom = '0', zFrom = '0', xTo = '0', yTo = '0', zTo = '0' }) =>
   keyframes({
     from: { transform: `translate3d(${xFrom}, ${yFrom}, ${zFrom})` },
     to: { transform: `translate3d(${xTo}, ${yTo}, ${zTo}` },


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2294" title="WEB-2294" target="_blank">WEB-2294</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Polls and quizes design parity</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

Sidepane should open like bottom sheet in mweb