### PR TITLE
fix: add optimisations to HMSEffects Plugin

### DIFF
--- a/packages/hms-virtual-background/src/HMSEffectsPlugin.ts
+++ b/packages/hms-virtual-background/src/HMSEffectsPlugin.ts
@@ -100,6 +100,7 @@ export class HMSEffectsPlugin implements HMSMediaStreamPlugin {
     this.removeBackground();
     this.executeAfterInit(() => {
       this.effects.setBlur(this.blurAmount);
+      this.effects.run();
     });
   }
 
@@ -138,6 +139,7 @@ export class HMSEffectsPlugin implements HMSMediaStreamPlugin {
     this.removeBlur();
     this.executeAfterInit(() => {
       this.effects.setBackground(this.background);
+      this.effects.run();
     });
   }
 
@@ -179,6 +181,5 @@ export class HMSEffectsPlugin implements HMSMediaStreamPlugin {
     } else if (this.background) {
       this.setBackground(this.background);
     }
-    this.effects.run();
   }
 }

--- a/packages/hms-virtual-background/src/HMSEffectsPlugin.ts
+++ b/packages/hms-virtual-background/src/HMSEffectsPlugin.ts
@@ -45,14 +45,8 @@ export class HMSEffectsPlugin implements HMSMediaStreamPlugin {
       if (this.effects) {
         this.initialised = true;
         this.onInit?.();
-        if (
-          this.background !== HMSVirtualBackgroundTypes.NONE &&
-          this.backgroundType !== HMSVirtualBackgroundTypes.NONE
-        ) {
-          this.effects.setBackgroundFitMode('fill');
-          this.effects.setSegmentationPreset(this.preset);
-          this.applyEffect();
-        }
+        this.effects.setBackgroundFitMode('fill');
+        this.effects.setSegmentationPreset(this.preset);
       }
     };
   }

--- a/packages/hms-virtual-background/src/HMSEffectsPlugin.ts
+++ b/packages/hms-virtual-background/src/HMSEffectsPlugin.ts
@@ -45,10 +45,15 @@ export class HMSEffectsPlugin implements HMSMediaStreamPlugin {
       if (this.effects) {
         this.initialised = true;
         this.onInit?.();
-        this.effects.run();
-        this.effects.setBackgroundFitMode('fill');
-        this.effects.setSegmentationPreset(this.preset);
-        this.applyEffect();
+        if (
+          this.background !== HMSVirtualBackgroundTypes.NONE &&
+          this.backgroundType !== HMSVirtualBackgroundTypes.NONE
+        ) {
+          this.effects.run();
+          this.effects.setBackgroundFitMode('fill');
+          this.effects.setSegmentationPreset(this.preset);
+          this.applyEffect();
+        }
       }
     };
   }
@@ -95,6 +100,7 @@ export class HMSEffectsPlugin implements HMSMediaStreamPlugin {
     this.backgroundType = HMSVirtualBackgroundTypes.BLUR;
     this.removeBackground();
     this.executeAfterInit(() => {
+      this.effects.run();
       this.effects.setBlur(this.blurAmount);
     });
   }
@@ -123,6 +129,9 @@ export class HMSEffectsPlugin implements HMSMediaStreamPlugin {
     this.backgroundType = HMSVirtualBackgroundTypes.NONE;
     this.removeBackground();
     this.removeBlur();
+    this.executeAfterInit(() => {
+      this.effects.stop();
+    });
   }
 
   setBackground(url: HMSEffectsBackground) {
@@ -130,6 +139,7 @@ export class HMSEffectsPlugin implements HMSMediaStreamPlugin {
     this.backgroundType = HMSVirtualBackgroundTypes.IMAGE;
     this.removeBlur();
     this.executeAfterInit(() => {
+      this.effects.run();
       this.effects.setBackground(this.background);
     });
   }
@@ -164,9 +174,6 @@ export class HMSEffectsPlugin implements HMSMediaStreamPlugin {
 
   stop() {
     this.removeEffects();
-    this.executeAfterInit(() => {
-      this.effects.stop();
-    });
   }
 
   private applyEffect() {

--- a/packages/hms-virtual-background/src/HMSEffectsPlugin.ts
+++ b/packages/hms-virtual-background/src/HMSEffectsPlugin.ts
@@ -100,8 +100,8 @@ export class HMSEffectsPlugin implements HMSMediaStreamPlugin {
     this.backgroundType = HMSVirtualBackgroundTypes.BLUR;
     this.removeBackground();
     this.executeAfterInit(() => {
-      this.effects.run();
       this.effects.setBlur(this.blurAmount);
+      this.effects.run();
     });
   }
 
@@ -139,8 +139,8 @@ export class HMSEffectsPlugin implements HMSMediaStreamPlugin {
     this.backgroundType = HMSVirtualBackgroundTypes.IMAGE;
     this.removeBlur();
     this.executeAfterInit(() => {
-      this.effects.run();
       this.effects.setBackground(this.background);
+      this.effects.run();
     });
   }
 

--- a/packages/hms-virtual-background/src/HMSEffectsPlugin.ts
+++ b/packages/hms-virtual-background/src/HMSEffectsPlugin.ts
@@ -49,7 +49,6 @@ export class HMSEffectsPlugin implements HMSMediaStreamPlugin {
           this.background !== HMSVirtualBackgroundTypes.NONE &&
           this.backgroundType !== HMSVirtualBackgroundTypes.NONE
         ) {
-          this.effects.run();
           this.effects.setBackgroundFitMode('fill');
           this.effects.setSegmentationPreset(this.preset);
           this.applyEffect();
@@ -101,7 +100,6 @@ export class HMSEffectsPlugin implements HMSMediaStreamPlugin {
     this.removeBackground();
     this.executeAfterInit(() => {
       this.effects.setBlur(this.blurAmount);
-      this.effects.run();
     });
   }
 
@@ -140,7 +138,6 @@ export class HMSEffectsPlugin implements HMSMediaStreamPlugin {
     this.removeBlur();
     this.executeAfterInit(() => {
       this.effects.setBackground(this.background);
-      this.effects.run();
     });
   }
 
@@ -182,5 +179,6 @@ export class HMSEffectsPlugin implements HMSMediaStreamPlugin {
     } else if (this.background) {
       this.setBackground(this.background);
     }
+    this.effects.run();
   }
 }


### PR DESCRIPTION
# Description

- Run the effects only when an effect(background or blur) is set.
- Stop the effects when removing effects(no effect)


_List which issues are fixed by this PR. You must list at least one issue._

---

## Implementation note, gotchas, related work and Future TODOs (optional)

<!-- Add any other context or additional information about the pull request.-->

-

### Pre-launch Checklist

- [ ] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [ ] I updated/added relevant documentation.
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making, or this PR is test-exempt.
- [ ] All existing and new tests are passing.

### Merging:
- Squash merge to dev
- Merge commit to publish-alpha and main

<!-- Links -->

[Documentation]: https://www.100ms.live/docs