### PR TITLE
fix: improve chat UX for small heights

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Chat/ChatBody.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Chat/ChatBody.tsx
@@ -426,11 +426,15 @@ export const ChatBody = React.forwardRef<VariableSizeList, { scrollToBottom: (co
       return unsubscribe;
     }, [vanillaStore, listRef, scrollToBottom]);
 
-    if (filteredMessages.length === 0) {
-      return <EmptyChat />;
-    }
-
-    return <VirtualizedChatMessages messages={filteredMessages} ref={listRef} scrollToBottom={scrollToBottom} />;
+    return (
+      <Box css={{ overflowY: 'auto' }}>
+        {filteredMessages.length === 0 ? (
+          <EmptyChat />
+        ) : (
+          <VirtualizedChatMessages messages={filteredMessages} ref={listRef} scrollToBottom={scrollToBottom} />
+        )}
+      </Box>
+    );
   },
 );
 

--- a/packages/roomkit-react/src/Prebuilt/components/Chat/EmptyChat.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Chat/EmptyChat.tsx
@@ -33,13 +33,12 @@ export const EmptyChat = () => {
       justify="center"
     >
       <Box>
-        {window && window.screen.height > 600 ? (
-          <img src={emptyChat} alt="Empty Chat" height={132} width={185} style={{ margin: '0 auto' }} />
-        ) : null}
+        <img src={emptyChat} alt="Empty Chat" height={132} width={185} style={{ margin: '0 auto' }} />
+
         <Text variant="h5" css={{ mt: '$8', c: '$on_surface_high' }}>
           {canSendMessages ? 'Start a conversation' : 'No messages yet'}
         </Text>
-        {canSendMessages && window.screen.height > 400 ? (
+        {canSendMessages ? (
           <Text
             variant="sm"
             css={{ mt: '$4', maxWidth: '80%', textAlign: 'center', mx: 'auto', c: '$on_surface_medium' }}

--- a/packages/roomkit-react/src/Prebuilt/components/Chat/EmptyChat.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Chat/EmptyChat.tsx
@@ -33,11 +33,13 @@ export const EmptyChat = () => {
       justify="center"
     >
       <Box>
-        <img src={emptyChat} alt="Empty Chat" height={132} width={185} style={{ margin: '0 auto' }} />
+        {window && window.screen.height > 600 ? (
+          <img src={emptyChat} alt="Empty Chat" height={132} width={185} style={{ margin: '0 auto' }} />
+        ) : null}
         <Text variant="h5" css={{ mt: '$8', c: '$on_surface_high' }}>
           {canSendMessages ? 'Start a conversation' : 'No messages yet'}
         </Text>
-        {canSendMessages ? (
+        {canSendMessages && window.screen.height > 400 ? (
           <Text
             variant="sm"
             css={{ mt: '$4', maxWidth: '80%', textAlign: 'center', mx: 'auto', c: '$on_surface_medium' }}


### PR DESCRIPTION
### Details

- The empty chat image is hidden for small screens https://100ms.atlassian.net/browse/WEB-2612

<img width="921" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/0bdc84c4-dd51-4d91-b85c-39628bc0f3b3">
