### PR TITLE
ci: added github actions workflow to mark stale PRs & issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: Close stale issues and PRs
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: "This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days."
+          stale-pr-message: "This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days."
+          close-issue-message: "This issue was closed because it has been stalled for 5 days with no activity."
+          close-pr-message: "This PR was closed because it has been stalled for 10 days with no activity."
+          days-before-issue-stale: 30
+          days-before-pr-stale: 45
+          days-before-issue-close: 5
+          days-before-pr-close: 10


### PR DESCRIPTION
### Details(context, link the issue, how was the bug fixed, what does the new feature do)

- Once a PR or Issue is older than 30 days, GitHub Actions will mark it as Stale for 10 days & then close it.
- Attached is a sample screenshot of the bot comment

<img width="919" alt="Screenshot 2024-09-21 at 1 45 00 PM" src="https://github.com/user-attachments/assets/35b00d74-5556-4be9-9d32-69349c2f98b5">
