### PR TITLE
fix: make hls player take more space when in fullscreen

### DIFF
--- a/examples/prebuilt-react-integration/src/App.jsx
+++ b/examples/prebuilt-react-integration/src/App.jsx
@@ -9,5 +9,16 @@ export default function App() {
     return <Diagnostics />;
   }
 
-  return <HMSPrebuilt roomCode={roomCode} />;
+  return (
+    <HMSPrebuilt
+      roomCode={roomCode}
+      options={{
+        endpoints: {
+          tokenByRoomCode: 'https://auth-nonprod.100ms.live/v2/token',
+          roomLayout: 'https://api-nonprod.100ms.live/v2/layouts/ui',
+          init: 'https://qa-in2-ipv6.100ms.live/init',
+        },
+      }}
+    />
+  );
 }

--- a/examples/prebuilt-react-integration/src/App.jsx
+++ b/examples/prebuilt-react-integration/src/App.jsx
@@ -9,16 +9,5 @@ export default function App() {
     return <Diagnostics />;
   }
 
-  return (
-    <HMSPrebuilt
-      roomCode={roomCode}
-      options={{
-        endpoints: {
-          tokenByRoomCode: 'https://auth-nonprod.100ms.live/v2/token',
-          roomLayout: 'https://api-nonprod.100ms.live/v2/layouts/ui',
-          init: 'https://qa-in2-ipv6.100ms.live/init',
-        },
-      }}
-    />
-  );
+  return <HMSPrebuilt roomCode={roomCode} />;
 }

