### PR TITLE
fix: stop stream being called twice

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Leave/DesktopLeaveRoom.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Leave/DesktopLeaveRoom.tsx
@@ -77,6 +77,7 @@ export const DesktopLeaveRoom = ({
                   bg: '$surface_dim',
                   color: '$on_surface_medium',
                   '&:hover': { bg: '$surface_default', color: '$on_surface_high' },
+                  p: '0',
                 }}
                 data-testid="just_leave_btn"
               >
@@ -89,7 +90,7 @@ export const DesktopLeaveRoom = ({
                   titleColor="$on_surface_high"
                   icon={<ExitIcon height={24} width={24} style={{ transform: 'rotate(180deg)' }} />}
                   onClick={async () => await leaveRoom()}
-                  css={{ p: 0 }}
+                  css={{ p: '$8 $4' }}
                 />
               </Dropdown.Item>
 
@@ -98,6 +99,7 @@ export const DesktopLeaveRoom = ({
                   bg: '$alert_error_dim',
                   color: '$alert_error_bright',
                   '&:hover': { bg: '$alert_error_dim', color: '$alert_error_brighter' },
+                  p: '0',
                 }}
                 data-testid="end_room_btn"
               >
@@ -113,7 +115,7 @@ export const DesktopLeaveRoom = ({
                     setOpen(false);
                     setShowEndStreamAlert(true);
                   }}
-                  css={{ p: 0 }}
+                  css={{ p: '$8 $4' }}
                 />
               </Dropdown.Item>
             </Dropdown.Content>


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2506" title="WEB-2506" target="_blank">WEB-2506</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>LIVE-1965 Error notification while stopping live stream</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Incident" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />
        Incident
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details

- Leave room was being called twice, which in this scenario also called stopStream twice
