### PR TITLE
fix: preview scroll in smaller dimensions

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
@@ -212,6 +212,7 @@ export const PreviewTile = ({ name, error }: { name: string; error?: boolean }) 
         bg: '$surface_default',
         aspectRatio,
         height: 'min(360px, 70vh)',
+        width: 'auto',
         maxWidth: '640px',
         overflow: 'clip',
         mt: '$14',

--- a/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
@@ -160,20 +160,7 @@ const PreviewJoin = ({
             <Chip content={getParticipantChipContent(peerCount)} hideIfNoContent />
           </Flex>
         </Flex>
-        {toggleVideo ? (
-          <Flex
-            align="center"
-            justify="center"
-            css={{
-              mt: '$14',
-              '@md': { mt: 0 },
-              '@sm': { width: '100%' },
-              flexDirection: 'column',
-            }}
-          >
-            <PreviewTile name={name} error={previewError} />
-          </Flex>
-        ) : null}
+        {toggleVideo ? <PreviewTile name={name} error={previewError} /> : null}
         <Box css={{ w: '100%', maxWidth: `${Math.max(aspectRatio, 1) * 360}px` }}>
           <PreviewControls hideSettings={!toggleVideo && !toggleAudio} vbEnabled={!!virtual_background} />
           <PreviewForm
@@ -227,7 +214,9 @@ export const PreviewTile = ({ name, error }: { name: string; error?: boolean }) 
         height: 'min(360px, 70vh)',
         maxWidth: '640px',
         overflow: 'clip',
+        mt: '$14',
         '@md': {
+          mt: 0,
           width: 'min(220px, 70vw)',
           maxWidth: '100%',
           my: '$4',


### PR DESCRIPTION

<details open>
  <summary><a href="https://100ms.atlassian.net/browse/WEB-2485" title="WEB-2485" target="_blank">WEB-2485</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
      <td>Fix preview for smaller viewport resolutions</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Incident" src="https://100ms.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />
        Incident
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
    <tr>
      <th>Points</th>
      <td>N/A</td>
    </tr>
    <tr>
      <th>Labels</th>
      <td>-</td>
    </tr>
  </table>
</details>
<!--
  do not remove this marker as it will break jira-lint's functionality.
  added_by_jira_lint
-->

---

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

-
-

### Choose one of these(put a 'x' in the bracket):

- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.

### Implementation note, gotchas, related work and Future TODOs (optional)
