### PR TITLE
fix: process plugins on device change

### DIFF
--- a/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
@@ -182,6 +182,9 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
       // if track is muted, we just cache the settings for when it is unmuted
       this.settings = newSettings;
       return;
+    } else {
+      await this.pluginsManager.waitForRestart();
+      this.processPlugins();
     }
     await this.handleSettingsChange(newSettings);
     this.settings = newSettings;

--- a/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
@@ -184,7 +184,7 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
       return;
     } else {
       await this.pluginsManager.waitForRestart();
-      this.processPlugins();
+      await this.processPlugins();
     }
     await this.handleSettingsChange(newSettings);
     this.settings = newSettings;

--- a/packages/hms-virtual-background/src/HMSEffectsPlugin.ts
+++ b/packages/hms-virtual-background/src/HMSEffectsPlugin.ts
@@ -34,26 +34,34 @@ export class HMSEffectsPlugin implements HMSMediaStreamPlugin {
     return 'HMSEffects';
   }
 
-  setBlur(blur: number) {
-    this.blurAmount = blur;
+  removeBlur() {
+    this.blurAmount = 0;
+    this.effects.clearBlur();
     this.background = '';
-    this.backgroundType = HMSVirtualBackgroundTypes.BLUR;
-    this.effects.setBlur(blur);
+  }
+
+  removeBackground() {
+    this.background = '';
     this.effects.clearBackground();
   }
 
+  setBlur(blur: number) {
+    this.removeBackground();
+    this.blurAmount = blur;
+    this.backgroundType = HMSVirtualBackgroundTypes.BLUR;
+    this.effects.setBlur(blur);
+  }
+
   removeEffects() {
-    this.effects.clearBackground();
-    this.effects.clearBlur();
     this.backgroundType = HMSVirtualBackgroundTypes.NONE;
-    this.background = '';
+    this.removeBackground();
+    this.removeBlur();
   }
 
   setBackground(url: HMSEffectsBackground) {
     this.background = url;
-    this.blurAmount = 0;
+    this.removeBlur();
     this.backgroundType = HMSVirtualBackgroundTypes.IMAGE;
-    this.effects.clearBlur();
     this.effects.setBackground(url);
   }
 


### PR DESCRIPTION
### Details(context, link the issue, how was the bug fixed, what does the new feature do)

- Currently changing the video input results in black tile if virtual background plugins are applied since the plugin has the older stream ID
- The fix processes the plugins when the device changes
- Tested on OBS virtual camera, to test on a real device
