### PR TITLE
Polls UI: collapsible options

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/common/constants.js
+++ b/packages/roomkit-react/src/Prebuilt/common/constants.js
@@ -118,7 +118,7 @@ export const INTERACTION_TYPE = {
 export const QUESTION_TYPE_TITLE = {
   'single-choice': 'Single Choice',
   'multiple-choice': 'Multiple Choice',
-  // "short-answer": "Short Answer",
+  // 'short-answer': 'Short Answer',
   // "long-answer": "Long Answer",
 };
 

--- a/packages/roomkit-react/src/Prebuilt/components/Polls/CreatePollQuiz/PollsQuizMenu.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Polls/CreatePollQuiz/PollsQuizMenu.jsx
@@ -1,5 +1,5 @@
 // @ts-check
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import {
   selectLocalPeerRoleName,
   selectPermissions,
@@ -65,6 +65,7 @@ function InteractionSelectionCard({ title, icon, active, onClick }) {
 
 const AddMenu = () => {
   const actions = useHMSActions();
+  const inputRef = useRef(null);
   const [title, setTitle] = useState('');
   const localPeerRoleName = useHMSStore(selectLocalPeerRoleName);
   const [anonymous, setAnonymous] = useState(false);
@@ -104,37 +105,45 @@ const AddMenu = () => {
         <InteractionSelectionCard
           title={INTERACTION_TYPE.POLL}
           icon={<StatsIcon width={32} height={32} />}
-          onClick={() => setInteractionType(INTERACTION_TYPE.POLL)}
+          onClick={() => {
+            setInteractionType(INTERACTION_TYPE.POLL);
+            inputRef.current?.focus();
+          }}
           active={interactionType === INTERACTION_TYPE.POLL}
         />
         <InteractionSelectionCard
           title={INTERACTION_TYPE.QUIZ}
           icon={<QuestionIcon width={32} height={32} />}
-          onClick={() => setInteractionType(INTERACTION_TYPE.QUIZ)}
+          onClick={() => {
+            setInteractionType(INTERACTION_TYPE.QUIZ);
+            inputRef.current?.focus();
+          }}
           active={interactionType === INTERACTION_TYPE.QUIZ}
         />
       </Flex>
       <Flex direction="column">
         <Text variant="body2" css={{ mb: '$4' }}>{`Name this ${interactionType.toLowerCase()}`}</Text>
         <Input
+          ref={inputRef}
           type="text"
           value={title}
+          autoFocus
           onChange={event => setTitle(event.target.value)}
           css={{
             backgroundColor: '$surface_bright',
             border: '1px solid $border_default',
           }}
         />
-        <Flex align="center" css={{ mt: '$10' }}>
+        <Flex direction="rowReverse" align="center" justify="between" css={{ mt: '$10', w: '100%' }}>
           <Switch onCheckedChange={value => setHideVoteCount(value)} css={{ mr: '$6' }} />
           <Text variant="body2" css={{ c: '$on_surface_medium' }}>
-            Hide Vote Count
+            Hide vote count
           </Text>
         </Flex>
-        <Flex align="center" css={{ mt: '$10' }}>
+        <Flex direction="rowReverse" align="center" justify="between" css={{ mt: '$10', w: '100%' }}>
           <Switch onCheckedChange={value => setAnonymous(value)} css={{ mr: '$6' }} />
           <Text variant="body2" css={{ c: '$on_surface_medium' }}>
-            Make Results Anonymous
+            Make results anonymous
           </Text>
         </Flex>
         {/* <Timer
@@ -163,7 +172,7 @@ const AddMenu = () => {
               .catch(err => setError(err.message));
           }}
         >
-          Create {interactionType}
+          Add Questions
         </Button>
         <ErrorText error={error || titleError} />
       </Flex>

--- a/packages/roomkit-react/src/Prebuilt/components/Polls/CreateQuestions/CreateQuestions.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Polls/CreateQuestions/CreateQuestions.jsx
@@ -97,7 +97,7 @@ export function CreateQuestions() {
           </Text>
         </Flex>
         <Flex css={{ w: '100%' }} justify="end">
-          <Button disabled={!isValidPoll} onClick={launchPoll}>
+          <Button disabled={!isValidPoll} onClick={launchPoll} css={{ fontWeight: '$semiBold' }}>
             Launch {interaction.type}
           </Button>
         </Flex>

--- a/packages/roomkit-react/src/Prebuilt/components/Polls/CreateQuestions/QuestionForm.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Polls/CreateQuestions/QuestionForm.jsx
@@ -1,7 +1,8 @@
 // @ts-check
 import React, { useCallback, useRef, useState } from 'react';
 import { AddCircleIcon, TrashIcon } from '@100mslive/react-icons';
-import { Box, Button, Dropdown, Flex, Input, Switch, Text, Tooltip } from '../../../../';
+import { Button, Dropdown, Flex, Input, Switch, Text, Tooltip } from '../../../../';
+import IconButton from '../../../IconButton';
 import { DialogDropdownTrigger } from '../../../primitives/DropdownTrigger';
 import { DeleteQuestionModal } from './DeleteQuestionModal';
 import { useDropdownSelection } from '../../hooks/useDropdownSelection';
@@ -10,10 +11,13 @@ import { MultipleChoiceOptionInputs } from '../common/MultipleChoiceOptions';
 import { SingleChoiceOptionInputs } from '../common/SingleChoiceOptions';
 import { QUESTION_TYPE, QUESTION_TYPE_TITLE } from '../../../common/constants';
 
+const Line = () => <Flex css={{ w: '100%', borderBottom: '1px solid $border_bright', h: '1px', my: '$8' }} />;
+
 export const QuestionForm = ({ question, index, length, onSave, removeQuestion, isQuiz }) => {
   const ref = useRef(null);
   const selectionBg = useDropdownSelection();
   const [openDelete, setOpenDelete] = useState(false);
+  // const inputRef = useRef(null);
   const [open, setOpen] = useState(false);
   const [type, setType] = useState(question.type || QUESTION_TYPE.SINGLE_CHOICE);
   const [text, setText] = useState(question.text);
@@ -121,13 +125,21 @@ export const QuestionForm = ({ question, index, length, onSave, removeQuestion, 
           backgroundColor: '$surface_bright',
           border: '1px solid $border_bright',
         }}
+        autoFocus
         type="text"
         value={text}
         onChange={event => setText(event.target.value)}
       />
+
+      <Line />
+
+      {/* {type === QUESTION_TYPE.SHORT_ANSWER && isQuiz ? (
+        <Input ref={inputRef} placeholder="Enter the answer" onBlur={e => acceptTextAnswer(inputRef.current?.value)} />
+      ) : null} */}
+
       {type === QUESTION_TYPE.SINGLE_CHOICE || type === QUESTION_TYPE.MULTIPLE_CHOICE ? (
         <>
-          <Text variant="body2" css={{ my: '$6', c: '$on_surface_medium' }}>
+          <Text variant="body2" css={{ mb: '$6', c: '$on_surface_medium' }}>
             Options
           </Text>
 
@@ -181,27 +193,22 @@ export const QuestionForm = ({ question, index, length, onSave, removeQuestion, 
               </Text>
             </Flex>
           )}
-          {isQuiz ? (
-            <Flex css={{ mt: '$md', gap: '$6' }}>
-              <Switch defaultChecked={skippable} onCheckedChange={checked => setSkippable(checked)} />
-              <Text variant="sm" css={{ color: '$on_surface_medium' }}>
-                Not required to answer
-              </Text>
-            </Flex>
-          ) : null}
+
+          <Line />
+
+          <Flex justify="between" css={{ gap: '$6', w: '100%' }}>
+            <Text variant="sm" css={{ color: '$on_surface_medium' }}>
+              Allow to skip
+            </Text>
+            <Switch defaultChecked={skippable} onCheckedChange={checked => setSkippable(checked)} />
+          </Flex>
         </>
       ) : null}
 
-      <Flex justify="between" align="center" css={{ mt: '$12' }}>
-        <Box
-          css={{
-            color: '$on_surface_medium',
-            cursor: 'pointer',
-            '&:hover': { color: '$on_surface_high' },
-          }}
-        >
-          <TrashIcon onClick={() => setOpenDelete(!open)} />
-        </Box>
+      <Flex justify="end" align="center" css={{ mt: '$12', w: '100%', gap: '$4' }}>
+        <IconButton css={{ background: 'none' }} onClick={() => setOpenDelete(!open)}>
+          <TrashIcon />
+        </IconButton>
         <Tooltip
           disabled={isValid}
           title={

--- a/packages/roomkit-react/src/Prebuilt/components/Polls/CreateQuestions/SavedQuestion.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Polls/CreateQuestions/SavedQuestion.jsx
@@ -1,49 +1,57 @@
 // @ts-check
 import React, { useState } from 'react';
-import { CheckCircleIcon, TrashIcon } from '@100mslive/react-icons';
+import { CheckCircleIcon, ChevronDownIcon, TrashIcon } from '@100mslive/react-icons';
 import { Box, Button, Flex, Text } from '../../../../';
+import IconButton from '../../../IconButton';
 import { DeleteQuestionModal } from './DeleteQuestionModal';
 import { QUESTION_TYPE_TITLE } from '../../../common/constants';
 
 export const SavedQuestion = ({ question, index, length, convertToDraft, removeQuestion }) => {
   const [openDeleteModal, setOpenDeleteModal] = useState(false);
+  const [showOptions, setShowOptions] = useState(false);
+
   return (
     <>
       <Text variant="overline" css={{ c: '$on_surface_low', textTransform: 'uppercase' }}>
         Question {index + 1} of {length}: {QUESTION_TYPE_TITLE[question.type]}
       </Text>
-      <Text variant="body2" css={{ mt: '$4', mb: '$md' }}>
-        {question.text}
-      </Text>
-      {question.options.map(option => (
-        <Flex css={{ alignItems: 'center', my: '$xs' }}>
-          <Text variant="body2" css={{ c: '$on_surface_medium' }}>
-            {option.text}
-          </Text>
-          {option.isCorrectAnswer && (
-            <Flex css={{ color: '$alert_success', mx: '$xs' }}>
-              <CheckCircleIcon height={24} width={24} />
-            </Flex>
-          )}
-        </Flex>
-      ))}
+      <Flex justify="between" css={{ w: '100%' }}>
+        <Text variant="body2" css={{ mt: '$4', mb: '$md', maxWidth: 'calc(100% - 16px)' }}>
+          {question.text}
+        </Text>
+        <Box
+          css={{ pt: '$4', color: '$on_surface_medium', '&:hover': { color: '$on_surface_high', cursor: 'pointer' } }}
+          onClick={() => setShowOptions(prev => !prev)}
+        >
+          <ChevronDownIcon
+            style={{ transform: showOptions ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.3s ease' }}
+          />
+        </Box>
+      </Flex>
+      <Box css={{ maxHeight: showOptions ? '$80' : '0', transition: 'max-height 0.3s ease', overflow: 'hidden' }}>
+        {question.options.map(option => (
+          <Flex css={{ alignItems: 'center', my: '$xs' }}>
+            <Text variant="body2" css={{ c: '$on_surface_medium' }}>
+              {option.text}
+            </Text>
+            {option.isCorrectAnswer && (
+              <Flex css={{ color: '$alert_success', mx: '$xs' }}>
+                <CheckCircleIcon height={24} width={24} />
+              </Flex>
+            )}
+          </Flex>
+        ))}
+      </Box>
       {question.skippable ? (
         <Text variant="sm" css={{ color: '$on_surface_low', my: '$md' }}>
           Not required to answer
         </Text>
       ) : null}
-      <Flex justify="between" css={{ w: '100%', alignItems: 'center' }}>
-        <Box
-          onClick={() => setOpenDeleteModal(true)}
-          css={{ color: '$on_surface_low', '&:hover': { color: '$on_surface_medium', cursor: 'pointer' } }}
-        >
+      <Flex justify="end" css={{ w: '100%', alignItems: 'center', gap: '$4' }}>
+        <IconButton onClick={() => setOpenDeleteModal(true)} css={{ background: 'none' }}>
           <TrashIcon />
-        </Box>
-        <Button
-          variant="standard"
-          css={{ fontWeight: '$semiBold', p: '$4 $8' }}
-          onClick={() => convertToDraft(question.draftID)}
-        >
+        </IconButton>
+        <Button variant="standard" css={{ fontWeight: '$semiBold' }} onClick={() => convertToDraft(question.draftID)}>
           Edit
         </Button>
       </Flex>

--- a/packages/roomkit-react/src/Prebuilt/components/Polls/Voting/QuestionCard.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Polls/Voting/QuestionCard.jsx
@@ -1,7 +1,7 @@
 // @ts-check
 import React, { useCallback, useMemo, useState } from 'react';
 import { selectLocalPeerID, selectLocalPeerRoleName, useHMSActions, useHMSStore } from '@100mslive/react-sdk';
-import { ChevronLeftIcon, ChevronRightIcon } from '@100mslive/react-icons';
+import { ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon } from '@100mslive/react-icons';
 import { Box, Button, Flex, IconButton, Input, styled, Text } from '../../../../';
 import { checkCorrectAnswer } from '../../../common/utils';
 import { MultipleChoiceOptions } from '../common/MultipleChoiceOptions';
@@ -67,6 +67,7 @@ export const QuestionCard = ({
   const [textAnswer, setTextAnswer] = useState('');
   const [singleOptionAnswer, setSingleOptionAnswer] = useState();
   const [multipleOptionAnswer, setMultipleOptionAnswer] = useState(new Set());
+  const [showOptions, setShowOptions] = useState(true);
 
   const stringAnswerExpected = [QUESTION_TYPE.LONG_ANSWER, QUESTION_TYPE.SHORT_ANSWER].includes(type);
 
@@ -156,72 +157,81 @@ export const QuestionCard = ({
         ) : null}
       </Flex>
 
-      <Box css={{ my: '$md' }}>
+      <Flex justify="between" css={{ my: '$md' }}>
         <Text css={{ color: '$on_surface_high' }}>{text}</Text>
+        <Box
+          css={{ color: '$on_surface_medium', '&:hover': { color: '$on_surface_high', cursor: 'pointer' } }}
+          onClick={() => setShowOptions(prev => !prev)}
+        >
+          <ChevronDownIcon
+            style={{ transform: showOptions ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.3s ease' }}
+          />
+        </Box>
+      </Flex>
+      <Box css={{ maxHeight: showOptions ? '$80' : '0', transition: 'max-height 0.3s ease', overflowY: 'hidden' }}>
+        {type === QUESTION_TYPE.SHORT_ANSWER ? (
+          <Input
+            disabled={!canRespond}
+            placeholder="Enter your answer"
+            onChange={e => setTextAnswer(e.target.value)}
+            css={{
+              w: '100%',
+              backgroundColor: '$surface_brighter',
+              mb: '$md',
+              border: '1px solid $border_default',
+              cursor: localPeerResponse ? 'not-allowed' : 'text',
+            }}
+          />
+        ) : null}
+
+        {type === QUESTION_TYPE.LONG_ANSWER ? (
+          <TextArea
+            disabled={!canRespond}
+            placeholder="Enter your answer"
+            onChange={e => setTextAnswer(e.target.value)}
+          />
+        ) : null}
+
+        {type === QUESTION_TYPE.SINGLE_CHOICE ? (
+          <SingleChoiceOptions
+            questionIndex={index}
+            isQuiz={isQuiz}
+            canRespond={canRespond}
+            response={localPeerResponse}
+            correctOptionIndex={answer?.option}
+            options={options}
+            setAnswer={setSingleOptionAnswer}
+            totalResponses={result?.totalResponses}
+            showVoteCount={showVoteCount}
+          />
+        ) : null}
+
+        {type === QUESTION_TYPE.MULTIPLE_CHOICE ? (
+          <MultipleChoiceOptions
+            questionIndex={index}
+            isQuiz={isQuiz}
+            canRespond={canRespond}
+            response={localPeerResponse}
+            correctOptionIndexes={answer?.options}
+            options={options}
+            selectedOptions={multipleOptionAnswer}
+            setSelectedOptions={setMultipleOptionAnswer}
+            totalResponses={result?.totalResponses}
+            showVoteCount={showVoteCount}
+          />
+        ) : null}
+
+        {isLive && (
+          <QuestionActions
+            isValidVote={isValidVote}
+            skippable={skippable}
+            onSkip={handleSkip}
+            onVote={handleVote}
+            response={localPeerResponse}
+            stringAnswerExpected={stringAnswerExpected}
+          />
+        )}
       </Box>
-
-      {type === QUESTION_TYPE.SHORT_ANSWER ? (
-        <Input
-          disabled={!canRespond}
-          placeholder="Enter your answer"
-          onChange={e => setTextAnswer(e.target.value)}
-          css={{
-            w: '100%',
-            backgroundColor: '$surface_brighter',
-            mb: '$md',
-            border: '1px solid $border_default',
-            cursor: localPeerResponse ? 'not-allowed' : 'text',
-          }}
-        />
-      ) : null}
-
-      {type === QUESTION_TYPE.LONG_ANSWER ? (
-        <TextArea
-          disabled={!canRespond}
-          placeholder="Enter your answer"
-          onChange={e => setTextAnswer(e.target.value)}
-        />
-      ) : null}
-
-      {type === QUESTION_TYPE.SINGLE_CHOICE ? (
-        <SingleChoiceOptions
-          questionIndex={index}
-          isQuiz={isQuiz}
-          canRespond={canRespond}
-          response={localPeerResponse}
-          correctOptionIndex={answer?.option}
-          options={options}
-          setAnswer={setSingleOptionAnswer}
-          totalResponses={result?.totalResponses}
-          showVoteCount={showVoteCount}
-        />
-      ) : null}
-
-      {type === QUESTION_TYPE.MULTIPLE_CHOICE ? (
-        <MultipleChoiceOptions
-          questionIndex={index}
-          isQuiz={isQuiz}
-          canRespond={canRespond}
-          response={localPeerResponse}
-          correctOptionIndexes={answer?.options}
-          options={options}
-          selectedOptions={multipleOptionAnswer}
-          setSelectedOptions={setMultipleOptionAnswer}
-          totalResponses={result?.totalResponses}
-          showVoteCount={showVoteCount}
-        />
-      ) : null}
-
-      {isLive && (
-        <QuestionActions
-          isValidVote={isValidVote}
-          skippable={skippable}
-          onSkip={handleSkip}
-          onVote={handleVote}
-          response={localPeerResponse}
-          stringAnswerExpected={stringAnswerExpected}
-        />
-      )}
     </Box>
   );
 };

--- a/packages/roomkit-react/src/Prebuilt/components/Polls/common/SingleChoiceOptions.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Polls/common/SingleChoiceOptions.jsx
@@ -86,10 +86,11 @@ export const SingleChoiceOptionInputs = ({ isQuiz, options, selectAnswer, handle
                 <RadioGroup.Item
                   css={{
                     background: 'none',
-                    w: '$9',
                     border: '2px solid',
                     borderColor: '$on_surface_high',
                     display: 'flex',
+                    w: '$8',
+                    flexShrink: '0',
                     justifyContent: 'center',
                     alignItems: 'center',
                     cursor: 'pointer',


### PR DESCRIPTION
<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2339" title="WEB-2339" target="_blank">WEB-2339</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Polls new design changes</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

- Updated question card layout for design parity
- Options in the question card can now be collapsed 
- Updated labels, added autoFocus on inputs

WIP
- Correct/Incorrect response UI
- Skipping should allow resubmissions
- Quizzes require a central submit button at the end. Results should be shown only after [submit] (https://www.figma.com/file/ELM8oi6Abp9w1dzF5ApiJA/Prebuilt-Kit---Stage-1.5?node-id=1571%3A562437&mode=dev)
- To add text answer question type added for quiz - requires handling in InteractivityCenter
- Allow changing answers/voting again on question level - to check if this requires changes in InteractivityCenter