### PR TITLE
feat(prebuilt): allow custom footer in participant side pane

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Footer/ParticipantList.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Footer/ParticipantList.tsx
@@ -46,9 +46,11 @@ import { SIDE_PANE_OPTIONS } from '../../common/constants';
 export const ParticipantList = ({
   offStageRoles = [],
   onActive,
+  footer,
 }: {
   offStageRoles: HMSRoleName[];
   onActive: (role: string) => void;
+  footer?: React.ReactNode;
 }) => {
   const [filter, setFilter] = useState<{ search?: string } | undefined>();
   const { participants, isConnected, peerCount } = useParticipants(filter);
@@ -121,6 +123,7 @@ export const ParticipantList = ({
             </Flex>
           ) : null}
         </VirtualizedParticipants>
+        {footer}
       </Flex>
     </Fragment>
   );

--- a/packages/roomkit-react/src/Prebuilt/components/SidePaneTabs.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/SidePaneTabs.tsx
@@ -53,6 +53,7 @@ export const SidePaneTabs = React.memo<{
   const chat_title = elements?.chat?.chat_title || 'Chat';
   const showChat = !!elements?.chat;
   const showParticipants = !!elements?.participant_list;
+  const participantFooter = elements?.participant_list?.footer;
   const hideTabs = !(showChat && showParticipants) || hideTab;
   const isMobile = useMedia(cssConfig.media.md);
   const isOverlayChat = !!elements?.chat?.is_overlay && isMobile;
@@ -157,7 +158,7 @@ export const SidePaneTabs = React.memo<{
               {activeTab === SIDE_PANE_OPTIONS.CHAT ? (
                 <Chat />
               ) : (
-                <ParticipantList offStageRoles={off_stage_roles} onActive={setActiveRole} />
+                <ParticipantList offStageRoles={off_stage_roles} onActive={setActiveRole} footer={participantFooter} />
               )}
             </>
           );
@@ -201,7 +202,7 @@ export const SidePaneTabs = React.memo<{
                 )}
               </Flex>
               <Tabs.Content value={SIDE_PANE_OPTIONS.PARTICIPANTS} css={{ p: 0 }}>
-                <ParticipantList offStageRoles={off_stage_roles} onActive={setActiveRole} />
+                <ParticipantList offStageRoles={off_stage_roles} onActive={setActiveRole} footer={participantFooter} />
               </Tabs.Content>
               <Tabs.Content value={SIDE_PANE_OPTIONS.CHAT} css={{ p: 0 }}>
                 <Chat />

--- a/packages/roomkit-react/src/Prebuilt/types.d.ts
+++ b/packages/roomkit-react/src/Prebuilt/types.d.ts
@@ -1,0 +1,7 @@
+import type { ReactNode } from 'react';
+
+declare module '@100mslive/types-prebuilt/elements/participant_list' {
+  export interface ParticipantList {
+    footer?: ReactNode;
+  }
+}


### PR DESCRIPTION
# Description
Fixes #3446

Allows prebuilt consumers to render a custom react component at the bottom of the participant list side pane:
<img width="434" alt="image" src="https://github.com/user-attachments/assets/2d72079d-a15c-4795-b04e-f8ff6a35346a" />

## Implementation note, gotchas, related work and Future TODOs (optional)

- I could not figure out where `types-prebuilt` is coming from
- I suspect using `ReactNode` as the type may be problematic b/c that library doesn't have `react` as a dependency right now

### Pre-launch Checklist

- [ ] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [ ] I updated/added relevant documentation.
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

### Merging:
- Squash merge to dev
- Merge commit to publish-alpha and main

<!-- Links -->

[Documentation]: https://www.100ms.live/docs