### PR TITLE
fix: hide incorrect answer indicator until quiz ends

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Polls/Voting/QuestionCard.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Polls/Voting/QuestionCard.jsx
@@ -40,6 +40,7 @@ export const QuestionCard = ({
     roleCanViewResponse && (localPeerResponse || (isLocalPeerCreator && pollState === 'stopped')) && !isQuiz;
 
   const isLive = pollState === 'started';
+  const pollEnded = pollState === 'stopped';
   const canRespond = isLive && !localPeerResponse;
   const startTime = useRef(Date.now());
   const isCorrectAnswer = checkCorrectAnswer(answer, localPeerResponse, type);
@@ -117,8 +118,8 @@ export const QuestionCard = ({
             gap: '$4',
           }}
         >
-          {respondedToQuiz && isCorrectAnswer ? <CheckCircleIcon height={20} width={20} /> : null}
-          {respondedToQuiz && !isCorrectAnswer ? <CrossCircleIcon height={20} width={20} /> : null}
+          {respondedToQuiz && isCorrectAnswer && pollEnded ? <CheckCircleIcon height={20} width={20} /> : null}
+          {respondedToQuiz && !isCorrectAnswer && pollEnded ? <CrossCircleIcon height={20} width={20} /> : null}
           QUESTION {index} OF {totalQuestions}: {type.toUpperCase()}
         </Text>
       </Flex>


### PR DESCRIPTION
### Details(context, link the issue, how was the bug fixed, what does the new feature do)

- The indicator for correct/incorrect response was being shown on voting, before the quiz ended

After:
![image](https://github.com/100mslive/web-sdks/assets/57426646/8ea6b7a0-0085-43ed-8d11-e784b1329c3d)
