### PR TITLE
fix: poll toggle

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/AppData/useSidepane.js
+++ b/packages/roomkit-react/src/Prebuilt/components/AppData/useSidepane.js
@@ -39,22 +39,21 @@ export const useSidepaneToggle = sidepaneType => {
 };
 
 export const usePollViewToggle = () => {
+  const hmsActions = useHMSActions();
   const { view, setPollState } = usePollViewState();
   const isOpen = useSidepaneState() === SIDE_PANE_OPTIONS.POLLS;
-  const toggleSidepane = useSidepaneToggle(SIDE_PANE_OPTIONS.POLLS);
 
   const togglePollView = useCallback(
     id => {
       id = typeof id === 'string' ? id : undefined;
+      const newView = id ? POLL_VIEWS.VOTE : isOpen && view ? null : POLL_VIEWS.CREATE_POLL_QUIZ;
       setPollState({
         [POLL_STATE.pollInView]: id,
-        [POLL_STATE.view]: id ? POLL_VIEWS.VOTE : isOpen && view ? null : POLL_VIEWS.CREATE_POLL_QUIZ,
+        [POLL_STATE.view]: newView,
       });
-      if (!id) {
-        toggleSidepane();
-      }
+      hmsActions.setAppData(APP_DATA.sidePane, newView ? SIDE_PANE_OPTIONS.POLLS : '');
     },
-    [view, setPollState, isOpen, toggleSidepane],
+    [hmsActions, view, setPollState, isOpen],
   );
 
   return togglePollView;


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2326" title="WEB-2326" target="_blank">WEB-2326</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Clicking Vote button on notification is closing the polls/quizz widget if already open.</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
