### PR TITLE
fix: match button borders, padding

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/IconButtonWithOptions/IconButtonWithOptions.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/IconButtonWithOptions/IconButtonWithOptions.jsx
@@ -28,7 +28,7 @@ const IconSection = styled(IconButton, {
 const OptionsSection = styled(IconButton, {
   w: 'unset',
   h: '$14',
-  p: '$4',
+  p: '$4 $2',
   r: '$1',
   borderTopLeftRadius: 0,
   borderColor: '$border_bright',


### PR DESCRIPTION
<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2314" title="WEB-2314" target="_blank">WEB-2314</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Inconsistent button borders</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

- Match button borders for IconButton and IconButtonWithOptions
- Match padding with screenshare and leave split buttons

https://100ms.atlassian.net/browse/WEB-2386

<img width="715" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/86d08fde-4801-422f-bc73-36fcdcd9a16a">
