### PR TITLE
fix: preview form width

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
@@ -134,7 +134,7 @@ const PreviewJoin = ({
 
   return roomState === HMSRoomState.Preview ? (
     <Flex justify="center" css={{ size: '100%', position: 'relative' }}>
-      <Container css={{ h: '100%', pt: '$10', '@md': { justifyContent: 'space-between' }, width: 'unset' }}>
+      <Container css={{ h: '100%', pt: '$10', '@md': { justifyContent: 'space-between' } }}>
         {toggleVideo ? null : <Box />}
         <Flex direction="column" justify="center" css={{ w: '100%', maxWidth: '640px' }}>
           <Logo />


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2361" title="WEB-2361" target="_blank">WEB-2361</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>fix preview ui for viewers</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

## Roles with AV permissions
<img width="1756" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/3277306b-09d9-4746-a28d-4e2e8a928d87">


## Roles without AV permissions

<img width="1763" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/1313f866-44c6-4b63-95ee-13abd2666ac6">

