### PR TITLE
fix: show trophy only if peer has a score

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Polls/Voting/LeaderboardEntry.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Polls/Voting/LeaderboardEntry.tsx
@@ -54,7 +54,7 @@ export const LeaderboardEntry = ({
       </Flex>
 
       <Flex align="center" css={{ gap: '$4', color: '$on_surface_medium' }}>
-        {position === 1 ? <TrophyFilledIcon height={16} width={16} /> : null}
+        {position === 1 && score ? <TrophyFilledIcon height={16} width={16} /> : null}
         {questionCount ? (
           <>
             <CheckCircleIcon height={16} width={16} />


### PR DESCRIPTION
### Screenshot

<img width="391" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/88cf8f01-143a-4108-b431-d5dc100fbeb4">
