### PR TITLE
feat: close existing screenshare or whiteboard when the other is started

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/hooks/useCloseScreenshareWhiteboard.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/hooks/useCloseScreenshareWhiteboard.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { usePrevious } from 'react-use';
+import { useScreenShare, useWhiteboard } from '@100mslive/react-sdk';
+
+/**
+ * close existing screenshare or whiteboard when the other is started
+ */
+export const useCloseScreenshareWhiteboard = () => {
+  const { amIScreenSharing, toggleScreenShare } = useScreenShare();
+  const { isOwner: isWhiteboardOwner, toggle: toggleWhiteboard } = useWhiteboard();
+  const prevScreenSharer = usePrevious(amIScreenSharing);
+  const prevWhiteboardOwner = usePrevious(isWhiteboardOwner);
+
+  // if both screenshare and whiteboard are open, close the one that was open earlier
+  useEffect(() => {
+    if (isWhiteboardOwner && amIScreenSharing) {
+      if (prevScreenSharer && !prevWhiteboardOwner) {
+        toggleScreenShare?.();
+      } else if (prevWhiteboardOwner && !prevScreenSharer) {
+        toggleWhiteboard?.();
+      }
+    }
+  }, [isWhiteboardOwner, amIScreenSharing, prevScreenSharer, prevWhiteboardOwner, toggleScreenShare, toggleWhiteboard]);
+};

--- a/packages/roomkit-react/src/Prebuilt/layouts/VideoStreamingSection.tsx
+++ b/packages/roomkit-react/src/Prebuilt/layouts/VideoStreamingSection.tsx
@@ -30,6 +30,7 @@ import {
   useWaitingViewerRole,
   // @ts-ignore: No implicit Any
 } from '../components/AppData/useUISettings';
+import { useCloseScreenshareWhiteboard } from '../components/hooks/useCloseScreenshareWhiteboard';
 // @ts-ignore: No implicit Any
 import { SESSION_STORE_KEY } from '../common/constants';
 
@@ -55,6 +56,7 @@ export const VideoStreamingSection = ({
   const waitingViewerRole = useWaitingViewerRole();
   const urlToIframe = useUrlToEmbed();
   const pdfAnnotatorActive = usePDFConfig();
+  useCloseScreenshareWhiteboard();
 
   useEffect(() => {
     if (!isConnected) {


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2408" title="WEB-2408" target="_blank">WEB-2408</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Whiteboard In Prebuilt</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
