### PR TITLE
fix: make interruption reason generic 

### DIFF
--- a/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
@@ -522,11 +522,12 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
   }
 
   private handleTrackMute = () => {
-    HMSLogger.d(this.TAG, 'muted natively');
+    HMSLogger.d(this.TAG, 'muted natively', document.visibilityState);
+    const reason = 'visibility-change';
     this.eventBus.analytics.publish(
       this.sendInterruptionEvent({
         started: true,
-        reason: 'incoming-call',
+        reason: reason,
       }),
     );
     this.eventBus.localVideoEnabled.publish({ enabled: false, track: this });
@@ -534,11 +535,12 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
 
   /** @internal */
   handleTrackUnmute = () => {
-    HMSLogger.d(this.TAG, 'unmuted natively');
+    HMSLogger.d(this.TAG, 'unmuted natively', document.visibilityState);
+    const reason = 'visibility-change';
     this.eventBus.analytics.publish(
       this.sendInterruptionEvent({
         started: false,
-        reason: 'incoming-call',
+        reason: reason,
       }),
     );
     super.handleTrackUnmute();

--- a/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
@@ -523,7 +523,7 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
 
   private handleTrackMute = () => {
     HMSLogger.d(this.TAG, 'muted natively', document.visibilityState);
-    const reason = 'visibility-change';
+    const reason = document.visibilityState === 'hidden' ? 'visibility-change' : 'incoming-call';
     this.eventBus.analytics.publish(
       this.sendInterruptionEvent({
         started: true,
@@ -536,7 +536,7 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
   /** @internal */
   handleTrackUnmute = () => {
     HMSLogger.d(this.TAG, 'unmuted natively', document.visibilityState);
-    const reason = 'visibility-change';
+    const reason = document.visibilityState === 'hidden' ? 'visibility-change' : 'incoming-call';
     this.eventBus.analytics.publish(
       this.sendInterruptionEvent({
         started: false,


### PR DESCRIPTION
### Details(context, link the issue, how was the bug fixed, what does the new feature do)

- Made native video track mute status change reason generic instead of always incoming-call
