### PR TITLE
feat: handle force role change from layout api

### DIFF
--- a/packages/roomkit-react/package.json
+++ b/packages/roomkit-react/package.json
@@ -80,7 +80,7 @@
     "@100mslive/hms-virtual-background": "1.11.24",
     "@100mslive/react-icons": "0.8.24",
     "@100mslive/react-sdk": "0.8.24",
-    "@100mslive/types-prebuilt": "0.12.4",
+    "@100mslive/types-prebuilt": "0.12.5",
     "@emoji-mart/data": "^1.0.6",
     "@emoji-mart/react": "^1.0.1",
     "@radix-ui/react-accordion": "1.0.0",

--- a/packages/roomkit-react/src/Prebuilt/components/Footer/ParticipantList.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Footer/ParticipantList.jsx
@@ -261,6 +261,7 @@ const ParticipantMoreActions = ({ peerId, role, elements, canChangeRole, canRemo
     remove_from_stage_label,
     on_stage_role,
     off_stage_roles = [],
+    skip_preview_for_role_change = false,
   } = elements.on_stage_exp || {};
   const isInStage = role === on_stage_role;
   const shouldShowStageRoleChange =
@@ -275,7 +276,7 @@ const ParticipantMoreActions = ({ peerId, role, elements, canChangeRole, canRemo
     if (isInStage) {
       prevRole && hmsActions.changeRoleOfPeer(peerId, prevRole, true);
     } else {
-      await hmsActions.changeRoleOfPeer(peerId, on_stage_role);
+      await hmsActions.changeRoleOfPeer(peerId, on_stage_role, skip_preview_for_role_change);
     }
     setOpen(false);
   };

--- a/packages/roomkit-react/src/Prebuilt/components/RoleChangeModal.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/RoleChangeModal.jsx
@@ -170,7 +170,7 @@ export const RoleChangeModal = ({ peerId, onOpenChange }) => {
                 variant="primary"
                 css={{ width: '100%' }}
                 onClick={async () => {
-                  await hmsActions.changeRole(peerId, selectedRole, peer.isLocal ? true : !requestPermission);
+                  await hmsActions.changeRoleOfPeer(peerId, selectedRole, peer.isLocal ? true : !requestPermission);
                   onOpenChange(false);
                 }}
               >

--- a/packages/roomkit-react/src/Prebuilt/components/Toast/ToastConfig.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Toast/ToastConfig.jsx
@@ -38,15 +38,24 @@ const HandRaiseAction = React.forwardRef(({ id = '', isSingleHandRaise = true },
     bring_to_stage_label,
     on_stage_role,
     off_stage_roles = [],
+    skip_preview_for_role_change = false,
   } = layout?.screens?.conferencing?.default?.elements.on_stage_exp || {};
 
   const onClickHandler = useCallback(() => {
     if (isSingleHandRaise) {
-      hmsActions.changeRoleOfPeer(id, on_stage_role);
+      hmsActions.changeRoleOfPeer(id, on_stage_role, skip_preview_for_role_change);
     } else {
       !isParticipantsOpen && toggleSidepane();
     }
-  }, [hmsActions, id, isParticipantsOpen, isSingleHandRaise, on_stage_role, toggleSidepane]);
+  }, [
+    hmsActions,
+    id,
+    isParticipantsOpen,
+    isSingleHandRaise,
+    on_stage_role,
+    toggleSidepane,
+    skip_preview_for_role_change,
+  ]);
 
   // show nothing if handRaise is single and peer role is not hls
   if (isSingleHandRaise && (!peer || !off_stage_roles.includes(peer.roleName))) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@100mslive/types-prebuilt@0.12.4":
-  version "0.12.4"
-  resolved "https://registry.yarnpkg.com/@100mslive/types-prebuilt/-/types-prebuilt-0.12.4.tgz#1b79f421a8ecb0d4ab47870e017a2fda17ef9c5f"
-  integrity sha512-MzqYyoEMNob+ffKp2pFCxNFC9ZQflpDF+GfKJIPW/FuwGKEouyp77mkQ2b5Hv6z7U1m0MoiqsgCgyakz8+23fg==
+"@100mslive/types-prebuilt@0.12.5":
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/@100mslive/types-prebuilt/-/types-prebuilt-0.12.5.tgz#505d19e228f7e2929eb93c489a0f886d628df02f"
+  integrity sha512-OQrNVosEe0S1RsGGueOLKMioHJhtP97M+1y3RXcELXOyowwBL/058V1FeVqsRjEyfA8sH85v7afN+QknI6ituw==
 
 "@aashutoshrathi/word-wrap@^1.2.3":
   version "1.2.6"


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2488" title="WEB-2488" target="_blank">WEB-2488</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>One click role change</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
