### PR TITLE
fix: polls icon rerender

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/hooks/useUnreadPollQuizPresent.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/hooks/useUnreadPollQuizPresent.tsx
@@ -4,14 +4,11 @@ import { HMSNotificationTypes, useHMSNotifications, useHMSStore } from '@100msli
 
 export const useUnreadPollQuizPresent = () => {
   const localPeerID = useHMSStore(selectLocalPeerID);
-  const notification = useHMSNotifications();
+  const notification = useHMSNotifications(HMSNotificationTypes.POLL_STARTED);
   const [unreadPollQuiz, setUnreadPollQuiz] = useState(false);
 
   useEffect(() => {
     if (!notification) {
-      return;
-    }
-    if (notification.type !== HMSNotificationTypes.POLL_STARTED) {
       return;
     }
     setUnreadPollQuiz(notification.data.startedBy !== localPeerID);


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2540" title="WEB-2540" target="_blank">WEB-2540</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Polls Icon rerendering unnecessarily</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
