### PR TITLE
Persisting audio & video device selection across local peer's role change

### DIFF
--- a/packages/hms-video-store/src/device-manager/DeviceManager.ts
+++ b/packages/hms-video-store/src/device-manager/DeviceManager.ts
@@ -31,6 +31,12 @@ export class DeviceManager implements HMSDeviceManager {
   hasWebcamPermission = false;
   hasMicrophonePermission = false;
 
+  prevSelection: SelectedDevices = {
+    audioInput: undefined,
+    videoInput: undefined,
+    audioOutput: undefined,
+  };
+
   private readonly TAG = '[Device Manager]:';
   private initialized = false;
   private videoInputChanged = false;

--- a/packages/hms-video-store/src/sdk/RoleChangeManager.ts
+++ b/packages/hms-video-store/src/sdk/RoleChangeManager.ts
@@ -1,6 +1,6 @@
 import { Store } from './store';
 import { DeviceManager } from '../device-manager';
-import { HMSRole } from '../interfaces';
+import { DeviceType, HMSRole } from '../interfaces';
 import InitialSettings from '../interfaces/settings';
 import { SimulcastLayers } from '../interfaces/simulcast-layers';
 import { HMSPeerUpdate, HMSTrackUpdate, HMSUpdateListener } from '../interfaces/update-listener';
@@ -144,14 +144,47 @@ export default class RoleChangeManager {
   }
 
   private getSettings(): InitialSettings {
-    const initialSettings = this.store.getConfig()?.settings;
+    const { isAudioMuted, isVideoMuted } = this.getMutedStatus();
+    const { audioInputDeviceId, audioOutputDeviceId } = this.getAudioDeviceSettings();
+    const videoDeviceId = this.getVideoInputDeviceId();
+    return {
+      isAudioMuted: isAudioMuted,
+      isVideoMuted: isVideoMuted,
+      audioInputDeviceId: audioInputDeviceId,
+      audioOutputDeviceId: audioOutputDeviceId,
+      videoDeviceId: videoDeviceId,
+    };
+  }
 
+  private getMutedStatus(): { isAudioMuted: boolean; isVideoMuted: boolean } {
+    const initialSettings = this.store.getConfig()?.settings;
     return {
       isAudioMuted: initialSettings?.isAudioMuted ?? true,
       isVideoMuted: initialSettings?.isVideoMuted ?? true,
-      audioInputDeviceId: initialSettings?.audioInputDeviceId || 'default',
-      audioOutputDeviceId: initialSettings?.audioOutputDeviceId || 'default',
-      videoDeviceId: initialSettings?.videoDeviceId || 'default',
     };
+  }
+
+  private getAudioDeviceSettings(): { audioInputDeviceId: string; audioOutputDeviceId: string } {
+    const initialSettings = this.store.getConfig()?.settings;
+    const audioInputDeviceId =
+      this.deviceManager.prevSelection[DeviceType.audioInput]?.deviceId ||
+      initialSettings?.audioInputDeviceId ||
+      'default';
+    const audioOutputDeviceId =
+      this.deviceManager.prevSelection[DeviceType.audioOutput]?.deviceId ||
+      initialSettings?.audioOutputDeviceId ||
+      'default';
+
+    return {
+      audioInputDeviceId,
+      audioOutputDeviceId,
+    };
+  }
+
+  private getVideoInputDeviceId(): string {
+    const initialSettings = this.store.getConfig()?.settings;
+    return (
+      this.deviceManager.prevSelection[DeviceType.videoInput]?.deviceId || initialSettings?.videoDeviceId || 'default'
+    );
   }
 }

--- a/packages/hms-video-store/src/sdk/index.ts
+++ b/packages/hms-video-store/src/sdk/index.ts
@@ -1350,6 +1350,7 @@ export class HMSSdk implements HMSInterface {
   }
 
   private handleLocalRoleUpdate = async ({ oldRole, newRole }: { oldRole: HMSRole; newRole: HMSRole }) => {
+    this.deviceManager.prevSelection = this.deviceManager.getCurrentSelection();
     await this.transport.handleLocalRoleUpdate({ oldRole, newRole });
     await this.roleChangeManager?.handleLocalPeerRoleUpdate({ oldRole, newRole });
     await this.interactivityCenter.whiteboard.handleLocalRoleUpdate();


### PR DESCRIPTION
# Description

- Using previous selection for device inputs after local role change

### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I updated/added relevant documentation.
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

### Merging:
- Squash merge to dev
- Merge commit to publish-alpha and main

<!-- Links -->

[Documentation]: https://www.100ms.live/docs