### PR TITLE
fix: clear pinned message in mweb

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Chat/Chat.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Chat/Chat.jsx
@@ -108,7 +108,7 @@ export const Chat = ({ screenType }) => {
       {isLocalPeerBlacklisted ? <ChatBlocked /> : null}
 
       {isMobile && elements?.chat?.is_overlay && elements?.chat?.allow_pinning_messages ? (
-        <PinnedMessage clearPinnedMessage={removePinnedMessage} />
+        <PinnedMessage clearPinnedMessage={index => removePinnedMessage(pinnedMessages, index)} />
       ) : null}
 
       {isChatEnabled && !isLocalPeerBlacklisted ? (


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2414" title="WEB-2414" target="_blank">WEB-2414</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>mweb: not able to remove multi pinned messages on mweb</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

The function arguments were not updated for the second instance of PinnedMessages (mweb instance)