### PR TITLE
doximity rtc peer connection keyword modified to public from readonly

### DIFF
--- a/packages/hms-video-store/src/connection/HMSConnection.ts
+++ b/packages/hms-video-store/src/connection/HMSConnection.ts
@@ -11,12 +11,27 @@ import { enableOpusDtx, fixMsid } from '../utils/session-description';
 
 const TAG = '[HMSConnection]';
 
+/**
+ * Abstract base class that handles WebRTC peer connections for 100ms SDK
+ * Provides common functionality for both publishing (sending) and subscribing (receiving) connections
+ */
 export default abstract class HMSConnection {
+  /**
+   * Indicates whether this connection is for publishing or subscribing media
+   */
   readonly role: HMSConnectionRole;
+
   protected readonly signal: JsonRpcSignal;
 
   protected abstract readonly observer: IConnectionObserver;
+
+  /**
+   * The native WebRTC peer connection object
+   * @abstract
+   * @type {RTCPeerConnection}
+   */
   abstract nativeConnection: RTCPeerConnection;
+
   /**
    * We keep a list of pending IceCandidates received
    * from the signalling server. When the peer-connection
@@ -131,7 +146,6 @@ export default abstract class HMSConnection {
           const iceTransport = transmitter.transport.iceTransport;
 
           const handleSelectedCandidate = () => {
-            // @ts-expect-error
             if (typeof iceTransport.getSelectedCandidatePair === 'function') {
               // @ts-expect-error
               this.selectedCandidatePair = iceTransport.getSelectedCandidatePair();
@@ -147,9 +161,7 @@ export default abstract class HMSConnection {
             }
           };
 
-          // @ts-expect-error
           if (typeof iceTransport.onselectedcandidatepairchange === 'function') {
-            // @ts-expect-error
             iceTransport.onselectedcandidatepairchange = handleSelectedCandidate;
           }
           handleSelectedCandidate();

--- a/packages/hms-video-store/src/connection/HMSConnection.ts
+++ b/packages/hms-video-store/src/connection/HMSConnection.ts
@@ -16,7 +16,7 @@ export default abstract class HMSConnection {
   protected readonly signal: JsonRpcSignal;
 
   protected abstract readonly observer: IConnectionObserver;
-  abstract readonly nativeConnection: RTCPeerConnection;
+  abstract nativeConnection: RTCPeerConnection;
   /**
    * We keep a list of pending IceCandidates received
    * from the signalling server. When the peer-connection

--- a/packages/hms-video-store/src/connection/HMSConnection.ts
+++ b/packages/hms-video-store/src/connection/HMSConnection.ts
@@ -146,6 +146,7 @@ export default abstract class HMSConnection {
           const iceTransport = transmitter.transport.iceTransport;
 
           const handleSelectedCandidate = () => {
+            // @ts-expect-error
             if (typeof iceTransport.getSelectedCandidatePair === 'function') {
               // @ts-expect-error
               this.selectedCandidatePair = iceTransport.getSelectedCandidatePair();
@@ -161,7 +162,9 @@ export default abstract class HMSConnection {
             }
           };
 
+          // @ts-expect-error
           if (typeof iceTransport.onselectedcandidatepairchange === 'function') {
+            // @ts-expect-error
             iceTransport.onselectedcandidatepairchange = handleSelectedCandidate;
           }
           handleSelectedCandidate();

--- a/packages/hms-video-store/src/connection/publish/publishConnection.ts
+++ b/packages/hms-video-store/src/connection/publish/publishConnection.ts
@@ -5,10 +5,23 @@ import HMSLogger from '../../utils/logger';
 import HMSConnection from '../HMSConnection';
 import { HMSConnectionRole } from '../model';
 
+/**
+ * Represents a connection for publishing media to the signalling server.
+ * Extends the HMSConnection class to provide additional functionality for publishing media
+ * @extends {HMSConnection}
+ */
 export default class HMSPublishConnection extends HMSConnection {
   private readonly TAG = '[HMSPublishConnection]';
   protected readonly observer: IPublishConnectionObserver;
+  /**
+   * The native WebRTC peer connection object
+   * @type {RTCPeerConnection}
+   */
   nativeConnection: RTCPeerConnection;
+  /**
+   * The data channel used for communication with the signalling server
+   * @type {RTCDataChannel}
+   */
   readonly channel: RTCDataChannel;
 
   constructor(signal: JsonRpcSignal, config: RTCConfiguration, observer: IPublishConnectionObserver) {

--- a/packages/hms-video-store/src/connection/publish/publishConnection.ts
+++ b/packages/hms-video-store/src/connection/publish/publishConnection.ts
@@ -8,7 +8,7 @@ import { HMSConnectionRole } from '../model';
 export default class HMSPublishConnection extends HMSConnection {
   private readonly TAG = '[HMSPublishConnection]';
   protected readonly observer: IPublishConnectionObserver;
-  readonly nativeConnection: RTCPeerConnection;
+  nativeConnection: RTCPeerConnection;
   readonly channel: RTCDataChannel;
 
   constructor(signal: JsonRpcSignal, config: RTCConfiguration, observer: IPublishConnectionObserver) {

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
@@ -15,12 +15,21 @@ import HMSConnection from '../HMSConnection';
 import HMSDataChannel from '../HMSDataChannel';
 import { HMSConnectionRole } from '../model';
 
+/**
+ * Represents a connection for subscribing to media from the signalling server.
+ * Extends the HMSConnection class to provide additional functionality for subscribing to media
+ * @extends {HMSConnection}
+ */
 export default class HMSSubscribeConnection extends HMSConnection {
   private readonly TAG = '[HMSSubscribeConnection]';
   private readonly remoteStreams = new Map<string, HMSRemoteStream>();
   protected readonly observer: ISubscribeConnectionObserver;
   private readonly MAX_RETRIES = 3;
 
+  /**
+   * The native WebRTC peer connection object
+   * @type {RTCPeerConnection}
+   */
   nativeConnection: RTCPeerConnection;
 
   private pendingMessageQueue: string[] = [];

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
@@ -21,7 +21,7 @@ export default class HMSSubscribeConnection extends HMSConnection {
   protected readonly observer: ISubscribeConnectionObserver;
   private readonly MAX_RETRIES = 3;
 
-  readonly nativeConnection: RTCPeerConnection;
+  nativeConnection: RTCPeerConnection;
 
   private pendingMessageQueue: string[] = [];
 


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/c3181e09-c53d-42b9-801f-61a19a8fcef1)
---

## Implementation note, gotchas, related work and Future TODOs (optional)

<!-- Add any other context or additional information about the pull request.-->

Exposed nativeConnection class for getting rtc peer connection 

__hms.sdk.transport.subscribeConnection
__hms.sdk.transport.publishConnection


### Pre-launch Checklist

- [x] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [x] I updated/added relevant documentation.
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

### Merging:
- Squash merge to dev
- Merge commit to publish-alpha and main

<!-- Links -->

[Documentation]: https://www.100ms.live/docs