### PR TITLE
fix: remove autofocus from chat textarea

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Chat/ChatFooter.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Chat/ChatFooter.tsx
@@ -219,7 +219,6 @@ export const ChatFooter = ({ onSend, children }: { onSend: (count: number) => vo
               placeholder={message_placeholder}
               ref={inputRef}
               required
-              autoFocus={!isMobile}
               onKeyPress={async event => {
                 if (event.key === 'Enter') {
                   if (!event.shiftKey) {


### PR DESCRIPTION
### Details

- Updating the chat placeholder via the prebuilt customiser causes the component to re-render and it captures the focus (autoFocus was added for UX improvement)
