### PR TITLE
feat: stop reason for hls stop

### DIFF
--- a/packages/hms-video-store/src/IHMSActions.ts
+++ b/packages/hms-video-store/src/IHMSActions.ts
@@ -21,6 +21,7 @@ import {
   HMSVideoPlugin,
   HMSVideoTrackSettings,
   RTMPRecordingConfig,
+  StopHLSConfig,
   TokenRequest,
   TokenRequestOptions,
 } from './internal';
@@ -426,7 +427,7 @@ export interface IHMSActions<T extends HMSGenericTypes = { sessionStore: Record<
    * @param params HLSConfig - HLSConfig object with the required fields
    * @returns Promise<void> - resolves when the HLS streaming is stopped
    */
-  stopHLSStreaming(params?: HLSConfig): Promise<void>;
+  stopHLSStreaming(params?: StopHLSConfig): Promise<void>;
 
   /**
    * If you want to start transcriptions(Closed Caption).

--- a/packages/hms-video-store/src/interfaces/hls-config.ts
+++ b/packages/hms-video-store/src/interfaces/hls-config.ts
@@ -19,6 +19,10 @@ export interface HLSConfig {
   };
 }
 
+export interface StopHLSConfig extends HLSConfig {
+  stop_reason?: string;
+}
+
 export interface HLSMeetingURLVariant {
   /**
    * This meeting URL is opened in a headless chrome instance for generating the HLS feed.

--- a/packages/hms-video-store/src/interfaces/hms.ts
+++ b/packages/hms-video-store/src/interfaces/hms.ts
@@ -1,7 +1,7 @@
 import { HMSChangeMultiTrackStateParams } from './change-track-state';
 import { HMSConfig, HMSPreviewConfig } from './config';
 import { TokenRequest, TokenRequestOptions } from './get-token';
-import { HLSConfig } from './hls-config';
+import { HLSConfig, StopHLSConfig } from './hls-config';
 import { HMSLocalPeer, HMSPeer } from './peer';
 import { HMSPeerListIteratorOptions } from './peer-list-iterator';
 import { HMSPlaylistManager, HMSPlaylistSettings } from './playlist';
@@ -62,7 +62,7 @@ export interface HMSInterface {
    * @param {HLSConfig} params
    */
   startHLSStreaming(params?: HLSConfig): Promise<void>;
-  stopHLSStreaming(params?: HLSConfig): Promise<void>;
+  stopHLSStreaming(params?: StopHLSConfig): Promise<void>;
   startTranscription(params: TranscriptionConfig): Promise<void>;
   stopTranscription(params: TranscriptionConfig): Promise<void>;
   getRecordingState(): HMSRecording | undefined;

--- a/packages/hms-video-store/src/reactive-store/HMSSDKActions.ts
+++ b/packages/hms-video-store/src/reactive-store/HMSSDKActions.ts
@@ -715,7 +715,7 @@ export class HMSSDKActions<T extends HMSGenericTypes = { sessionStore: Record<st
     await this.sdk.startHLSStreaming(params);
   }
 
-  async stopHLSStreaming(params?: sdkTypes.HLSConfig): Promise<void> {
+  async stopHLSStreaming(params?: sdkTypes.StopHLSConfig): Promise<void> {
     await this.sdk.stopHLSStreaming(params);
   }
 

--- a/packages/hms-video-store/src/sdk/index.ts
+++ b/packages/hms-video-store/src/sdk/index.ts
@@ -44,7 +44,7 @@ import {
 } from '../interfaces';
 import { DeviceChangeListener } from '../interfaces/devices';
 import { IErrorListener } from '../interfaces/error-listener';
-import { HLSConfig, HLSTimedMetadata } from '../interfaces/hls-config';
+import { HLSConfig, HLSTimedMetadata, StopHLSConfig } from '../interfaces/hls-config';
 import { HMSInterface } from '../interfaces/hms';
 import { HMSLeaveRoomRequest } from '../interfaces/leave-room-request';
 import { HMSPeerListIteratorOptions } from '../interfaces/peer-list-iterator';
@@ -1170,7 +1170,7 @@ export class HMSSdk implements HMSInterface {
     await this.transport?.signal.startHLSStreaming(hlsParams);
   }
 
-  async stopHLSStreaming(params?: HLSConfig) {
+  async stopHLSStreaming(params?: StopHLSConfig) {
     if (!this.localPeer) {
       throw ErrorFactory.GenericErrors.NotConnected(
         HMSAction.VALIDATION,
@@ -1186,7 +1186,9 @@ export class HMSSdk implements HMSInterface {
           }
           return hlsVariant;
         }),
+        stop_reason: params.stop_reason,
       };
+
       await this.transport?.signal.stopHLSStreaming(hlsParams);
     }
     await this.transport?.signal.stopHLSStreaming();

--- a/packages/hms-video-store/src/signal/interfaces/superpowers.ts
+++ b/packages/hms-video-store/src/signal/interfaces/superpowers.ts
@@ -72,6 +72,7 @@ export interface HLSRequestParams {
     single_file_per_layer?: boolean; // false by default on server
     hls_vod?: boolean; // false by default on server
   };
+  stop_reason?: string;
 }
 
 export interface HLSTimedMetadataParams {

--- a/packages/roomkit-react/src/Prebuilt/components/Leave/LeaveRoom.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Leave/LeaveRoom.tsx
@@ -42,11 +42,11 @@ export const LeaveRoom = ({
   const isMobileHLSStream = useMobileHLSStream();
   const isLandscapeHLSStream = useLandscapeHLSStream();
 
-  const stopStream = async () => {
+  const stopStream = async (stop_reason = '') => {
     try {
       if (permissions?.hlsStreaming) {
         console.log('Stopping HLS stream');
-        await hmsActions.stopHLSStreaming();
+        await hmsActions.stopHLSStreaming({ stop_reason });
         ToastManager.addToast({ title: 'Stopping the stream' });
       }
     } catch (e) {

--- a/packages/roomkit-react/src/Prebuilt/components/Leave/LeaveRoom.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Leave/LeaveRoom.tsx
@@ -61,7 +61,7 @@ export const LeaveRoom = ({
 
   const leaveRoom = async (options: { endStream?: boolean } = { endStream: false }) => {
     if (options.endStream || (hlsState.running && peersWithStreamingRights.length === 1)) {
-      await stopStream();
+      await stopStream('last publisher left');
     }
     await hmsActions.leave();
   };


### PR DESCRIPTION
# Description

Added the option to send stop_reason while stopping HLS. Pending changes in biz and beam 

### Pre-launch Checklist

- [x] WS message being sent should contain the stop reason
