### PR TITLE
fix: preview go-live check

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewForm.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewForm.tsx
@@ -27,13 +27,16 @@ const PreviewForm = ({
     e.preventDefault();
   };
   const isMobile = useMedia(cssConfig.media.md);
-  const { isHLSRunning, isRTMPRunning } = useRecordingStreaming();
+  const { isHLSRunning, isRTMPRunning, isRecordingOn } = useRecordingStreaming();
 
   const layout = useRoomLayout();
   const { join_form: joinForm = {} } = layout?.screens?.preview?.default?.elements || {};
 
   const showGoLive =
-    joinForm?.join_btn_type === JoinForm_JoinBtnType.JOIN_BTN_TYPE_JOIN_AND_GO_LIVE && !isHLSRunning && !isRTMPRunning;
+    joinForm?.join_btn_type === JoinForm_JoinBtnType.JOIN_BTN_TYPE_JOIN_AND_GO_LIVE &&
+    !isHLSRunning &&
+    !isRTMPRunning &&
+    !isRecordingOn;
 
   return (
     <Form

--- a/packages/roomkit-react/src/Prebuilt/components/hooks/useAutoStartStreaming.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/hooks/useAutoStartStreaming.tsx
@@ -19,7 +19,7 @@ export const useAutoStartStreaming = () => {
   const showStreamingUI = useShowStreamingUI();
   const hmsActions = useHMSActions();
   const isConnected = useHMSStore(selectIsConnectedToRoom);
-  const { isHLSRunning, isRTMPRunning } = useRecordingStreaming();
+  const { isHLSRunning, isRTMPRunning, isRecordingOn } = useRecordingStreaming();
   const streamStartedRef = useRef(false);
 
   const startHLS = useCallback(async () => {
@@ -44,10 +44,10 @@ export const useAutoStartStreaming = () => {
   }, [isHLSStarted, isHLSRunning]);
 
   useEffect(() => {
-    if (!isConnected || streamStartedRef.current || !permissions?.hlsStreaming) {
+    if (!isConnected || streamStartedRef.current || !permissions?.hlsStreaming || isRecordingOn) {
       return;
     }
-    // Is a streaming kit and broadcaster joins
+    // Is a streaming kit and peer with streaming permissions joins
     startHLS();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isConnected]);


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2332" title="WEB-2332" target="_blank">WEB-2332</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Go Live stuck on loader when beam recording is running</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

## Changes
- Show "join now" instead of recording is running