--- a/packages/hls-player/src/controllers/HMSHLSPlayer.ts
+++ b/packages/hls-player/src/controllers/HMSHLSPlayer.ts
@@ -236,7 +236,7 @@ export class HMSHLSPlayer implements IHMSHLSPlayer, IHMSHLSPlayerEventEmitter {
     });
   };
   private volumeEventHandler = () => {
-    this._volume = this._videoEl.volume;
+    this._volume = this._videoEl.volume * 100;
   };
 
   private reConnectToStream = () => {

--- a/packages/hls-player/src/controllers/HMSHLSPlayer.ts
+++ b/packages/hls-player/src/controllers/HMSHLSPlayer.ts
@@ -236,7 +236,7 @@ export class HMSHLSPlayer implements IHMSHLSPlayer, IHMSHLSPlayerEventEmitter {
     });
   };
   private volumeEventHandler = () => {
-    this._volume = this._videoEl.volume * 100;
+    this._volume = Math.round(this._videoEl.volume * 100);
   };
 
   private reConnectToStream = () => {

--- a/packages/roomkit-react/src/Prebuilt/components/HMSVideo/HMSVideo.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/HMSVideo/HMSVideo.jsx
@@ -1,17 +1,26 @@
 import React, { forwardRef, useEffect, useState } from 'react';
 import { Flex } from '../../../Layout';
 
-export const HMSVideo = forwardRef(({ fullscreen, children, ...props }, videoRef) => {
+export const HMSVideo = forwardRef(({ children, ...props }, videoRef) => {
   const [width, setWidth] = useState('auto');
-  const updatingVideoWidth = () => {
-    if (videoRef.current.videoWidth > videoRef.current.videoHeight && width !== '100%') {
-      setWidth('100%');
-    }
-  };
+
   useEffect(() => {
-    videoRef.current?.addEventListener('loadedmetadata', updatingVideoWidth);
+    const updatingVideoWidth = () => {
+      const videoEl = videoRef.current;
+      if (!videoEl) {
+        return;
+      }
+      if (videoEl.videoWidth > videoEl.videoHeight && width !== '100%') {
+        setWidth('100%');
+      }
+    };
+    const videoEl = videoRef.current;
+    if (!videoEl) {
+      return;
+    }
+    videoEl.addEventListener('loadedmetadata', updatingVideoWidth);
     return () => {
-      videoRef.current?.removeEventListener('loadedmetadata', updatingVideoWidth);
+      videoEl.removeEventListener('loadedmetadata', updatingVideoWidth);
     };
   }, []);
   return (
@@ -24,7 +33,7 @@ export const HMSVideo = forwardRef(({ fullscreen, children, ...props }, videoRef
         transition: 'all 0.3s ease-in-out',
         '@md': {
           '& video': {
-            height: fullscreen ? '' : '$60 !important',
+            height: props.fullscreen ? '' : '$60 !important',
           },
         },
         '& video::cue': {

--- a/packages/roomkit-react/src/Prebuilt/components/HMSVideo/HMSVideo.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/HMSVideo/HMSVideo.jsx
@@ -33,7 +33,7 @@ export const HMSVideo = forwardRef(({ children, ...props }, videoRef) => {
         transition: 'all 0.3s ease-in-out',
         '@md': {
           '& video': {
-            height: props.fullscreen ? '' : '$60 !important',
+            height: props.isFullScreen ? '' : '$60 !important',
           },
         },
         '& video::cue': {

--- a/packages/roomkit-react/src/Prebuilt/components/HMSVideo/HMSVideo.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/HMSVideo/HMSVideo.jsx
@@ -1,11 +1,8 @@
 import React, { forwardRef, useEffect, useState } from 'react';
-import { useMedia } from 'react-use';
 import { Flex } from '../../../Layout';
-import { config } from '../../../Theme';
 
 export const HMSVideo = forwardRef(({ children, ...props }, videoRef) => {
   const [width, setWidth] = useState('auto');
-  const isMobile = useMedia(config.media.md);
   const updatingVideoWidth = () => {
     if (videoRef.current.videoWidth > videoRef.current.videoHeight && width !== '100%') {
       setWidth('100%');
@@ -57,7 +54,7 @@ export const HMSVideo = forwardRef(({ children, ...props }, videoRef) => {
           margin: '0 auto',
           objectFit: 'contain',
           width: width,
-          height: isMobile && width === 'auto' ? '' : 'inherit !important',
+          height: '100%',
           maxWidth: '100%',
         }}
         ref={videoRef}

--- a/packages/roomkit-react/src/Prebuilt/components/HMSVideo/HMSVideo.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/HMSVideo/HMSVideo.jsx
@@ -9,9 +9,9 @@ export const HMSVideo = forwardRef(({ fullscreen, children, ...props }, videoRef
     }
   };
   useEffect(() => {
-    videoRef.current.addEventListener('loadedmetadata', updatingVideoWidth);
+    videoRef.current?.addEventListener('loadedmetadata', updatingVideoWidth);
     return () => {
-      videoRef.current.removeEventListener('loadedmetadata', updatingVideoWidth);
+      videoRef.current?.removeEventListener('loadedmetadata', updatingVideoWidth);
     };
   }, []);
   return (

--- a/packages/roomkit-react/src/Prebuilt/components/HMSVideo/HMSVideo.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/HMSVideo/HMSVideo.jsx
@@ -1,7 +1,19 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
 import { Flex } from '../../../Layout';
 
 export const HMSVideo = forwardRef(({ children, ...props }, videoRef) => {
+  const [width, setWidth] = useState('auto');
+  const updatingVideoWidth = () => {
+    if (videoRef.current.videoWidth > videoRef.current.videoHeight && width !== '100%') {
+      setWidth('100%');
+    }
+  };
+  useEffect(() => {
+    videoRef.current.addEventListener('loadedmetadata', updatingVideoWidth);
+    return () => {
+      videoRef.current.removeEventListener('loadedmetadata', updatingVideoWidth);
+    };
+  }, []);
   return (
     <Flex
       data-testid="hms-video"
@@ -41,8 +53,8 @@ export const HMSVideo = forwardRef(({ children, ...props }, videoRef) => {
         style={{
           margin: '0 auto',
           objectFit: 'contain',
-          width: 'auto',
-          height: '100%',
+          width: width,
+          height: 'inherit !important',
           maxWidth: '100%',
         }}
         ref={videoRef}

--- a/packages/roomkit-react/src/Prebuilt/components/HMSVideo/HMSVideo.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/HMSVideo/HMSVideo.jsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, useEffect, useState } from 'react';
 import { Flex } from '../../../Layout';
 
-export const HMSVideo = forwardRef(({ children, ...props }, videoRef) => {
+export const HMSVideo = forwardRef(({ fullscreen, children, ...props }, videoRef) => {
   const [width, setWidth] = useState('auto');
   const updatingVideoWidth = () => {
     if (videoRef.current.videoWidth > videoRef.current.videoHeight && width !== '100%') {
@@ -23,9 +23,8 @@ export const HMSVideo = forwardRef(({ children, ...props }, videoRef) => {
         justifyContent: 'center',
         transition: 'all 0.3s ease-in-out',
         '@md': {
-          height: 'auto',
           '& video': {
-            height: '$60 !important',
+            height: fullscreen ? '' : '$60 !important',
           },
         },
         '& video::cue': {

--- a/packages/roomkit-react/src/Prebuilt/components/HMSVideo/HMSVideo.jsx
+++ b/packages/roomkit-react/src/Prebuilt/components/HMSVideo/HMSVideo.jsx
@@ -1,8 +1,11 @@
 import React, { forwardRef, useEffect, useState } from 'react';
+import { useMedia } from 'react-use';
 import { Flex } from '../../../Layout';
+import { config } from '../../../Theme';
 
 export const HMSVideo = forwardRef(({ children, ...props }, videoRef) => {
   const [width, setWidth] = useState('auto');
+  const isMobile = useMedia(config.media.md);
   const updatingVideoWidth = () => {
     if (videoRef.current.videoWidth > videoRef.current.videoHeight && width !== '100%') {
       setWidth('100%');
@@ -54,7 +57,7 @@ export const HMSVideo = forwardRef(({ children, ...props }, videoRef) => {
           margin: '0 auto',
           objectFit: 'contain',
           width: width,
-          height: 'inherit !important',
+          height: isMobile && width === 'auto' ? '' : 'inherit !important',
           maxWidth: '100%',
         }}
         ref={videoRef}

--- a/packages/roomkit-react/src/Prebuilt/layouts/HLSView.jsx
+++ b/packages/roomkit-react/src/Prebuilt/layouts/HLSView.jsx
@@ -536,7 +536,7 @@ const HLSView = () => {
             onMouseMove={onHoverHandler}
             onMouseLeave={onHoverHandler}
             onClick={onClickHandler}
-            fullscreen={isFullScreen}
+            isFullScreen={isFullScreen}
             onDoubleClick={e => {
               onDoubleClickHandler(e);
             }}

--- a/packages/roomkit-react/src/Prebuilt/layouts/HLSView.jsx
+++ b/packages/roomkit-react/src/Prebuilt/layouts/HLSView.jsx
@@ -536,6 +536,7 @@ const HLSView = () => {
             onMouseMove={onHoverHandler}
             onMouseLeave={onHoverHandler}
             onClick={onClickHandler}
+            fullscreen={isFullScreen}
             onDoubleClick={e => {
               onDoubleClickHandler(e);
             }}

--- a/packages/roomkit-react/src/Prebuilt/layouts/HLSView.jsx
+++ b/packages/roomkit-react/src/Prebuilt/layouts/HLSView.jsx
@@ -728,6 +728,7 @@ const HLSView = () => {
                           selection={currentSelectedQuality}
                           onQualityChange={handleQuality}
                           isAuto={isUserSelectedAuto}
+                          containerRef={hlsViewRef.current}
                         />
                       ) : null}
                       {isFullScreenSupported ? (

--- a/packages/roomkit-react/src/Prebuilt/layouts/HLSView.jsx
+++ b/packages/roomkit-react/src/Prebuilt/layouts/HLSView.jsx
@@ -485,11 +485,6 @@ const HLSView = () => {
       css={{
         flex: isLandscape ? '2 1 0' : '1 1 0',
         transition: 'all 0.3s ease-in-out',
-        '&:fullscreen': {
-          '& video': {
-            height: 'unset !important',
-          },
-        },
       }}
     >
       {hlsViewRef.current && (isMobile || isLandscape) && (


### PR DESCRIPTION
Issues:
- [x] Video quality popup not working in fullscreen mode.
- [x] Volume slider is taking value in decimal
- [x] Managing the width and height of a video based on its aspect ratio.