### PR TITLE
fix: quiz duration formatting

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Polls/Voting/LeaderboardEntry.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Polls/Voting/LeaderboardEntry.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { CheckCircleIcon, ClockIcon, TrophyFilledIcon } from '@100mslive/react-icons';
 import { Box, Flex } from '../../../../Layout';
 import { Text } from '../../../../Text';
+import { getFormattedTime } from '../common/utils';
 
 const positionColorMap: Record<number, string> = { 1: '#D69516', 2: '#3E3E3E', 3: '#583B0F' };
 
@@ -66,7 +67,7 @@ export const LeaderboardEntry = ({
         {duration ? (
           <Flex align="center" css={{ gap: '$2', color: '$on_surface_medium' }}>
             <ClockIcon height={16} width={16} />
-            <Text variant="xs">{(duration / 1000).toFixed(3)}s</Text>
+            <Text variant="xs">{getFormattedTime(duration)}</Text>
           </Flex>
         ) : null}
       </Flex>

--- a/packages/roomkit-react/src/Prebuilt/components/Polls/Voting/PeerParticipationSummary.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Polls/Voting/PeerParticipationSummary.tsx
@@ -4,6 +4,7 @@ import { Box } from '../../../../Layout';
 import { Text } from '../../../../Text';
 import { StatisticBox } from './StatisticBox';
 import { useQuizSummary } from './useQuizSummary';
+import { getFormattedTime } from '../common/utils';
 
 export const PeerParticipationSummary = ({ quiz }: { quiz: HMSPoll }) => {
   const localPeerId = useHMSStore(selectLocalPeerID);
@@ -29,7 +30,7 @@ export const PeerParticipationSummary = ({ quiz }: { quiz: HMSPoll }) => {
           }/${summary.totalUsers})`,
         },
         // Time in ms
-        { title: 'Avg. Time Taken', value: `${(summary.avgTime / 1000).toFixed(3)}s` },
+        { title: 'Avg. Time Taken', value: getFormattedTime(summary.avgTime) },
         {
           title: 'Avg. Score',
           value: Number.isInteger(summary.avgScore) ? summary.avgScore : summary.avgScore.toFixed(2),
@@ -39,7 +40,7 @@ export const PeerParticipationSummary = ({ quiz }: { quiz: HMSPoll }) => {
         { title: 'Your rank', value: peerEntry?.position || '-' },
         { title: 'Points', value: peerEntry?.score },
         // Time in ms
-        { title: 'Time Taken', value: `${((peerEntry?.duration || 0) / 1000).toFixed(3)}s` },
+        { title: 'Time Taken', value: getFormattedTime(peerEntry?.duration) },
         {
           title: 'Correct Answers',
           value: peerEntry?.totalResponses ? `${peerEntry?.correctResponses}/${peerEntry.totalResponses}` : '-',

--- a/packages/roomkit-react/src/Prebuilt/components/Polls/common/utils.ts
+++ b/packages/roomkit-react/src/Prebuilt/components/Polls/common/utils.ts
@@ -1,12 +1,16 @@
 export const getFormattedTime = (milliseconds: number | undefined) => {
   if (!milliseconds) return '-';
+
   const totalSeconds = milliseconds / 1000;
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
 
-  const timeString = `${minutes ? `${minutes}m ` : ''}${
-    Number.isInteger(seconds) || minutes ? seconds.toFixed(0) : seconds.toFixed(1)
-  }s`;
+  let formattedSeconds = '';
+  if (Number.isInteger(seconds) || minutes) {
+    formattedSeconds = seconds.toFixed(0);
+  } else {
+    formattedSeconds = seconds.toFixed(1);
+  }
 
-  return timeString;
+  return `${minutes ? `${minutes}m ` : ''}${formattedSeconds}s`;
 };

--- a/packages/roomkit-react/src/Prebuilt/components/Polls/common/utils.ts
+++ b/packages/roomkit-react/src/Prebuilt/components/Polls/common/utils.ts
@@ -1,4 +1,4 @@
-export const getFormattedTime = (milliseconds: number) => {
+export const getFormattedTime = (milliseconds: number | undefined) => {
   if (!milliseconds) return '-';
   const totalSeconds = milliseconds / 1000;
   const minutes = Math.floor(totalSeconds / 60);

--- a/packages/roomkit-react/src/Prebuilt/components/Polls/common/utils.ts
+++ b/packages/roomkit-react/src/Prebuilt/components/Polls/common/utils.ts
@@ -1,0 +1,11 @@
+export const getFormattedTime = (milliseconds = 0) => {
+  const totalSeconds = milliseconds / 1000;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  const timeString = `${minutes ? `${minutes}m ` : ''}${
+    Number.isInteger(seconds) || minutes ? seconds.toFixed(0) : seconds.toFixed(1)
+  }s`;
+
+  return timeString;
+};

--- a/packages/roomkit-react/src/Prebuilt/components/Polls/common/utils.ts
+++ b/packages/roomkit-react/src/Prebuilt/components/Polls/common/utils.ts
@@ -1,4 +1,5 @@
-export const getFormattedTime = (milliseconds = 0) => {
+export const getFormattedTime = (milliseconds: number) => {
+  if (!milliseconds) return '-';
   const totalSeconds = milliseconds / 1000;
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;


### PR DESCRIPTION
### Details(context, link the issue, how was the bug fixed, what does the new feature do)

- Format time into minutes and seconds, fix decimal places to match designs


<img width="379" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/7bf6ec1e-303e-4ed5-8d02-07d45092a871">


<img width="398" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/2707892b-adc7-41cb-a0ed-c0b96f8de1ae">

<img width="398" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/878e2667-bb86-44f5-bed4-fdc313f5b191">

