### PR TITLE
fix: add an event when tracks are published with no data

### DIFF
--- a/packages/hms-video-store/src/error/ErrorCodes.ts
+++ b/packages/hms-video-store/src/error/ErrorCodes.ts
@@ -76,6 +76,9 @@ export const ErrorCodes = {
 
     // Selected device not detected on change
     SELECTED_DEVICE_MISSING: 3014,
+
+    // Track is publishing with no data, can happen when a whatsapp call is ongoing before 100ms call in mweb
+    NO_DATA: 3015,
   },
 
   WebrtcErrors: {

--- a/packages/hms-video-store/src/error/ErrorFactory.ts
+++ b/packages/hms-video-store/src/error/ErrorFactory.ts
@@ -255,7 +255,7 @@ export const ErrorFactory = {
     NoDataInTrack(description: string) {
       return new HMSException(
         ErrorCodes.TracksErrors.NO_DATA,
-        'Track is not publishing any data',
+        'Track does not have any data',
         HMSAction.TRACK,
         description,
         'This could possibily due to another application taking priority over the access to camera or microphone or due to an incoming call',

--- a/packages/hms-video-store/src/error/ErrorFactory.ts
+++ b/packages/hms-video-store/src/error/ErrorFactory.ts
@@ -251,6 +251,16 @@ export const ErrorFactory = {
         false,
       );
     },
+
+    NoDataInTrack(description: string) {
+      return new HMSException(
+        ErrorCodes.TracksErrors.NO_DATA,
+        'Track is not publishing any data',
+        HMSAction.TRACK,
+        description,
+        description,
+      );
+    },
   },
 
   WebrtcErrors: {

--- a/packages/hms-video-store/src/error/ErrorFactory.ts
+++ b/packages/hms-video-store/src/error/ErrorFactory.ts
@@ -258,7 +258,7 @@ export const ErrorFactory = {
         'Track is not publishing any data',
         HMSAction.TRACK,
         description,
-        description,
+        'This could possibily due to another application taking priority over the access to camera or microphone or due to an incoming call',
       );
     },
   },

--- a/packages/hms-video-store/src/interfaces/config.ts
+++ b/packages/hms-video-store/src/interfaces/config.ts
@@ -43,10 +43,6 @@ export interface HMSConfig {
   autoVideoSubscribe?: boolean;
   initEndpoint?: string;
   /**
-   * Request Camera/Mic permissions irrespective of role to avoid delay in getting device list
-   */
-  alwaysRequestPermissions?: boolean;
-  /**
    * Enable to get a network quality score while in preview. The score ranges from -1 to 5.
    * -1 when we are not able to connect to 100ms servers within an expected time limit
    * 0 when there is a timeout/failure when measuring the quality

--- a/packages/hms-video-store/src/media/tracks/HMSLocalAudioTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalAudioTrack.ts
@@ -8,6 +8,7 @@ import { HMSAudioTrackSettings as IHMSAudioTrackSettings } from '../../interface
 import { HMSAudioPlugin, HMSPluginSupportResult } from '../../plugins';
 import { HMSAudioPluginsManager } from '../../plugins/audio';
 import Room from '../../sdk/models/HMSRoom';
+import { stringifyMediaStreamTrack } from '../../utils/json';
 import HMSLogger from '../../utils/logger';
 import { getAudioTrack, isEmptyTrack } from '../../utils/track';
 import { TrackAudioLevelMonitor } from '../../utils/track-audio-level-monitor';
@@ -114,6 +115,7 @@ export class HMSLocalAudioTrack extends HMSAudioTrack {
         }),
       );
     } else {
+      alert('replacing audio track');
       HMSLogger.d(this.TAG, 'On visibile replacing track as it is not publishing');
       await this.replaceTrackWith(this.settings);
       this.eventBus.analytics.publish(
@@ -155,6 +157,7 @@ export class HMSLocalAudioTrack extends HMSAudioTrack {
       this.tracksCreated.add(newTrack);
       HMSLogger.d(this.TAG, 'replaceTrack, Previous track stopped', prevTrack, 'newTrack', newTrack);
       await this.updateTrack(newTrack);
+      alert(stringifyMediaStreamTrack(newTrack));
     } catch (e) {
       // Generate a new track from previous settings so there will be audio because previous track is stopped
       const newTrack = await getAudioTrack(this.settings);

--- a/packages/hms-video-store/src/media/tracks/HMSLocalAudioTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalAudioTrack.ts
@@ -65,6 +65,7 @@ export class HMSLocalAudioTrack extends HMSAudioTrack {
     }
     this.pluginsManager = new HMSAudioPluginsManager(this, eventBus, room);
     this.setFirstTrackId(track.id);
+    this.eventBus.localVideoUnmutedNatively.subscribe(this.handleVisibilityChange);
     if (source === 'regular') {
       document.addEventListener('visibilitychange', this.handleVisibilityChange);
     }
@@ -98,10 +99,6 @@ export class HMSLocalAudioTrack extends HMSAudioTrack {
   resetManuallySelectedDeviceId() {
     this.manuallySelectedDeviceId = undefined;
   }
-
-  private isTrackNotPublishing = () => {
-    return this.nativeTrack.readyState === 'ended' || this.nativeTrack.muted;
-  };
 
   private handleVisibilityChange = async () => {
     // track state is fine do nothing
@@ -185,7 +182,7 @@ export class HMSLocalAudioTrack extends HMSAudioTrack {
     }
 
     // Replace silent empty track or muted track(happens when microphone is disabled from address bar in iOS) with an actual audio track, if enabled.
-    if (value && (isEmptyTrack(this.nativeTrack) || this.nativeTrack.muted)) {
+    if (value && (isEmptyTrack(this.nativeTrack) || this.isTrackNotPublishing())) {
       await this.replaceTrackWith(this.settings);
     }
     await super.setEnabled(value);

--- a/packages/hms-video-store/src/media/tracks/HMSLocalAudioTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalAudioTrack.ts
@@ -315,10 +315,11 @@ export class HMSLocalAudioTrack extends HMSAudioTrack {
 
   private handleTrackMute = () => {
     HMSLogger.d(this.TAG, 'muted natively');
+    const reason = document.visibilityState === 'hidden' ? 'visibility-change' : 'incoming-call';
     this.eventBus.analytics.publish(
       this.sendInterruptionEvent({
         started: true,
-        reason: 'incoming-call',
+        reason,
       }),
     );
   };
@@ -326,10 +327,11 @@ export class HMSLocalAudioTrack extends HMSAudioTrack {
   /** @internal */
   handleTrackUnmute = () => {
     HMSLogger.d(this.TAG, 'unmuted natively');
+    const reason = document.visibilityState === 'hidden' ? 'visibility-change' : 'incoming-call';
     this.eventBus.analytics.publish(
       this.sendInterruptionEvent({
         started: false,
-        reason: 'incoming-call',
+        reason,
       }),
     );
     this.setEnabled(this.enabled);

--- a/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
@@ -134,10 +134,7 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
   // eslint-disable-next-line complexity
   async setEnabled(value: boolean): Promise<void> {
     if (value === this.enabled) {
-      if (value && !this.isTrackNotPublishing()) {
-        HMSLogger.d(this.TAG, 'track is in valid state and enable state is same');
-        return;
-      }
+      return;
     }
     if (this.source === 'regular') {
       let track: MediaStreamTrack;

--- a/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
@@ -131,9 +131,13 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
    * use this function to set the enabled state of a track. If true the track will be unmuted and muted otherwise.
    * @param value
    */
+  // eslint-disable-next-line complexity
   async setEnabled(value: boolean): Promise<void> {
     if (value === this.enabled) {
-      return;
+      if (value && !this.isTrackNotPublishing()) {
+        HMSLogger.d(this.TAG, 'track is in valid state and enable state is same');
+        return;
+      }
     }
     if (this.source === 'regular') {
       let track: MediaStreamTrack;
@@ -544,6 +548,7 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
     super.handleTrackUnmute();
     this.eventBus.localVideoEnabled.publish({ enabled: this.enabled, track: this });
     this.eventBus.localVideoUnmutedNatively.publish();
+    this.setEnabled(this.enabled);
   };
 
   /**

--- a/packages/hms-video-store/src/media/tracks/HMSTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSTrack.ts
@@ -85,6 +85,11 @@ export abstract class HMSTrack {
   protected setFirstTrackId(trackId: string) {
     this.firstTrackId = trackId;
   }
+
+  isTrackNotPublishing = () => {
+    return this.nativeTrack.readyState === 'ended' || this.nativeTrack.muted;
+  };
+
   /**
    * @internal
    * It will send event to analytics when interruption start/stop

--- a/packages/hms-video-store/src/media/tracks/HMSVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSVideoTrack.ts
@@ -93,8 +93,8 @@ export class HMSVideoTrack extends HMSTrack {
 
   private reTriggerPlay = ({ videoElement }: { videoElement: HTMLVideoElement }) => {
     setTimeout(() => {
-      videoElement.play().catch(() => {
-        HMSLogger.w('[HMSVideoTrack]', 'failed to play');
+      videoElement.play().catch((e: Error) => {
+        HMSLogger.w('[HMSVideoTrack]', 'failed to play', e.message);
       });
     }, 0);
   };

--- a/packages/hms-video-store/src/sdk/LocalTrackManager.test.ts
+++ b/packages/hms-video-store/src/sdk/LocalTrackManager.test.ts
@@ -109,6 +109,7 @@ const mockMediaStream = {
       kind: 'video',
       getSettings: jest.fn(() => ({ deviceId: 'video-device-id' })),
       addEventListener: jest.fn(() => {}),
+      removeEventListener: jest.fn(() => {}),
     },
   ]),
   getAudioTracks: jest.fn(() => [
@@ -117,6 +118,7 @@ const mockMediaStream = {
       kind: 'audio',
       getSettings: jest.fn(() => ({ deviceId: 'audio-device-id' })),
       addEventListener: jest.fn(() => {}),
+      removeEventListener: jest.fn(() => {}),
     },
   ]),
   addTrack: jest.fn(() => {}),
@@ -206,7 +208,13 @@ const mockAudioContext = {
     return {
       stream: {
         getAudioTracks: jest.fn(() => [
-          { id: 'audio-id', kind: 'audio', getSettings: jest.fn(() => ({ deviceId: 'audio-mock-device-id' })) },
+          {
+            id: 'audio-id',
+            kind: 'audio',
+            getSettings: jest.fn(() => ({ deviceId: 'audio-mock-device-id' })),
+            addEventListener: jest.fn(() => {}),
+            removeEventListener: jest.fn(() => {}),
+          },
         ]),
       },
     };
@@ -426,6 +434,7 @@ describe('LocalTrackManager', () => {
           kind: 'video',
           getSettings: () => ({ deviceId: 'video-device-id', groupId: 'video-group-id' }),
           addEventListener: jest.fn(() => {}),
+          removeEventListener: jest.fn(() => {}),
         } as unknown as MediaStreamTrack,
         HMSPeerType.REGULAR,
         testEventBus,
@@ -459,6 +468,7 @@ describe('LocalTrackManager', () => {
           kind: 'video',
           getSettings: () => ({ deviceId: 'video-device-id', groupId: 'video-group-id' }),
           addEventListener: jest.fn(() => {}),
+          removeEventListener: jest.fn(() => {}),
         } as unknown as MediaStreamTrack,
         HMSPeerType.REGULAR,
         testEventBus,

--- a/packages/hms-video-store/src/sdk/index.ts
+++ b/packages/hms-video-store/src/sdk/index.ts
@@ -1326,14 +1326,16 @@ export class HMSSdk implements HMSInterface {
     for (const track of tracks) {
       await this.transport.publish([track]);
       if (track.isTrackNotPublishing()) {
+        const error = ErrorFactory.TracksErrors.NoDataInTrack(
+          `${track.type} track has no data. muted: ${track.nativeTrack.muted}, readyState: ${track.nativeTrack.readyState}`,
+        );
         this.sendAnalyticsEvent(
           AnalyticsEventFactory.publish({
             devices: this.deviceManager.getDevices(),
-            error: ErrorFactory.TracksErrors.NoDataInTrack(
-              `${track.type} track has no data. muted: ${track.nativeTrack.muted}, readyState: ${track.nativeTrack.readyState}`,
-            ),
+            error: error,
           }),
         );
+        this.listener?.onError(error);
       }
       this.setLocalPeerTrack(track);
       this.listener?.onTrackUpdate(HMSTrackUpdate.TRACK_ADDED, track, this.localPeer!);

--- a/packages/hms-video-store/src/sdk/index.ts
+++ b/packages/hms-video-store/src/sdk/index.ts
@@ -1567,10 +1567,12 @@ export class HMSSdk implements HMSInterface {
   private sendAudioPresenceFailed = () => {
     const error = ErrorFactory.TracksErrors.NoAudioDetected(HMSAction.PREVIEW);
     HMSLogger.w(this.TAG, 'Audio Presence Failure', this.transportState, error);
-    this.sendAnalyticsEvent(
-      AnalyticsEventFactory.audioDetectionFail(error, this.deviceManager.getCurrentSelection().audioInput),
-    );
-    this.listener?.onError(error);
+    // this.sendAnalyticsEvent(
+    //   AnalyticsEventFactory.audioDetectionFail(error, this.deviceManager.getCurrentSelection().audioInput),
+    // );
+    if (this.isDiagnostics) {
+      this.listener?.onError(error);
+    }
   };
 
   private sendJoinAnalyticsEvent = (is_preview_called = false, error?: HMSException) => {

--- a/packages/hms-video-store/src/sdk/index.ts
+++ b/packages/hms-video-store/src/sdk/index.ts
@@ -457,7 +457,6 @@ export class HMSSdk implements HMSInterface {
           this.localPeer.asRole = newRole || this.localPeer.role;
         }
         const tracks = await this.localTrackManager.getTracksToPublish(config.settings);
-        alert(JSON.stringify(tracks.join('\n')));
         tracks.forEach(track => this.setLocalPeerTrack(track));
         this.localPeer?.audioTrack && this.initPreviewTrackAudioLevelMonitor();
         await this.initDeviceManagers();

--- a/packages/hms-video-store/src/sdk/index.ts
+++ b/packages/hms-video-store/src/sdk/index.ts
@@ -457,6 +457,7 @@ export class HMSSdk implements HMSInterface {
           this.localPeer.asRole = newRole || this.localPeer.role;
         }
         const tracks = await this.localTrackManager.getTracksToPublish(config.settings);
+        alert(JSON.stringify(tracks.join('\n')));
         tracks.forEach(track => this.setLocalPeerTrack(track));
         this.localPeer?.audioTrack && this.initPreviewTrackAudioLevelMonitor();
         await this.initDeviceManagers();

--- a/packages/hms-video-store/src/sdk/index.ts
+++ b/packages/hms-video-store/src/sdk/index.ts
@@ -435,13 +435,6 @@ export class HMSSdk implements HMSInterface {
     this.analyticsTimer.start(TimedEvent.PREVIEW);
     this.setUpPreview(config, listener);
 
-    // Request permissions and populate devices before waiting for policy
-    if (config.alwaysRequestPermissions) {
-      this.localTrackManager.requestPermissions().then(async () => {
-        await this.initDeviceManagers();
-      });
-    }
-
     let initSuccessful = false;
     let networkTestFinished = false;
     const timerId = setTimeout(() => {

--- a/packages/hms-video-store/src/utils/track-audio-level-monitor.ts
+++ b/packages/hms-video-store/src/utils/track-audio-level-monitor.ts
@@ -133,7 +133,7 @@ export class TrackAudioLevelMonitor {
     return percent;
   }
 
-  private isSilentThisInstant() {
+  isSilentThisInstant() {
     if (!this.analyserNode || !this.dataArray) {
       HMSLogger.d(this.TAG, 'AudioContext not initialized');
       return;


### PR DESCRIPTION
### Details(context, link the issue, how was the bug fixed, what does the new feature do)

- Handle possible scenarios where this can be recovered
- Happens when whatsapp call is already happening and 100ms link is joined on iOS mweb.

### Implementation note, gotchas, related work and Future TODOs (optional)
