### PR TITLE
fix: black space when pinning inset tile

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/VideoLayouts/GridLayout.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/VideoLayouts/GridLayout.tsx
@@ -58,8 +58,9 @@ export const GridLayout = ({
       return peers.filter(peer => peer.id !== activeScreensharePeerId);
     }
     if (isInsetEnabled) {
+      const isLocalPeerPinned = localPeerID === pinnedTrack?.peerId;
       // if localPeer role is prominent role, it shows up in the center or local peer is pinned, so allow it in active speaker sorting
-      if ((localPeerRole && prominentRoles.includes(localPeerRole)) || localPeerID === pinnedTrack?.peerId) {
+      if ((localPeerRole && prominentRoles.includes(localPeerRole)) || isLocalPeerPinned) {
         return peers;
       } else {
         return peers.filter(peer => !peer.isLocal);


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2539" title="WEB-2539" target="_blank">WEB-2539</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Inset mode results in a black space in the center while pinning/spotlightling the local peer</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Incident" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />
        Incident
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
