### PR TITLE
fix: use exact constraint for deviceId in getUserMedia calls

### DIFF
--- a/examples/prebuilt-react-integration/package.json
+++ b/examples/prebuilt-react-integration/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@100mslive/roomkit-react": "0.3.35",
+    "@100mslive/roomkit-react": "0.3.36-alpha.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/prebuilt-react-integration/package.json
+++ b/examples/prebuilt-react-integration/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@100mslive/roomkit-react": "0.3.36-alpha.0",
+    "@100mslive/roomkit-react": "0.3.36-alpha.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/hls-player/package.json
+++ b/packages/hls-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/hls-player",
-  "version": "0.3.36-alpha.0",
+  "version": "0.3.36-alpha.1",
   "description": "HLS client library which uses HTML5 Video element and Media Source Extension for playback",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
@@ -36,7 +36,7 @@
   "author": "100ms",
   "license": "MIT",
   "dependencies": {
-    "@100mslive/hls-stats": "0.4.36-alpha.0",
+    "@100mslive/hls-stats": "0.4.36-alpha.1",
     "eventemitter2": "^6.4.9",
     "hls.js": "1.4.12"
   },

--- a/packages/hls-player/package.json
+++ b/packages/hls-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/hls-player",
-  "version": "0.3.35",
+  "version": "0.3.36-alpha.0",
   "description": "HLS client library which uses HTML5 Video element and Media Source Extension for playback",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
@@ -36,7 +36,7 @@
   "author": "100ms",
   "license": "MIT",
   "dependencies": {
-    "@100mslive/hls-stats": "0.4.35",
+    "@100mslive/hls-stats": "0.4.36-alpha.0",
     "eventemitter2": "^6.4.9",
     "hls.js": "1.4.12"
   },

--- a/packages/hls-stats/package.json
+++ b/packages/hls-stats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/hls-stats",
-  "version": "0.4.35",
+  "version": "0.4.36-alpha.0",
   "description": "A simple library that provides stats for your hls stream",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/hls-stats/package.json
+++ b/packages/hls-stats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/hls-stats",
-  "version": "0.4.36-alpha.0",
+  "version": "0.4.36-alpha.1",
   "description": "A simple library that provides stats for your hls stream",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/hms-video-store/package.json
