### PR TITLE
fix: tooltip positioning for network indicator

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Connection/ConnectionIndicator.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Connection/ConnectionIndicator.tsx
@@ -39,7 +39,7 @@ export const ConnectionIndicator = ({
   }
   if (downlinkQuality === 0) {
     return (
-      <Tooltip title={getTooltipText(downlinkQuality)}>
+      <Tooltip side="left" title={getTooltipText(downlinkQuality)}>
         <Wrapper isTile={isTile} css={{ color: '#ED4C5A' }} data-testid="tile_network">
           <PoorConnectivityIcon />
         </Wrapper>
@@ -48,7 +48,7 @@ export const ConnectionIndicator = ({
   }
   const size = isTile ? 12 : 16;
   return (
-    <Tooltip title={getTooltipText(downlinkQuality)}>
+    <Tooltip side="left" title={getTooltipText(downlinkQuality)}>
       <Wrapper isTile={isTile} data-testid="tile_network" css={{ backgroundColor: hideBg ? '' : '$surface_bright' }}>
         <svg
           width={size}


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2342" title="WEB-2342" target="_blank">WEB-2342</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>LIVE-1827 Network indicator tooltip hidden in participant list</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Incident" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />
        Incident
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

The FixedSizeList rendering the participants clips the tooltip for the last participant in the list