### PR TITLE
fix: radio/checkbox shrink for longer options

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/common/utils.js
+++ b/packages/roomkit-react/src/Prebuilt/common/utils.js
@@ -112,7 +112,7 @@ export const checkCorrectAnswer = (answer, localPeerResponse, type) => {
   }
 };
 
-export const isValidTextInput = (text, minLength = 1, maxLength = 100) => {
+export const isValidTextInput = (text, minLength = 1, maxLength = 1024) => {
   return text && text.length >= minLength && text.length <= maxLength;
 };
 

--- a/packages/roomkit-react/src/Prebuilt/components/Polls/common/MultipleChoiceOptions.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Polls/common/MultipleChoiceOptions.jsx
@@ -33,7 +33,7 @@ export const MultipleChoiceOptions = ({
     <Flex direction="column" css={{ gap: '$md', w: '100%', mb: '$md' }}>
       {options.map(option => {
         return (
-          <Flex align="center" key={`${questionIndex}-${option.index}`} css={{ w: '100%', gap: '$9' }}>
+          <Flex align="center" key={`${questionIndex}-${option.index}`} css={{ w: '100%', gap: '$4' }}>
             {!isStopped || !isQuiz ? (
               <Checkbox.Root
                 id={`${questionIndex}-${option.index}`}
@@ -42,6 +42,7 @@ export const MultipleChoiceOptions = ({
                 onCheckedChange={checked => handleCheckedChange(checked, option.index)}
                 css={{
                   cursor: canRespond ? 'pointer' : 'not-allowed',
+                  flexShrink: 0,
                 }}
               >
                 <Checkbox.Indicator>

--- a/packages/roomkit-react/src/Prebuilt/components/Polls/common/OptionInputWithDelete.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Polls/common/OptionInputWithDelete.tsx
@@ -28,7 +28,7 @@ export const OptionInputWithDelete = ({
         value={option?.text || ''}
         key={index}
         onChange={event => handleOptionTextChange(index, event.target.value.trimStart())}
-        maxLength={100}
+        maxLength={250}
       />
       <IconButton onClick={() => removeOption(index)} css={{ bg: 'transparent', border: 'none' }}>
         <TrashIcon />

--- a/packages/roomkit-react/src/Prebuilt/components/Polls/common/OptionInputWithDelete.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Polls/common/OptionInputWithDelete.tsx
@@ -28,6 +28,7 @@ export const OptionInputWithDelete = ({
         value={option?.text || ''}
         key={index}
         onChange={event => handleOptionTextChange(index, event.target.value.trimStart())}
+        maxLength={100}
       />
       <IconButton onClick={() => removeOption(index)} css={{ bg: 'transparent', border: 'none' }}>
         <TrashIcon />

--- a/packages/roomkit-react/src/Prebuilt/components/Polls/common/SingleChoiceOptions.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Polls/common/SingleChoiceOptions.jsx
@@ -23,7 +23,7 @@ export const SingleChoiceOptions = ({
       <Flex direction="column" css={{ gap: '$md', w: '100%', mb: '$md' }}>
         {options.map(option => {
           return (
-            <Flex align="start" key={`${questionIndex}-${option.index}`} css={{ w: '100%', gap: '$4' }}>
+            <Flex align="center" key={`${questionIndex}-${option.index}`} css={{ w: '100%', gap: '$4' }}>
               {!isStopped || !isQuiz ? (
                 <RadioGroup.Item
                   css={{
@@ -33,6 +33,8 @@ export const SingleChoiceOptions = ({
                     border: '2px solid',
                     borderColor: '$on_surface_high',
                     display: 'flex',
+                    flexShrink: 0,
+                    pt: '$1',
                     justifyContent: 'center',
                     alignItems: 'center',
                     cursor: canRespond ? 'pointer' : 'not-allowed',


### PR DESCRIPTION
<img width="420" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/0643a3fd-fe78-4852-a571-b36967d96f47">

### Fixed:

- Spacing parity between checkbox - option and radio - option
- Radio/checkbox shrinkage when the option is large
- Max limit for option input