### PR TITLE
fix: active speaker sorting

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/common/PeersSorter.ts
+++ b/packages/roomkit-react/src/Prebuilt/common/PeersSorter.ts
@@ -17,6 +17,7 @@ class PeersSorter {
   }
 
   setPeersAndTilesPerPage = ({ peers, tilesPerPage }: { peers: HMSPeer[]; tilesPerPage: number }) => {
+    this.speaker = undefined;
     this.tilesPerPage = tilesPerPage;
     const peerIds = new Set(peers.map(peer => peer.id));
     // remove existing peers which are no longer provided
@@ -46,6 +47,8 @@ class PeersSorter {
     this.updateListeners();
     this.listeners.clear();
     this.storeUnsubscribe?.();
+    this.storeUnsubscribe = undefined;
+    this.speaker = undefined;
   };
 
   moveSpeakerToFront = (speaker?: HMSPeer) => {
@@ -68,10 +71,16 @@ class PeersSorter {
   };
 
   onDominantSpeakerChange = (speaker: HMSPeer | null) => {
-    if (speaker && speaker.id !== this?.speaker?.id) {
-      this.speaker = speaker;
-      this.moveSpeakerToFront(speaker);
+    // no speaker or is current speaker do nothing
+    if (!speaker || speaker.id === this.speaker?.id) {
+      return;
     }
+    // if the active speaker is not from the peers passed ignore
+    if (!this.peers.has(speaker.id)) {
+      return;
+    }
+    this.speaker = speaker;
+    this.moveSpeakerToFront(speaker);
   };
 
   updateListeners = () => {

--- a/packages/roomkit-react/src/Prebuilt/components/VideoLayouts/EqualProminence.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/VideoLayouts/EqualProminence.tsx
@@ -10,7 +10,6 @@ import { LayoutProps } from './interface';
 // @ts-ignore: No implicit Any
 import { useUISettings } from '../AppData/useUISettings';
 import { usePagesWithTiles, useTileLayout } from '../hooks/useTileLayout';
-// @ts-ignore: No implicit Any
 import { UI_SETTINGS } from '../../common/constants';
 
 export function EqualProminence({ isInsetEnabled = false, peers, onPageChange, onPageSize, edgeToEdge }: LayoutProps) {
@@ -23,10 +22,12 @@ export function EqualProminence({ isInsetEnabled = false, peers, onPageChange, o
     maxTileCount,
   });
   // useMemo is needed to prevent recursion as new array is created for localPeer
-  const inputPeers = useMemo(
-    () => (pageList.length === 0 ? (localPeer ? [localPeer] : []) : peers),
-    [pageList.length, peers, localPeer],
-  );
+  const inputPeers = useMemo(() => {
+    if (pageList.length === 0) {
+      return localPeer ? [localPeer] : [];
+    }
+    return peers;
+  }, [pageList.length, peers, localPeer]);
   // Pass local peer to main grid if no other peer has tiles
   pageList = usePagesWithTiles({
     peers: inputPeers,

--- a/packages/roomkit-react/src/Prebuilt/components/VideoLayouts/ScreenshareLayout.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/VideoLayouts/ScreenshareLayout.tsx
@@ -10,7 +10,6 @@ import { LayoutProps } from './interface';
 import { ProminenceLayout } from './ProminenceLayout';
 // @ts-ignore: No implicit Any
 import { useSetAppDataByKey } from '../AppData/useUISettings';
-// @ts-ignore: No implicit Any
 import { APP_DATA } from '../../common/constants';
 
 export const ScreenshareLayout = ({ peers, onPageChange, onPageSize, edgeToEdge }: LayoutProps) => {


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2459" title="WEB-2459" target="_blank">WEB-2459</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Active speaker sorting in inset mode/screenshare shuffling the peers even when no. of tiles are same as peers</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Incident" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />
        Incident
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
