### PR TITLE
fix: audio bottomsheet in mweb design parity

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Header/common.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Header/common.jsx
@@ -173,7 +173,7 @@ const SelectWithLabel = ({ label, icon = <></>, checked, id, onChange }) => {
         css={{
           fontSize: '$md',
           fontWeight: '$semiBold',
-          color: checked ? '$on_surface_high' : '$on_surface_low',
+          color: '$on_surface_high',
           cursor: 'pointer',
           display: 'flex',
           alignItems: 'center',


### PR DESCRIPTION
![Screenshot_2023-11-14-10-28-40-25_40deb401b9ffe8e1df2f1cc5ba480b12](https://github.com/100mslive/web-sdks/assets/110378139/21805601-1891-499a-91a4-19303edab867)
![Screenshot_20231114_134004_Chrome](https://github.com/100mslive/web-sdks/assets/110378139/c52e3e0b-9ea3-4770-ba57-88f4391e20f2)
