### PR TITLE
fix: make device label change a warning instead of error

### DIFF
--- a/packages/hms-video-store/src/utils/media.ts
+++ b/packages/hms-video-store/src/utils/media.ts
@@ -73,7 +73,7 @@ export enum HMSAudioDeviceCategory {
 
 export const getAudioDeviceCategory = (deviceLabel?: string) => {
   if (!deviceLabel) {
-    HMSLogger.e('[DeviceManager]:', 'No device label provided');
+    HMSLogger.w('[DeviceManager]:', 'No device label provided');
     return HMSAudioDeviceCategory.SPEAKERPHONE;
   }
   const label = deviceLabel.toLowerCase();


### PR DESCRIPTION
### Details(context, link the issue, how was the bug fixed, what does the new feature do)

- Made device label change a warning instead of error
