### PR TITLE
fix: poll responses on reload

### DIFF
--- a/packages/hms-video-web/src/notification-manager/managers/PollsManager.ts
+++ b/packages/hms-video-web/src/notification-manager/managers/PollsManager.ts
@@ -59,6 +59,8 @@ export class PollsManager {
         questions: questions.questions.map(({ question, options, answer }) => ({ ...question, options, answer })),
       };
 
+      await this.updatePollResponses(poll, true);
+
       polls.push(poll);
       this.store.setPoll(poll);
     }
@@ -95,40 +97,7 @@ export class PollsManager {
       }
 
       this.updatePollResult(savedPoll, updatedPoll);
-
-      const serverResponseParams = await this.transport.getPollResponses({
-        poll_id: updatedPoll.poll_id,
-        index: 0,
-        count: 50,
-        self: false,
-      });
-
-      serverResponseParams.responses?.forEach(({ response, peer, final }) => {
-        const question = savedPoll?.questions?.find(question => question.index === response.question);
-        if (!question) {
-          return;
-        }
-        const pollResponse: HMSPollQuestionResponse = {
-          id: response.response_id,
-          questionIndex: response.question,
-          option: response.option,
-          options: response.options,
-          text: response.text,
-          responseFinal: final,
-          peer: { peerid: peer.peerid, userHash: peer.hash, userid: peer.userid, username: peer.username },
-          skipped: response.skipped,
-          type: response.type,
-          update: response.update,
-        };
-
-        if (Array.isArray(question.responses) && question.responses.length > 0) {
-          if (!question.responses.find(({ id }) => id === pollResponse.id)) {
-            question.responses.push(pollResponse);
-          }
-        } else {
-          question.responses = [pollResponse];
-        }
-      });
+      await this.updatePollResponses(savedPoll, false);
 
       updatedPolls.push(savedPoll);
     }
@@ -160,6 +129,42 @@ export class PollsManager {
           savedOption.voteCount = updatedVoteCount;
         }
       });
+    });
+  }
+
+  private async updatePollResponses(poll: HMSPoll, self: boolean) {
+    const serverResponseParams = await this.transport.getPollResponses({
+      poll_id: poll.id,
+      index: 0,
+      count: 50,
+      self,
+    });
+
+    serverResponseParams.responses?.forEach(({ response, peer, final }) => {
+      const question = poll?.questions?.find(question => question.index === response.question);
+      if (!question) {
+        return;
+      }
+      const pollResponse: HMSPollQuestionResponse = {
+        id: response.response_id,
+        questionIndex: response.question,
+        option: response.option,
+        options: response.options,
+        text: response.text,
+        responseFinal: final,
+        peer: { peerid: peer.peerid, userHash: peer.hash, userid: peer.userid, username: peer.username },
+        skipped: response.skipped,
+        type: response.type,
+        update: response.update,
+      };
+
+      if (Array.isArray(question.responses) && question.responses.length > 0) {
+        if (!question.responses.find(({ id }) => id === pollResponse.id)) {
+          question.responses.push(pollResponse);
+        }
+      } else {
+        question.responses = [pollResponse];
+      }
     });
   }
 }


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2365" title="WEB-2365" target="_blank">WEB-2365</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>user is not able to Vote a poll </td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
