### PR TITLE
fix: extra properties sent in the krisp usage event

### DIFF
--- a/packages/hms-video-store/src/analytics/AnalyticsEventFactory.ts
+++ b/packages/hms-video-store/src/analytics/AnalyticsEventFactory.ts
@@ -240,6 +240,7 @@ export default class AnalyticsEventFactory {
       name: 'krisp.usage',
       level: AnalyticsEventLevel.INFO,
       properties: { duration },
+      onlyForwardProperties: true,
     });
   }
 


### PR DESCRIPTION
### Before

<img width="339" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/12743b19-da1c-43a9-9d4e-42aa6c3ddf47">



### After

<img width="375" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/9fed3e5c-3d65-4548-8aae-9aee8b897dcd">
