### PR TITLE
fix: remove borders for styledbutton

### DIFF
--- a/packages/roomkit-react/src/TileMenu/StyledMenuTile.tsx
+++ b/packages/roomkit-react/src/TileMenu/StyledMenuTile.tsx
@@ -49,6 +49,7 @@ const styledItem = {
 const StyledItemButton = styled('button', {
   ...styledItem,
   height: '$14',
+  border: 'none',
   '&:hover': {
     backgroundColor: '$surface_brighter',
   },


### PR DESCRIPTION
<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2557" title="WEB-2557" target="_blank">WEB-2557</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Fix prebuilt element borders</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

- [x] Test in codesandbox with alpha version

https://codesandbox.io/p/sandbox/roomkit-react-v2p94v?file=%2Fpackage.json%3A9%2C27