### PR TITLE
fix: width for message sender name

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Chat/ChatBody.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Chat/ChatBody.tsx
@@ -169,7 +169,8 @@ const SenderName = styled(Text, {
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
-  maxWidth: '14ch',
+  // 10ch space for XY:ZZ AM and 2 spaces
+  maxWidth: 'calc(100% - 10ch)',
   minWidth: 0,
   color: '$on_surface_high',
   fontWeight: '$semiBold',
@@ -261,7 +262,7 @@ const ChatMessage = React.memo(
                   {message.senderName || 'Anonymous'}
                 </SenderName>
               ) : (
-                <Tooltip title={message.senderName} side="top" align="start">
+                <Tooltip title={message.senderName} side="top" align="start" boxCss={{ zIndex: 50 }}>
                   <SenderName
                     as="span"
                     variant="sub2"

--- a/packages/roomkit-react/src/Prebuilt/components/Chat/ChatBody.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Chat/ChatBody.tsx
@@ -75,28 +75,35 @@ const MessageTypeContainer = ({ left, right }: { left?: string; right?: string }
         ml: '$2',
         mr: '$4',
         gap: '$space$2',
+        flexWrap: 'nowrap',
       }}
     >
       {left && (
-        <SenderName
+        <Text
           variant="xs"
           as="span"
-          css={{ color: '$on_surface_medium', textTransform: 'capitalize', fontWeight: '$regular' }}
+          css={{
+            color: '$on_surface_medium',
+            textTransform: 'capitalize',
+            fontWeight: '$regular',
+            whiteSpace: 'nowrap',
+          }}
         >
           {left}
-        </SenderName>
+        </Text>
       )}
       {right && (
-        <SenderName
+        <Text
           as="span"
           variant="overline"
           css={{
             color: '$on_surface_medium',
             fontWeight: '$regular',
+            whiteSpace: 'nowrap',
           }}
         >
           {right}
-        </SenderName>
+        </Text>
       )}
     </Flex>
   );
@@ -169,8 +176,7 @@ const SenderName = styled(Text, {
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
-  // 10ch space for XY:ZZ AM and 2 spaces
-  maxWidth: 'calc(100% - 10ch)',
+  width: '100%',
   minWidth: 0,
   color: '$on_surface_high',
   fontWeight: '$semiBold',
@@ -252,7 +258,15 @@ const ChatMessage = React.memo(
             }}
             as="div"
           >
-            <Flex align="baseline">
+            <Flex
+              align="baseline"
+              css={{
+                flexWrap: 'nowrap',
+                maxWidth: 'calc(100% - 10ch)',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
               {message.senderName === 'You' || !message.senderName ? (
                 <SenderName
                   as="span"


### PR DESCRIPTION
### Before:

<img width="433" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/99feebd3-1e9b-4dfc-b4fe-a317e80b6531">

### After:

<img width="444" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/045e9317-d7dc-4943-8fb1-100c6a537c8c">

<img width="451" alt="image" src="https://github.com/100mslive/web-sdks/assets/57426646/db657a27-b559-4039-a3e5-9e6bedfe1ba5">

