### PR TITLE
fix: pip chat height

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/PIP/PIPChat.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/PIP/PIPChat.tsx
@@ -72,7 +72,7 @@ export const PIPChat = () => {
   ]);
 
   return (
-    <div style={{ height: '100%' }}>
+    <div style={{ height: '100vh' }}>
       <Box
         id="chat-container"
         css={{


### PR DESCRIPTION
# Description

PIP chat height is broken after Chrome version 131 update.

Before:

<img width="413" alt="image" src="https://github.com/user-attachments/assets/8fe0678b-6d96-4cb1-8e79-1b85aaa0bc2e">


After:

<img width="391" alt="image" src="https://github.com/user-attachments/assets/0aa18791-95e5-4d56-93de-674623973a03">



https://app.devrev.ai/100ms/works/ISS-30692

---


### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I updated/added relevant documentation.
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

### Merging:
- Squash merge to dev
- Merge commit to publish-alpha and main

<!-- Links -->

[Documentation]: https://www.100ms.live/docs