### PR TITLE
fix: adjust tile dimension calculation to handle 480p recording

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/hooks/useTileLayout.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/hooks/useTileLayout.tsx
@@ -115,10 +115,10 @@ export const useTileLayout = ({
             }
           }
         }
-        // Beam layout breaks at 480p resolution without this adjustment
+        // Beam layout breaks at 480p resolution because the gap of $4 between tiles is not accounted for
         for (let i = 0; i < row.length; i++) {
-          row[i].width = tileWidth - 5;
-          row[i].height = tileHeight - 5;
+          row[i].width = tileWidth - 8 / maxCols;
+          row[i].height = tileHeight - 8 / maxRows;
         }
       }
     }

--- a/packages/roomkit-react/src/Prebuilt/components/hooks/useTileLayout.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/hooks/useTileLayout.tsx
@@ -118,8 +118,8 @@ export const useTileLayout = ({
         // Beam layout breaks at 480p resolution because the gap of $4 between tiles is not accounted for
         // There could be more such cases, this is a generic fix
         for (let i = 0; i < row.length; i++) {
-          row[i].width = tileWidth - (8 / maxCols) * (maxCols - 1);
-          row[i].height = tileHeight - (8 / maxRows) * (maxRows - 1);
+          row[i].width = tileWidth - (gap / maxCols) * (maxCols - 1);
+          row[i].height = tileHeight - (gap / maxRows) * (maxRows - 1);
         }
       }
     }

--- a/packages/roomkit-react/src/Prebuilt/components/hooks/useTileLayout.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/hooks/useTileLayout.tsx
@@ -77,7 +77,7 @@ export const useTileLayout = ({
         return rowElements;
       });
 
-      const gap = edgeToEdge && isMobile ? 0 : 8; // gap between flex items
+      const gap = edgeToEdge ? 0 : 8; // gap between flex items
       const maxHeight = height - (maxRows - 1) * gap;
       const maxRowHeight = maxHeight / matrix.length;
       const aspectRatios =

--- a/packages/roomkit-react/src/Prebuilt/components/hooks/useTileLayout.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/hooks/useTileLayout.tsx
@@ -116,6 +116,7 @@ export const useTileLayout = ({
           }
         }
         // Beam layout breaks at 480p resolution because the gap of $4 between tiles is not accounted for
+        // There could be more such cases, this is a generic fix
         for (let i = 0; i < row.length; i++) {
           row[i].width = tileWidth - (8 / maxCols) * (maxCols - 1);
           row[i].height = tileHeight - (8 / maxRows) * (maxRows - 1);

--- a/packages/roomkit-react/src/Prebuilt/components/hooks/useTileLayout.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/hooks/useTileLayout.tsx
@@ -117,8 +117,8 @@ export const useTileLayout = ({
         }
         // Beam layout breaks at 480p resolution because the gap of $4 between tiles is not accounted for
         for (let i = 0; i < row.length; i++) {
-          row[i].width = tileWidth - 8 / maxCols;
-          row[i].height = tileHeight - 8 / maxRows;
+          row[i].width = tileWidth - (8 / maxCols) * (maxCols - 1);
+          row[i].height = tileHeight - (8 / maxRows) * (maxRows - 1);
         }
       }
     }

--- a/packages/roomkit-react/src/Prebuilt/components/hooks/useTileLayout.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/hooks/useTileLayout.tsx
@@ -115,9 +115,10 @@ export const useTileLayout = ({
             }
           }
         }
+        // Beam layout breaks at 480p resolution without this adjustment
         for (let i = 0; i < row.length; i++) {
-          row[i].width = tileWidth;
-          row[i].height = tileHeight;
+          row[i].width = tileWidth - 5;
+          row[i].height = tileHeight - 5;
         }
       }
     }


### PR DESCRIPTION
## Before:

![image](https://github.com/user-attachments/assets/8dd3cdae-7ab6-4e2d-a59e-e3e6ca6a580f)


## After:

![image](https://github.com/user-attachments/assets/59af1768-ffa4-4ec2-8dab-8a59ec62f4cb)


- Fix: The tiles have a gap of 8px. The tile dim calculation does not account for this. The gaps should be subtracted from each tile's height and width depending on the number of rows and columns
