### PR TITLE
fix: animate resize to prevent flickers

### DIFF
--- a/packages/roomkit-react/package.json
+++ b/packages/roomkit-react/package.json
@@ -102,6 +102,7 @@
     "@stitches/react": "^1.2.8",
     "emoji-mart": "^5.2.2",
     "eventemitter2": "^6.4.9",
+    "framer-motion":"^11.11.0",
     "lodash.merge": "^4.6.2",
     "qrcode.react": "^3.1.0",
     "react-dom": "^18.2.0",

--- a/packages/roomkit-react/src/Prebuilt/components/VideoLayouts/Grid.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/VideoLayouts/Grid.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { AnimatePresence } from 'framer-motion';
 import { TrackWithPeerAndDimensions } from '@100mslive/react-sdk';
 import { Box } from '../../../Layout';
 // @ts-ignore: No implicit Any
@@ -9,35 +10,37 @@ export const Grid = React.forwardRef<HTMLDivElement, { tiles: TrackWithPeerAndDi
   ({ tiles, edgeToEdge }, ref) => {
     const videoTileProps = useVideoTileContext();
     return (
-      <Box
-        ref={ref}
-        css={{
-          flex: '1 1 0',
-          gap: '$4',
-          display: 'flex',
-          placeContent: 'center',
-          alignItems: 'center',
-          justifyContent: 'center',
-          flexFlow: 'row wrap',
-          minHeight: 0,
-          '@md': { gap: edgeToEdge ? 0 : '$4' },
-        }}
-      >
-        {tiles?.map(tile => {
-          return (
-            <VideoTile
-              key={tile.track?.id || tile.peer?.id}
-              width={tile.width}
-              height={tile.height}
-              peerId={tile.peer?.id}
-              trackId={tile.track?.id}
-              rootCSS={{ padding: 0 }}
-              objectFit="contain"
-              {...videoTileProps}
-            />
-          );
-        })}
-      </Box>
+      <AnimatePresence>
+        <Box
+          ref={ref}
+          css={{
+            flex: '1 1 0',
+            gap: '$4',
+            display: 'flex',
+            placeContent: 'center',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexFlow: 'row wrap',
+            minHeight: 0,
+            '@md': { gap: edgeToEdge ? 0 : '$4' },
+          }}
+        >
+          {tiles?.map(tile => {
+            return (
+              <VideoTile
+                key={tile.track?.id || tile.peer?.id}
+                width={tile.width}
+                height={tile.height}
+                peerId={tile.peer?.id}
+                trackId={tile.track?.id}
+                rootCSS={{ padding: 0 }}
+                objectFit="contain"
+                {...videoTileProps}
+              />
+            );
+          })}
+        </Box>
+      </AnimatePresence>
     );
   },
 );

--- a/packages/roomkit-react/src/VideoTile/StyledVideoTile.tsx
+++ b/packages/roomkit-react/src/VideoTile/StyledVideoTile.tsx
@@ -15,7 +15,7 @@ MotionRoot.defaultProps = {
     stiffness: 300,
     damping: 30,
     mass: 1,
-    duration: 0.3,
+    duration: 0.15,
   },
 };
 

--- a/packages/roomkit-react/src/VideoTile/StyledVideoTile.tsx
+++ b/packages/roomkit-react/src/VideoTile/StyledVideoTile.tsx
@@ -10,11 +10,13 @@ export const Root = styled('div', {
 const MotionRoot = motion(Root);
 MotionRoot.defaultProps = {
   layout: true,
-  initial: { opacity: 0, scale: 0.8 },
-  animate: { opacity: 1, scale: 1 },
-  exit: { opacity: 0, scale: 0.8 },
-  transition: { duration: 0.3 },
-  style: { originX: 0, originY: 0 },
+  transition: {
+    type: 'spring',
+    stiffness: 300,
+    damping: 30,
+    mass: 1,
+    duration: 0.3,
+  },
 };
 
 const Container = styled('div', {

--- a/packages/roomkit-react/src/VideoTile/StyledVideoTile.tsx
+++ b/packages/roomkit-react/src/VideoTile/StyledVideoTile.tsx
@@ -1,14 +1,14 @@
+import { motion } from 'framer-motion';
 import { Box } from '../Layout';
 import { styled } from '../Theme';
 import { flexCenter } from '../utils';
 
 export const Root = styled('div', {
   padding: '0.75rem',
-  // show videotile context menu on hover
-  // [`&:hover .tile-menu`]: {
-  //   display: 'inline-block',
-  // },
 });
+
+const MotionRoot = motion(Root);
+MotionRoot.defaultProps = { layout: true };
 
 const Container = styled('div', {
   width: '100%',
@@ -128,7 +128,7 @@ const AvatarContainer = styled(Box, {
 });
 
 interface VideoTileType {
-  Root: typeof Root;
+  Root: typeof MotionRoot;
   Container: typeof Container;
   Overlay: typeof Overlay;
   Info: typeof Info;
@@ -139,7 +139,7 @@ interface VideoTileType {
 }
 
 export const StyledVideoTile: VideoTileType = {
-  Root,
+  Root: MotionRoot,
   Container,
   Overlay,
   Info,

--- a/packages/roomkit-react/src/VideoTile/StyledVideoTile.tsx
+++ b/packages/roomkit-react/src/VideoTile/StyledVideoTile.tsx
@@ -8,7 +8,14 @@ export const Root = styled('div', {
 });
 
 const MotionRoot = motion(Root);
-MotionRoot.defaultProps = { layout: true };
+MotionRoot.defaultProps = {
+  layout: true,
+  initial: { opacity: 0, scale: 0.8 },
+  animate: { opacity: 1, scale: 1 },
+  exit: { opacity: 0, scale: 0.8 },
+  transition: { duration: 0.3 },
+  style: { originX: 0, originY: 0 },
+};
 
 const Container = styled('div', {
   width: '100%',

--- a/yarn.lock
+++ b/yarn.lock
@@ -10433,6 +10433,13 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+framer-motion@^11.11.0:
+  version "11.11.9"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-11.11.9.tgz#a60ddf5abbd924812df923068628537a5c6ad8b9"
+  integrity sha512-XpdZseuCrZehdHGuW22zZt3SF5g6AHJHJi7JwQIigOznW4Jg1n0oGPMJQheMaKLC+0rp5gxUKMRYI6ytd3q4RQ==
+  dependencies:
+    tslib "^2.4.0"
+
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"


### PR DESCRIPTION
### Steps to repro:

- Open chat/participant list when multiple tiles are present
- The issue is more noticeable when downsizing the screen

### Bundle size increase:

Prod gzip:
<br />
![image](https://github.com/user-attachments/assets/9231e4d4-7d18-4ce6-8982-592ee6abfe58)
<br />
Deployment gzip:
<br />
![image](https://github.com/user-attachments/assets/0a836446-895a-4116-af07-34255685aa13)

 