### PR TITLE
fix: audio track constraints when krisp is enabled

### DIFF
--- a/packages/hms-video-store/src/media/settings/HMSAudioTrackSettings.ts
+++ b/packages/hms-video-store/src/media/settings/HMSAudioTrackSettings.ts
@@ -59,24 +59,6 @@ export class HMSAudioTrackSettingsBuilder {
     return this;
   }
 
-  updateConstraints(overrides: Partial<Array<MediaTrackConstraintSet>>) {
-    const constraintsMap = new Map<string, MediaTrackConstraintSet>();
-    this._advanced.forEach(constraint => {
-      const key = Object.keys(constraint)[0];
-      constraintsMap.set(key, constraint);
-    });
-
-    Object.entries(overrides).forEach(([key, value]) => {
-      if (value !== undefined) {
-        // @ts-ignore
-        constraintsMap.set(key, { [key]: { exact: value['exact'] } });
-      }
-    });
-
-    this._advanced = Array.from(constraintsMap.values());
-    return this;
-  }
-
   advanced(advanced: Array<MediaTrackConstraintSet>) {
     this._advanced = advanced;
     return this;

--- a/packages/hms-video-store/src/media/settings/HMSAudioTrackSettings.ts
+++ b/packages/hms-video-store/src/media/settings/HMSAudioTrackSettings.ts
@@ -1,3 +1,4 @@
+import { standardMediaConstraints } from './constants';
 import { IAnalyticsPropertiesProvider } from '../../analytics/IAnalyticsPropertiesProvider';
 import { HMSAudioCodec, HMSAudioMode, HMSAudioTrackSettings as IHMSAudioTrackSettings } from '../../interfaces';
 
@@ -8,20 +9,11 @@ export class HMSAudioTrackSettingsBuilder {
   private _deviceId = 'default';
   private _audioMode: HMSAudioMode = HMSAudioMode.VOICE;
   private _advanced: Array<MediaTrackConstraintSet> = [
-    // @ts-ignore
-    { googEchoCancellation: { exact: true } },
-    // @ts-ignore
-    { googExperimentalEchoCancellation: { exact: true } },
-    // @ts-ignore
+    ...standardMediaConstraints,
     { autoGainControl: { exact: true } },
     // @ts-ignore
     { noiseSuppression: { exact: true } },
-    // @ts-ignore
-    { googHighpassFilter: { exact: true } },
-    // @ts-ignore
-    { googAudioMirroring: { exact: true } },
   ];
-
   volume(volume: number) {
     if (!(0.0 <= volume && volume <= 1.0)) {
       throw Error('volume can only be in range [0.0, 1.0]');

--- a/packages/hms-video-store/src/media/settings/HMSAudioTrackSettings.ts
+++ b/packages/hms-video-store/src/media/settings/HMSAudioTrackSettings.ts
@@ -59,6 +59,24 @@ export class HMSAudioTrackSettingsBuilder {
     return this;
   }
 
+  updateConstraints(overrides: Partial<Array<MediaTrackConstraintSet>>) {
+    const constraintsMap = new Map<string, MediaTrackConstraintSet>();
+    this._advanced.forEach(constraint => {
+      const key = Object.keys(constraint)[0];
+      constraintsMap.set(key, constraint);
+    });
+
+    Object.entries(overrides).forEach(([key, value]) => {
+      if (value !== undefined) {
+        // @ts-ignore
+        constraintsMap.set(key, { [key]: { exact: value['exact'] } });
+      }
+    });
+
+    this._advanced = Array.from(constraintsMap.values());
+    return this;
+  }
+
   advanced(advanced: Array<MediaTrackConstraintSet>) {
     this._advanced = advanced;
     return this;

--- a/packages/hms-video-store/src/media/settings/constants.ts
+++ b/packages/hms-video-store/src/media/settings/constants.ts
@@ -1,0 +1,8 @@
+export const standardMediaConstraints = [
+  { echoCancellation: { exact: true } },
+  { highpassFilter: { exact: true } },
+  { audioMirroring: { exact: true } },
+  // These options can vary depending on the audio plugin
+  //   { autoGainControl: { exact: true } },
+  //   { noiseSuppression: { exact: true } },
+];

--- a/packages/hms-video-store/src/plugins/audio/HMSAudioPluginsManager.ts
+++ b/packages/hms-video-store/src/plugins/audio/HMSAudioPluginsManager.ts
@@ -5,6 +5,7 @@ import { ErrorFactory } from '../../error/ErrorFactory';
 import { HMSAction } from '../../error/HMSAction';
 import { EventBus } from '../../events/EventBus';
 import { HMSAudioTrackSettingsBuilder } from '../../media/settings';
+import { standardMediaConstraints } from '../../media/settings/constants';
 import { HMSLocalAudioTrack } from '../../media/tracks';
 import Room from '../../sdk/models/HMSRoom';
 import HMSLogger from '../../utils/logger';
@@ -92,18 +93,11 @@ export class HMSAudioPluginsManager {
           .maxBitrate(settings.maxBitrate)
           .deviceId(settings.deviceId!)
           .advanced([
-            // @ts-ignore
-            { googEchoCancellation: { exact: true } },
-            // @ts-ignore
-            { googExperimentalEchoCancellation: { exact: true } },
+            ...standardMediaConstraints,
             // @ts-ignore
             { autoGainControl: { exact: false } },
             // @ts-ignore
             { noiseSuppression: { exact: false } },
-            // @ts-ignore
-            { googHighpassFilter: { exact: true } },
-            // @ts-ignore
-            { googAudioMirroring: { exact: true } },
           ])
           .audioMode(settings.audioMode)
           .build();
@@ -194,18 +188,11 @@ export class HMSAudioPluginsManager {
           .maxBitrate(settings.maxBitrate)
           .deviceId(settings.deviceId!)
           .advanced([
-            // @ts-ignore
-            { googEchoCancellation: { exact: true } },
-            // @ts-ignore
-            { googExperimentalEchoCancellation: { exact: true } },
+            ...standardMediaConstraints,
             // @ts-ignore
             { autoGainControl: { exact: true } },
             // @ts-ignore
             { noiseSuppression: { exact: true } },
-            // @ts-ignore
-            { googHighpassFilter: { exact: true } },
-            // @ts-ignore
-            { googAudioMirroring: { exact: true } },
           ])
           .audioMode(settings.audioMode)
           .build();

--- a/packages/hms-video-store/src/plugins/audio/HMSAudioPluginsManager.ts
+++ b/packages/hms-video-store/src/plugins/audio/HMSAudioPluginsManager.ts
@@ -91,7 +91,20 @@ export class HMSAudioPluginsManager {
           .codec(settings.codec)
           .maxBitrate(settings.maxBitrate)
           .deviceId(settings.deviceId!)
-          .updateConstraints([{ autoGainControl: { exact: false } }, { noiseSuppression: { exact: false } }])
+          .advanced([
+            // @ts-ignore
+            { googEchoCancellation: { exact: true } },
+            // @ts-ignore
+            { googExperimentalEchoCancellation: { exact: true } },
+            // @ts-ignore
+            { autoGainControl: { exact: false } },
+            // @ts-ignore
+            { noiseSuppression: { exact: false } },
+            // @ts-ignore
+            { googHighpassFilter: { exact: true } },
+            // @ts-ignore
+            { googAudioMirroring: { exact: true } },
+          ])
           .audioMode(settings.audioMode)
           .build();
         await this.hmsTrack.setSettings(newAudioTrackSettings);
@@ -180,7 +193,20 @@ export class HMSAudioPluginsManager {
           .codec(settings.codec)
           .maxBitrate(settings.maxBitrate)
           .deviceId(settings.deviceId!)
-          .updateConstraints([{ autoGainControl: { exact: true } }, { noiseSuppression: { exact: true } }])
+          .advanced([
+            // @ts-ignore
+            { googEchoCancellation: { exact: true } },
+            // @ts-ignore
+            { googExperimentalEchoCancellation: { exact: true } },
+            // @ts-ignore
+            { autoGainControl: { exact: true } },
+            // @ts-ignore
+            { noiseSuppression: { exact: true } },
+            // @ts-ignore
+            { googHighpassFilter: { exact: true } },
+            // @ts-ignore
+            { googAudioMirroring: { exact: true } },
+          ])
           .audioMode(settings.audioMode)
           .build();
         await this.hmsTrack.setSettings(newAudioTrackSettings);

--- a/packages/roomkit-react/package.json
+++ b/packages/roomkit-react/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "@100mslive/hls-player": "0.3.24",
-    "@100mslive/hms-noise-cancellation": "0.0.1",
+    "@100mslive/hms-noise-cancellation": "0.0.2-alpha.3",
     "@100mslive/hms-virtual-background": "1.13.24",
     "@100mslive/hms-whiteboard": "0.0.14",
     "@100mslive/react-icons": "0.10.24",

--- a/packages/roomkit-react/package.json
+++ b/packages/roomkit-react/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "@100mslive/hls-player": "0.3.24",
-    "@100mslive/hms-noise-cancellation": "0.0.2-alpha.6",
+    "@100mslive/hms-noise-cancellation": "0.0.2-alpha.7",
     "@100mslive/hms-virtual-background": "1.13.24",
     "@100mslive/hms-whiteboard": "0.0.14",
     "@100mslive/react-icons": "0.10.24",

--- a/packages/roomkit-react/package.json
+++ b/packages/roomkit-react/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "@100mslive/hls-player": "0.3.24",
-    "@100mslive/hms-noise-cancellation": "0.0.2-alpha.4",
+    "@100mslive/hms-noise-cancellation": "0.0.2-alpha.6",
     "@100mslive/hms-virtual-background": "1.13.24",
     "@100mslive/hms-whiteboard": "0.0.14",
     "@100mslive/react-icons": "0.10.24",
@@ -102,7 +102,7 @@
     "@stitches/react": "1.3.1-1",
     "emoji-mart": "^5.2.2",
     "eventemitter2": "^6.4.9",
-    "framer-motion":"^11.11.0",
+    "framer-motion": "^11.11.0",
     "lodash.merge": "^4.6.2",
     "qrcode.react": "^3.1.0",
     "react-dom": "^18.2.0",

--- a/packages/roomkit-react/package.json
+++ b/packages/roomkit-react/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "@100mslive/hls-player": "0.3.24",
-    "@100mslive/hms-noise-cancellation": "0.0.2-alpha.3",
+    "@100mslive/hms-noise-cancellation": "0.0.2-alpha.4",
     "@100mslive/hms-virtual-background": "1.13.24",
     "@100mslive/hms-whiteboard": "0.0.14",
     "@100mslive/react-icons": "0.10.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@100mslive/hms-noise-cancellation@0.0.2-alpha.3":
-  version "0.0.2-alpha.3"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-noise-cancellation/-/hms-noise-cancellation-0.0.2-alpha.3.tgz#f36068a619b8560a27f8f66a83dcae1c1e71aa7a"
-  integrity sha512-t5it7a86lt24DkkA9h7bh65GujtPm62YhZv2UkFF4S749zHGsoBjSbRt1QwqmPWo6AmCNiEWtGXBcmocI5EVvg==
+"@100mslive/hms-noise-cancellation@0.0.2-alpha.4":
+  version "0.0.2-alpha.4"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-noise-cancellation/-/hms-noise-cancellation-0.0.2-alpha.4.tgz#4a86ed05681cfaea3ccb1de4c68fd10ffa9246d7"
+  integrity sha512-jjdfpO8mFIghsdbKByct/4sZlEksoBFKYowEslkO2wq5vNLTq7BEAKGMX1mjjACagworyF7YOqNnX55fXhke8g==
 
 "@100mslive/types-prebuilt@0.12.12":
   version "0.12.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@100mslive/hms-noise-cancellation@0.0.2-alpha.6":
-  version "0.0.2-alpha.6"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-noise-cancellation/-/hms-noise-cancellation-0.0.2-alpha.6.tgz#f8f4c00f82dbdc3366b8e2487bcb75aeb2bca60c"
-  integrity sha512-hQDMXaK7zMK0P2xfXgorth9gvMyr0K3vEVVQit/iHajCzIhnZbkKLgfySW8nQz2z5cePnI0X3ZUN/HP7UTdA/Q==
+"@100mslive/hms-noise-cancellation@0.0.2-alpha.7":
+  version "0.0.2-alpha.7"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-noise-cancellation/-/hms-noise-cancellation-0.0.2-alpha.7.tgz#049221bf8cac991c2e29594cf92e4022d1a8190b"
+  integrity sha512-XRhhbGWDWnSnKK6cfSiVaBpRyTleG/ysZr36Vec3WJab26rLBP7B9JTn0kT8MYpbBW+1mmyuPjR7vwI20Qo/vQ==
 
 "@100mslive/types-prebuilt@0.12.12":
   version "0.12.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@100mslive/hms-noise-cancellation@0.0.2-alpha.4":
-  version "0.0.2-alpha.4"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-noise-cancellation/-/hms-noise-cancellation-0.0.2-alpha.4.tgz#4a86ed05681cfaea3ccb1de4c68fd10ffa9246d7"
-  integrity sha512-jjdfpO8mFIghsdbKByct/4sZlEksoBFKYowEslkO2wq5vNLTq7BEAKGMX1mjjACagworyF7YOqNnX55fXhke8g==
+"@100mslive/hms-noise-cancellation@0.0.2-alpha.6":
+  version "0.0.2-alpha.6"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-noise-cancellation/-/hms-noise-cancellation-0.0.2-alpha.6.tgz#f8f4c00f82dbdc3366b8e2487bcb75aeb2bca60c"
+  integrity sha512-hQDMXaK7zMK0P2xfXgorth9gvMyr0K3vEVVQit/iHajCzIhnZbkKLgfySW8nQz2z5cePnI0X3ZUN/HP7UTdA/Q==
 
 "@100mslive/types-prebuilt@0.12.12":
   version "0.12.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@100mslive/hms-noise-cancellation@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-noise-cancellation/-/hms-noise-cancellation-0.0.1.tgz#037c8bdfb6b2d7bf12f9d257422150fe6ca43acb"
-  integrity sha512-DGnzcXRDJREWypIjGX70er+f2k/XLLRF41lrXPs1+PtB1imdEkECPPS0Fg4BA0BCWKDNAGTZBHZPrBDgUmr9Lw==
+"@100mslive/hms-noise-cancellation@0.0.2-alpha.3":
+  version "0.0.2-alpha.3"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-noise-cancellation/-/hms-noise-cancellation-0.0.2-alpha.3.tgz#f36068a619b8560a27f8f66a83dcae1c1e71aa7a"
+  integrity sha512-t5it7a86lt24DkkA9h7bh65GujtPm62YhZv2UkFF4S749zHGsoBjSbRt1QwqmPWo6AmCNiEWtGXBcmocI5EVvg==
 
 "@100mslive/types-prebuilt@0.12.12":
   version "0.12.12"
@@ -16541,16 +16541,7 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -16655,14 +16646,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -18015,7 +17999,7 @@ worker-timers@^7.0.40:
     worker-timers-broker "^6.0.95"
     worker-timers-worker "^7.0.59"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -18028,15 +18012,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Description

Disable noise suppression and auto gain control while enabling Krisp and re-enable when Krisp is being stopped. In hms-noise-cancellation's latest version (0.0.2-alpha.3), the model can be specified through the query param: 

?model=https://assets.100ms.live/krisp/2.0.0/models/model_16 (default)
Other possible values: _8 (mobile, lower quality and cpu usage), _32 (desktop, best quality but crashes on mweb)

https://app.devrev.ai/100ms/works/ISS-30666

---

### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

### Merging:
- Squash merge to dev
- Merge commit to publish-alpha and main

<!-- Links -->

[Documentation]: https://www.100ms.live/docs