### PR TITLE
fix: brighterly request to add user name from query param

### DIFF
--- a/apps/100ms-custom-app/src/App.jsx
+++ b/apps/100ms-custom-app/src/App.jsx
@@ -21,6 +21,7 @@ const App = () => {
   const subdomain = useSearchParam('subdomain') || window.location.hostname;
   const { roomId, role } = getRoomIdRoleFromUrl();
   const { overrideLayout, isHeadless } = useOverridePrebuiltLayout();
+  const paramUserName = useSearchParam('name');
   const hmsPrebuiltRef = useRef();
 
   useEffect(() => {
@@ -81,7 +82,7 @@ const App = () => {
           role={role}
           screens={overrideLayout ? overrideLayout : undefined}
           options={{
-            userName: isHeadless ? 'Beam' : undefined,
+            userName: isHeadless ? 'Beam' : paramUserName,
             endpoints: {
               tokenByRoomCode:
                 process.env.REACT_APP_TOKEN_BY_ROOM_CODE_ENDPOINT,

--- a/apps/100ms-custom-app/src/hooks/useSearchParam.js
+++ b/apps/100ms-custom-app/src/hooks/useSearchParam.js
@@ -3,5 +3,5 @@ export function useSearchParam(param) {
     return '';
   }
   const url = new URL(window.location.href);
-  return url.searchParams.get(param);
+  return url.searchParams.get(param) || undefined;
 }


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2341" title="WEB-2341" target="_blank">WEB-2341</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Brighterly - ?name= query parameter not working in hms links</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
