### PR TITLE
fix: pip chat height

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/PIP/PIPChat.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/PIP/PIPChat.tsx
@@ -72,7 +72,7 @@ export const PIPChat = () => {
   ]);
 
   return (
-    <div style={{ height: '100%' }}>
+    <div style={{ height: '100vh' }}>
       <Box
         id="chat-container"
         css={{


### PR DESCRIPTION
Testing document pip chat height fix - broken for Chrome versions 131 onwards