### PR TITLE
feat: internal method to check if recording should continue

### DIFF
--- a/packages/hms-video-store/src/IHMSActions.ts
+++ b/packages/hms-video-store/src/IHMSActions.ts
@@ -40,6 +40,7 @@ import {
   IHMSSessionStoreActions,
 } from './schema';
 import { HMSRoleChangeRequest } from './selectors';
+import { HMSStats } from './webrtc-stats';
 
 /**
  * The below interface defines our SDK API Surface for taking room related actions.
@@ -587,4 +588,10 @@ export interface IHMSActions<T extends HMSGenericTypes = { sessionStore: Record<
    * Method to get enabled flags and endpoints. Should only be called after joining.
    */
   getDebugInfo(): DebugInfo | undefined;
+
+  /**
+   * @internal
+   * Method to check if received bitrate is 0 for all remote peers or whether the room has whiteboard/quiz running. To be used by beam.
+   */
+  hasActiveElements(hmsStats: HMSStats): boolean;
 }

--- a/packages/hms-video-store/src/reactive-store/HMSSDKActions.ts
+++ b/packages/hms-video-store/src/reactive-store/HMSSDKActions.ts
@@ -92,6 +92,7 @@ import {
   selectVideoTrackByID,
 } from '../selectors';
 import { FindPeerByNameRequestParams } from '../signal/interfaces';
+import { HMSStats } from '../webrtc-stats';
 
 /**
  * This class implements the IHMSActions interface for 100ms SDK. It connects with SDK
@@ -1671,4 +1672,24 @@ export class HMSSDKActions<T extends HMSGenericTypes = { sessionStore: Record<st
   private setState: NamedSetState<HMSStore<T>> = (fn, name) => {
     return this.store.namedSetState(fn, name);
   };
+
+  /**
+   * @internal
+   * This will be used by beam to check if the recording should continue, it will pass __hms.stats
+   * It will poll at a fixed interval and start an exit timer if the method fails twice consecutively
+   * The exit timer is stopped if the method returns true before that
+   * @param hmsStats
+   */
+  hasActiveElements(hmsStats: HMSStats): boolean {
+    const isWhiteboardPresent = Object.keys(this.store.getState().whiteboards).length > 0;
+    const isQuizOrPollPresent = Object.keys(this.store.getState().polls).length > 0;
+    const peerCount = Object.keys(this.store.getState().peers).length > 0;
+    const remoteTracks = hmsStats.getState().remoteTrackStats;
+    return (
+      peerCount &&
+      (isWhiteboardPresent ||
+        isQuizOrPollPresent ||
+        Object.values(remoteTracks).some(track => track && typeof track.bitrate === 'number' && track.bitrate > 0))
+    );
+  }
 }


### PR DESCRIPTION
# Description

Beam currently continues recording even when it is not able to subscribe to any peers. Recording gets marked as successful despite being blank. Adding this method so beam can identify this and terminate after a timeout if the check fails continuously. 

This should not cause regular flows to fail (RTMP IN - no peers needed to join, rooms where js bridge is disabled - won't be able to execute this)

https://app.devrev.ai/100ms/works/ISS-30657

Usage:

<img width="471" alt="image" src="https://github.com/user-attachments/assets/b43b879a-c042-4500-85a2-2716835827df">

---

### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

### Merging:
- Squash merge to dev
- Merge commit to publish-alpha and main

<!-- Links -->

[Documentation]: https://www.100ms.live/docs