### PR TITLE
fix: sidepane header UI for single tab

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/SidePaneTabs.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/SidePaneTabs.tsx
@@ -107,16 +107,36 @@ export const SidePaneTabs = React.memo<{
         <>
           {hideTabs ? (
             <>
-              <Text variant="sm" css={{ fontWeight: '$semiBold', p: '$4', c: '$on_surface_high', pr: '$12' }}>
-                {showChat ? (
-                  chat_title
-                ) : (
-                  <span>
-                    Participants <ParticipantCount count={peerCount} />
-                  </span>
-                )}
-              </Text>
-
+              <Flex justify="between" css={{ w: '100%' }}>
+                <Text variant="sm" css={{ fontWeight: '$semiBold', p: '$4', c: '$on_surface_high', pr: '$12' }}>
+                  {showChat ? (
+                    chat_title
+                  ) : (
+                    <span>
+                      Participants <ParticipantCount count={peerCount} />
+                    </span>
+                  )}
+                </Text>
+                <Flex>
+                  {showChatSettings ? <ChatSettings /> : null}
+                  {isOverlayChat && isChatOpen ? null : (
+                    <IconButton
+                      css={{ my: '$1', color: '$on_surface_medium', '&:hover': { color: '$on_surface_high' } }}
+                      onClick={e => {
+                        e.stopPropagation();
+                        if (activeTab === SIDE_PANE_OPTIONS.CHAT) {
+                          toggleChat();
+                        } else {
+                          toggleParticipants();
+                        }
+                      }}
+                      data-testid="close_chat"
+                    >
+                      <CrossIcon />
+                    </IconButton>
+                  )}
+                </Flex>
+              </Flex>
               {showChat ? <Chat /> : <ParticipantList offStageRoles={off_stage_roles} onActive={setActiveRole} />}
             </>
           ) : (


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2508" title="WEB-2508" target="_blank">WEB-2508</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>LIVE-1970 Sidepane headers missing when participants list is disabled</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Incident" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />
        Incident
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details
- Fixed missing cross button when just Chat or Participant list is present
