### PR TITLE
fix: explicit hls stop events

### DIFF
--- a/packages/hms-video-store/src/IHMSActions.ts
+++ b/packages/hms-video-store/src/IHMSActions.ts
@@ -1,3 +1,4 @@
+import { AnalyticsEventLevel } from './analytics/AnalyticsEventLevel';
 import { HMSDiagnosticsInterface } from './diagnostics/interfaces';
 import { TranscriptionConfig } from './interfaces/transcription-config';
 import { FindPeerByNameRequestParams } from './signal/interfaces';
@@ -695,4 +696,10 @@ export interface IHMSActions<T extends HMSGenericTypes = { sessionStore: Record<
    * @param delay in ms
    */
   autoSelectAudioOutput(delay?: number): Promise<void>;
+
+  /**
+   * Send custom analytics event which will be forwarded by the webhooks
+   * @param event
+   */
+  sendCustomAnalyticsEvent(event: { name: string; level: AnalyticsEventLevel }): void;
 }

--- a/packages/hms-video-store/src/index.ts
+++ b/packages/hms-video-store/src/index.ts
@@ -78,5 +78,6 @@ export type {
 } from './internal';
 export * from './diagnostics';
 export { DomainCategory } from './analytics/AnalyticsEventDomains';
+export { AnalyticsEventLevel } from './analytics/AnalyticsEventLevel';
 
 export { HMSTrackExceptionTrackType } from './media/tracks/HMSTrackExceptionTrackType';

--- a/packages/hms-video-store/src/interfaces/hms.ts
+++ b/packages/hms-video-store/src/interfaces/hms.ts
@@ -14,7 +14,7 @@ import { HMSInteractivityCenter, HMSSessionStore } from './session-store';
 import { HMSScreenShareConfig } from './track-settings';
 import { TranscriptionConfig } from './transcription-config';
 import { HMSAudioListener, HMSConnectionQualityListener, HMSUpdateListener } from './update-listener';
-import { HMSAnalyticsLevel } from '../analytics/AnalyticsEventLevel';
+import { AnalyticsEventLevel, HMSAnalyticsLevel } from '../analytics/AnalyticsEventLevel';
 import { IAudioOutputManager } from '../device-manager/AudioOutputManager';
 import { HMSSessionFeedback } from '../end-call-feedback';
 import { HMSRemoteTrack, HMSTrackSource } from '../media/tracks';
@@ -106,4 +106,5 @@ export interface HMSInterface {
 
   updatePlaylistSettings(options: HMSPlaylistSettings): void;
   submitSessionFeedback(feedback: HMSSessionFeedback, eventEndpoint?: string): Promise<void>;
+  sendCustomAnalyticsEvent(event: { name: string; level: AnalyticsEventLevel }): void;
 }

--- a/packages/hms-video-store/src/reactive-store/HMSSDKActions.ts
+++ b/packages/hms-video-store/src/reactive-store/HMSSDKActions.ts
@@ -14,6 +14,7 @@ import { HMSNotifications } from './HMSNotifications';
 import { HMSPlaylist } from './HMSPlaylist';
 import { HMSSessionStore } from './HMSSessionStore';
 import { NamedSetState } from './internalTypes';
+import { AnalyticsEventLevel } from '../analytics/AnalyticsEventLevel';
 import { HMSLogger } from '../common/ui-logger';
 import { BeamSpeakerLabelsLogger } from '../controller/beam/BeamSpeakerLabelsLogger';
 import { Diagnostics } from '../diagnostics';
@@ -1700,5 +1701,9 @@ export class HMSSDKActions<T extends HMSGenericTypes = { sessionStore: Record<st
         isQuizOrPollPresent ||
         Object.values(remoteTracks).some(track => track && typeof track.bitrate === 'number' && track.bitrate > 0))
     );
+  }
+
+  sendCustomAnalyticsEvent(event: { name: string; level: AnalyticsEventLevel }): void {
+    this.sdk.sendCustomAnalyticsEvent(event);
   }
 }

--- a/packages/hms-video-store/src/sdk/index.ts
+++ b/packages/hms-video-store/src/sdk/index.ts
@@ -8,7 +8,7 @@ import { Store } from './store';
 import { WakeLockManager } from './WakeLockManager';
 import AnalyticsEvent from '../analytics/AnalyticsEvent';
 import AnalyticsEventFactory from '../analytics/AnalyticsEventFactory';
-import { HMSAnalyticsLevel } from '../analytics/AnalyticsEventLevel';
+import { AnalyticsEventLevel, HMSAnalyticsLevel } from '../analytics/AnalyticsEventLevel';
 import { AnalyticsEventsService } from '../analytics/AnalyticsEventsService';
 import { AnalyticsTimer, TimedEvent } from '../analytics/AnalyticsTimer';
 import { AudioSinkManager } from '../audio-sink-manager';
@@ -1704,5 +1704,9 @@ export class HMSSdk implements HMSInterface {
         .build();
       await track.setSettings(settings);
     }
+  }
+
+  sendCustomAnalyticsEvent(event: { name: string; level: AnalyticsEventLevel }): void {
+    this.sendAnalyticsEvent(new AnalyticsEvent(event));
   }
 }

--- a/packages/roomkit-react/src/Prebuilt/components/Leave/LeaveRoom.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Leave/LeaveRoom.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useMedia } from 'react-use';
 import { ConferencingScreen } from '@100mslive/types-prebuilt';
 import {
+  AnalyticsEventLevel,
   HMSPeer,
   HMSRole,
   selectHLSState,
@@ -56,11 +57,13 @@ export const LeaveRoom = ({
   };
 
   const endRoom = async () => {
+    hmsActions.sendCustomAnalyticsEvent({ name: 'peer.endroomcalled', level: AnalyticsEventLevel.INFO });
     await hmsActions.endRoom(false, 'End Room');
   };
 
   const leaveRoom = async (options: { endStream?: boolean } = { endStream: false }) => {
     if (options.endStream || (hlsState.running && peersWithStreamingRights.length === 1)) {
+      hmsActions.sendCustomAnalyticsEvent({ name: 'prebuilt.hlsstopcalled', level: AnalyticsEventLevel.INFO });
       await stopStream();
     }
     await hmsActions.leave();


### PR DESCRIPTION
Added a way to send custom events to know if hls stop was called by the app or the user