### PR TITLE
fix: dont send preview failed after join on disconnect

### DIFF
--- a/packages/hms-video-store/src/sdk/index.ts
+++ b/packages/hms-video-store/src/sdk/index.ts
@@ -429,16 +429,9 @@ export class HMSSdk implements HMSInterface {
         resolve();
       };
 
-      const errorHandler = (ex?: HMSException) => {
-        this.analyticsTimer.end(TimedEvent.PREVIEW);
-        ex && this.errorListener?.onError(ex);
-        this.sendPreviewAnalyticsEvent(ex);
-        this.sdkState.isPreviewInProgress = false;
-        reject(ex as HMSException);
-      };
-
       this.eventBus.policyChange.subscribeOnce(policyHandler);
-      this.eventBus.leave.subscribeOnce(errorHandler);
+      this.eventBus.leave.subscribeOnce(this.handlePreviewError);
+      this.eventBus.leave.subscribeOnce(ex => reject(ex as HMSException));
 
       this.transport
         .preview(
@@ -458,9 +451,19 @@ export class HMSSdk implements HMSInterface {
             });
           }
         })
-        .catch(errorHandler);
+        .catch(ex => {
+          this.handlePreviewError(ex);
+          reject(ex);
+        });
     });
   }
+
+  private handlePreviewError = (ex?: HMSException) => {
+    this.analyticsTimer.end(TimedEvent.PREVIEW);
+    ex && this.errorListener?.onError(ex);
+    this.sendPreviewAnalyticsEvent(ex);
+    this.sdkState.isPreviewInProgress = false;
+  };
 
   private async midCallPreview(asRole?: string, settings?: InitialSettings): Promise<void> {
     if (!this.localPeer || this.transportState !== TransportState.Joined) {
@@ -539,6 +542,8 @@ export class HMSSdk implements HMSInterface {
       throw ErrorFactory.GenericErrors.NotReady(HMSAction.JOIN, "Preview is in progress, can't join");
     }
 
+    // remove terminal error handling from preview(do not send preview.failed after join on disconnect)
+    this.eventBus.leave.unsubscribe(this.handlePreviewError);
     this.analyticsTimer.start(TimedEvent.JOIN);
     this.sdkState.isJoinInProgress = true;
 


### PR DESCRIPTION
Remove terminal error handling on preview after join 

### Details(context, link the issue, how was the bug fixed, what does the new feature do)

-
-

### Implementation note, gotchas, related work and Future TODOs (optional)
