### PR TITLE
fix: browser default camera/microphone not getting picked up

### DIFF
--- a/packages/hms-video-store/src/device-manager/DeviceManager.ts
+++ b/packages/hms-video-store/src/device-manager/DeviceManager.ts
@@ -197,12 +197,12 @@ export class DeviceManager implements HMSDeviceManager {
   private updateToActualDefaultDevice = async () => {
     const localPeer = this.store.getLocalPeer();
     const videoDeviceId = this.store.getConfig()?.settings?.videoDeviceId;
-    if (!videoDeviceId) {
-      await (localPeer?.videoTrack as HMSLocalVideoTrack).setSettings({ deviceId: this.videoInput[0]?.deviceId }, true);
+    if (!videoDeviceId && localPeer?.videoTrack) {
+      await (localPeer.videoTrack as HMSLocalVideoTrack).setSettings({ deviceId: this.videoInput[0]?.deviceId }, true);
     }
     const audioDeviceId = this.store.getConfig()?.settings?.audioInputDeviceId;
-    if (!audioDeviceId) {
-      await (localPeer?.audioTrack as HMSLocalAudioTrack).setSettings({ deviceId: this.audioInput[0]?.deviceId }, true);
+    if (!audioDeviceId && localPeer?.audioTrack) {
+      await (localPeer.audioTrack as HMSLocalAudioTrack).setSettings({ deviceId: this.audioInput[0]?.deviceId }, true);
     }
   };
 

--- a/packages/hms-video-store/src/device-manager/DeviceManager.ts
+++ b/packages/hms-video-store/src/device-manager/DeviceManager.ts
@@ -182,6 +182,9 @@ export class DeviceManager implements HMSDeviceManager {
         audioInput: [...this.audioInput],
         audioOutput: [...this.audioOutput],
       });
+      const localPeer = this.store.getLocalPeer();
+      await (localPeer?.videoTrack as HMSLocalVideoTrack).setSettings({ deviceId: this.videoInput[0]?.deviceId }, true);
+      await (localPeer?.audioTrack as HMSLocalAudioTrack).setSettings({ deviceId: this.audioInput[0]?.deviceId }, true);
       this.logDevices('Enumerate Devices');
     } catch (error) {
       HMSLogger.e(this.TAG, 'Failed enumerating devices', error);

--- a/packages/hms-video-store/src/device-manager/DeviceManager.ts
+++ b/packages/hms-video-store/src/device-manager/DeviceManager.ts
@@ -198,11 +198,11 @@ export class DeviceManager implements HMSDeviceManager {
     const localPeer = this.store.getLocalPeer();
     const videoDeviceId = this.store.getConfig()?.settings?.videoDeviceId;
     if (!videoDeviceId && localPeer?.videoTrack) {
-      await (localPeer.videoTrack as HMSLocalVideoTrack).setSettings({ deviceId: this.videoInput[0]?.deviceId }, true);
+      await localPeer.videoTrack.setSettings({ deviceId: this.videoInput[0]?.deviceId }, true);
     }
     const audioDeviceId = this.store.getConfig()?.settings?.audioInputDeviceId;
     if (!audioDeviceId && localPeer?.audioTrack) {
-      await (localPeer.audioTrack as HMSLocalAudioTrack).setSettings({ deviceId: this.audioInput[0]?.deviceId }, true);
+      await localPeer.audioTrack.setSettings({ deviceId: this.audioInput[0]?.deviceId }, true);
     }
   };
 
@@ -384,7 +384,7 @@ export class DeviceManager implements HMSDeviceManager {
       .deviceId(newSelection.deviceId)
       .build();
     try {
-      await (videoTrack as HMSLocalVideoTrack).setSettings(newVideoTrackSettings, true);
+      await videoTrack.setSettings(newVideoTrackSettings, true);
       // On replace track, enabled will be true. Need to be set to previous state
       // videoTrack.setEnabled(enabled); // TODO: remove this once verified on qa.
       this.eventBus.deviceChange.publish({


### PR DESCRIPTION
### Details(context, link the issue, how was the bug fixed, what does the new feature do)

-  Chrome getusermedia returns a different device than what is set from the site settings from chrome settings. Hence this additional handling is needed to update to the correct deviceId.
- https://100ms.atlassian.net/browse/WEB-2797

### Implementation note, gotchas, related work and Future TODOs (optional)
