### PR TITLE
fix: sfu recording should not affect go live

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewForm.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewForm.tsx
@@ -27,7 +27,7 @@ const PreviewForm = ({
     e.preventDefault();
   };
   const isMobile = useMedia(cssConfig.media.md);
-  const { isHLSRunning, isRTMPRunning, isRecordingOn } = useRecordingStreaming();
+  const { isHLSRunning, isRTMPRunning, isHLSRecordingOn, isBrowserRecordingOn } = useRecordingStreaming();
 
   const layout = useRoomLayout();
   const { join_form: joinForm = {} } = layout?.screens?.preview?.default?.elements || {};
@@ -36,7 +36,8 @@ const PreviewForm = ({
     joinForm?.join_btn_type === JoinForm_JoinBtnType.JOIN_BTN_TYPE_JOIN_AND_GO_LIVE &&
     !isHLSRunning &&
     !isRTMPRunning &&
-    !isRecordingOn;
+    !isHLSRecordingOn &&
+    !isBrowserRecordingOn;
 
   return (
     <Form

--- a/packages/roomkit-react/src/Prebuilt/components/hooks/useAutoStartStreaming.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/hooks/useAutoStartStreaming.tsx
@@ -19,12 +19,19 @@ export const useAutoStartStreaming = () => {
   const showStreamingUI = useShowStreamingUI();
   const hmsActions = useHMSActions();
   const isConnected = useHMSStore(selectIsConnectedToRoom);
-  const { isHLSRunning, isRTMPRunning, isRecordingOn } = useRecordingStreaming();
+  const { isHLSRunning, isRTMPRunning, isHLSRecordingOn, isBrowserRecordingOn } = useRecordingStreaming();
   const streamStartedRef = useRef(false);
 
   const startHLS = useCallback(async () => {
     try {
-      if (isHLSStarted || !showStreamingUI || isHLSRunning || isRTMPRunning) {
+      if (
+        isHLSStarted ||
+        !showStreamingUI ||
+        isHLSRunning ||
+        isRTMPRunning ||
+        isHLSRecordingOn ||
+        isBrowserRecordingOn
+      ) {
         return;
       }
       setHLSStarted(true);
@@ -44,7 +51,7 @@ export const useAutoStartStreaming = () => {
   }, [isHLSStarted, isHLSRunning]);
 
   useEffect(() => {
-    if (!isConnected || streamStartedRef.current || !permissions?.hlsStreaming || isRecordingOn) {
+    if (!isConnected || streamStartedRef.current || !permissions?.hlsStreaming) {
       return;
     }
     // Is a streaming kit and peer with streaming permissions joins


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/LIVE-1842" title="LIVE-1842" target="_blank">LIVE-1842</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Web: Cannot go live from prebuilt if SFU recording is on</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

https://100ms.atlassian.net/browse/WEB-2363