### PR TITLE
Fix: aspect ratio ignored due to type

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
@@ -203,8 +203,6 @@ export const PreviewTile = ({ name, error }: { name: string; error?: boolean }) 
     [calculatedWidth, calculatedHeight],
   );
 
-  console.log({ aspectRatio });
-
   return (
     <StyledVideoTile.Container
       ref={ref}

--- a/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
@@ -61,7 +61,7 @@ const useLocalTileAspectRatio = () => {
   } else {
     aspectRatio = isMobile ? 9 / 16 : 16 / 9;
   }
-  return aspectRatio;
+  return aspectRatio.toString();
 };
 
 const PreviewJoin = ({
@@ -113,6 +113,7 @@ const PreviewJoin = ({
   const { elements = {} } = useRoomLayoutPreviewScreen();
   const { preview_header: previewHeader = {}, virtual_background } = elements || {};
   const aspectRatio = useLocalTileAspectRatio();
+
   useEffect(() => {
     if (authToken) {
       if (skipPreview) {
@@ -201,6 +202,8 @@ export const PreviewTile = ({ name, error }: { name: string; error?: boolean }) 
     () => calculateAvatarAndAttribBoxSize(calculatedWidth, calculatedHeight),
     [calculatedWidth, calculatedHeight],
   );
+
+  console.log({ aspectRatio });
 
   return (
     <StyledVideoTile.Container

--- a/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
@@ -159,7 +159,7 @@ const PreviewJoin = ({
           </Flex>
         </Flex>
         {toggleVideo ? <PreviewTile name={name} error={previewError} /> : null}
-        <Box css={{ w: '100%', maxWidth: `${Math.max(aspectRatio, 1) * 340}px` }}>
+        <Box css={{ w: '100%', maxWidth: `${Math.max(parseFloat(aspectRatio), 1) * 340}px` }}>
           <PreviewControls hideSettings={!toggleVideo && !toggleAudio} vbEnabled={!!virtual_background} />
           <PreviewForm
             name={name}


### PR DESCRIPTION
Following the stitches upgrade, aspect ratio cannot be passed as a number