### PR TITLE
fix: remove `type: module` from whiteboard

### DIFF
--- a/packages/hms-whiteboard/package.json
+++ b/packages/hms-whiteboard/package.json
@@ -3,7 +3,6 @@
   "author": "100ms",
   "license": "MIT",
   "version": "0.0.0-alpha.0",
-  "type": "module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
### Details(context, link the issue, how was the bug fixed, what does the new feature do)

-
-

### Implementation note, gotchas, related work and Future TODOs (optional)