+++ b/packages/hms-video-store/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.12.36-alpha.0",
+  "version": "0.12.36-alpha.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/hms-video-store/package.json
+++ b/packages/hms-video-store/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.12.35",
+  "version": "0.12.36-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/hms-video-store/src/utils/track.ts
+++ b/packages/hms-video-store/src/utils/track.ts
@@ -5,8 +5,12 @@ import { HMSTrackExceptionTrackType } from '../media/tracks/HMSTrackExceptionTra
 
 export async function getAudioTrack(settings: HMSAudioTrackSettings): Promise<MediaStreamTrack> {
   try {
+    const audioConstraints = settings ? settings.toConstraints() : false;
+    if (audioConstraints && typeof audioConstraints === 'object' && settings?.deviceId) {
+      audioConstraints.deviceId = { exact: settings.deviceId };
+    }
     const stream = await navigator.mediaDevices.getUserMedia({
-      audio: settings ? settings.toConstraints() : false,
+      audio: audioConstraints,
     });
     return stream.getAudioTracks()[0];
   } catch (err) {
@@ -16,8 +20,12 @@ export async function getAudioTrack(settings: HMSAudioTrackSettings): Promise<Me
 
 export async function getVideoTrack(settings: HMSVideoTrackSettings): Promise<MediaStreamTrack> {
   try {
+    const videoConstraints = settings ? settings.toConstraints() : false;
+    if (videoConstraints && typeof videoConstraints === 'object' && settings?.deviceId) {
+      videoConstraints.deviceId = { exact: settings.deviceId };
+    }
     const stream = await navigator.mediaDevices.getUserMedia({
-      video: settings ? settings.toConstraints() : false,
+      video: videoConstraints,
     });
     return stream.getVideoTracks()[0];
   } catch (err) {

--- a/packages/hms-virtual-background/package.json
+++ b/packages/hms-virtual-background/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.13.36-alpha.0",
+  "version": "1.13.36-alpha.1",
   "license": "MIT",
   "name": "@100mslive/hms-virtual-background",
   "author": "100ms",
@@ -62,10 +62,10 @@
     "format": "prettier --write src/**/*.ts"
   },
   "peerDependencies": {
-    "@100mslive/hms-video-store": "0.12.36-alpha.0"
+    "@100mslive/hms-video-store": "0.12.36-alpha.1"
   },
   "devDependencies": {
-    "@100mslive/hms-video-store": "0.12.36-alpha.0"
+    "@100mslive/hms-video-store": "0.12.36-alpha.1"
   },
   "dependencies": {
     "@mediapipe/selfie_segmentation": "^0.1.1632777926",

--- a/packages/hms-virtual-background/package.json
+++ b/packages/hms-virtual-background/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.13.35",
+  "version": "1.13.36-alpha.0",
   "license": "MIT",
   "name": "@100mslive/hms-virtual-background",
   "author": "100ms",
@@ -62,10 +62,10 @@
     "format": "prettier --write src/**/*.ts"
   },
   "peerDependencies": {
-    "@100mslive/hms-video-store": "0.12.35"
+    "@100mslive/hms-video-store": "0.12.36-alpha.0"
   },
   "devDependencies": {
-    "@100mslive/hms-video-store": "0.12.35"
+    "@100mslive/hms-video-store": "0.12.36-alpha.0"
   },
   "dependencies": {
     "@mediapipe/selfie_segmentation": "^0.1.1632777926",

--- a/packages/hms-whiteboard/package.json
+++ b/packages/hms-whiteboard/package.json
@@ -2,7 +2,7 @@
   "name": "@100mslive/hms-whiteboard",
   "author": "100ms",
   "license": "MIT",
-  "version": "0.0.25",
+  "version": "0.0.26-alpha.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hms-whiteboard/package.json
+++ b/packages/hms-whiteboard/package.json
@@ -2,7 +2,7 @@
   "name": "@100mslive/hms-whiteboard",
   "author": "100ms",
   "license": "MIT",
-  "version": "0.0.26-alpha.0",
+  "version": "0.0.26-alpha.1",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "version": "0.10.36-alpha.0",
+  "version": "0.10.36-alpha.1",
   "author": "100ms",
   "license": "MIT",
   "repository": {

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "version": "0.10.35",
+  "version": "0.10.36-alpha.0",
   "author": "100ms",
   "license": "MIT",
   "repository": {

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "version": "0.10.35",
+  "version": "0.10.36-alpha.0",
   "author": "100ms",
   "license": "MIT",
   "repository": {
@@ -48,7 +48,7 @@
     "react": ">=16.8 <19.0.0"
   },
   "dependencies": {
-    "@100mslive/hms-video-store": "0.12.35",
+    "@100mslive/hms-video-store": "0.12.36-alpha.0",
     "react-resize-detector": "^7.0.0",
     "zustand": "^3.6.2"
   }

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "version": "0.10.36-alpha.0",
+  "version": "0.10.36-alpha.1",
   "author": "100ms",
   "license": "MIT",
   "repository": {
@@ -48,7 +48,7 @@
     "react": ">=16.8 <19.0.0"
   },
   "dependencies": {
-    "@100mslive/hms-video-store": "0.12.36-alpha.0",
+    "@100mslive/hms-video-store": "0.12.36-alpha.1",
     "react-resize-detector": "^7.0.0",
     "zustand": "^3.6.2"
   }

--- a/packages/roomkit-react/package.json
+++ b/packages/roomkit-react/package.json
@@ -10,7 +10,7 @@
     "prebuilt",
     "roomkit"
   ],
-  "version": "0.3.35",
+  "version": "0.3.36-alpha.0",
   "author": "100ms",
   "license": "MIT",
   "repository": {
@@ -75,12 +75,12 @@
     "react": ">=17.0.2 <19.0.0"
   },
   "dependencies": {
-    "@100mslive/hls-player": "0.3.35",
+    "@100mslive/hls-player": "0.3.36-alpha.0",
     "@100mslive/hms-noise-cancellation": "0.0.1",
-    "@100mslive/hms-virtual-background": "1.13.35",
-    "@100mslive/hms-whiteboard": "0.0.25",
-    "@100mslive/react-icons": "0.10.35",
-    "@100mslive/react-sdk": "0.10.35",
+    "@100mslive/hms-virtual-background": "1.13.36-alpha.0",
+    "@100mslive/hms-whiteboard": "0.0.26-alpha.0",
+    "@100mslive/react-icons": "0.10.36-alpha.0",
+    "@100mslive/react-sdk": "0.10.36-alpha.0",
     "@100mslive/types-prebuilt": "0.12.12",
     "@emoji-mart/data": "^1.0.6",
     "@emoji-mart/react": "^1.0.1",

--- a/packages/roomkit-react/package.json
+++ b/packages/roomkit-react/package.json
@@ -10,7 +10,7 @@
     "prebuilt",
     "roomkit"
   ],
-  "version": "0.3.36-alpha.0",
+  "version": "0.3.36-alpha.1",
   "author": "100ms",
   "license": "MIT",
   "repository": {
@@ -75,12 +75,12 @@
     "react": ">=17.0.2 <19.0.0"
   },
   "dependencies": {
-    "@100mslive/hls-player": "0.3.36-alpha.0",
+    "@100mslive/hls-player": "0.3.36-alpha.1",
     "@100mslive/hms-noise-cancellation": "0.0.1",
-    "@100mslive/hms-virtual-background": "1.13.36-alpha.0",
-    "@100mslive/hms-whiteboard": "0.0.26-alpha.0",
-    "@100mslive/react-icons": "0.10.36-alpha.0",
-    "@100mslive/react-sdk": "0.10.36-alpha.0",
+    "@100mslive/hms-virtual-background": "1.13.36-alpha.1",
+    "@100mslive/hms-whiteboard": "0.0.26-alpha.1",
+    "@100mslive/react-icons": "0.10.36-alpha.1",
+    "@100mslive/react-sdk": "0.10.36-alpha.1",
     "@100mslive/types-prebuilt": "0.12.12",
     "@emoji-mart/data": "^1.0.6",
     "@emoji-mart/react": "^1.0.1",

--- a/packages/roomkit-web/package.json
+++ b/packages/roomkit-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/roomkit-web",
-  "version": "0.2.36-alpha.0",
+  "version": "0.2.36-alpha.1",
   "description": "A web component implementation of 100ms Prebuilt component",
   "keywords": [
     "web-components",
@@ -33,7 +33,7 @@
     "build": "rm -rf dist && node ../../scripts/build-webapp"
   },
   "dependencies": {
-    "@100mslive/roomkit-react": "0.3.36-alpha.0",
+    "@100mslive/roomkit-react": "0.3.36-alpha.1",
     "@r2wc/react-to-web-component": "2.0.2"
   }
 }

--- a/packages/roomkit-web/package.json
+++ b/packages/roomkit-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/roomkit-web",
-  "version": "0.2.35",
+  "version": "0.2.36-alpha.0",
   "description": "A web component implementation of 100ms Prebuilt component",
   "keywords": [
     "web-components",
@@ -33,7 +33,7 @@
     "build": "rm -rf dist && node ../../scripts/build-webapp"
   },
   "dependencies": {
-    "@100mslive/roomkit-react": "0.3.35",
+    "@100mslive/roomkit-react": "0.3.36-alpha.0",
     "@r2wc/react-to-web-component": "2.0.2"
   }
 }


### PR DESCRIPTION
Modified getAudioTrack and getVideoTrack functions to use exact constraints when deviceId is specified. This ensures getUserMedia will use the specified device or fail, rather than falling back to a default device.

