### PR TITLE
fix: local peer Inset tile incorrect aspect ratio on mweb

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/InsetTile.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/InsetTile.tsx
@@ -105,7 +105,7 @@ export const InsetTile = ({ peerId }: { peerId?: string }) => {
           r: '$2',
           ...(!minimised
             ? {
-                aspectRatio: aspectRatio,
+                aspectRatio: `${aspectRatio}`,
                 h: height,
               }
             : {}),


### PR DESCRIPTION
### Details(context, link the issue, how was the bug fixed, what does the new feature do)

- Local peer inset tile has incorrect aspect ratio on mweb for QA links
- This issue is due to stitches upgrade which requires that `aspectRatio` should be passed as a `string`
