### PR TITLE
added mute detection popup when user speaks while muted

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Notifications/MutedSpeechNotification.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Notifications/MutedSpeechNotification.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useRef, useState } from 'react';
+import { 
+  selectIsLocalAudioEnabled, 
+  selectLocalPeer, 
+  selectLocalAudioTrackID,
+  selectTrackAudioByID,
+  useHMSStore,
+  useHMSActions 
+} from '@100mslive/react-sdk';
+import { MicOffIcon } from '@100mslive/react-icons';
+import { ToastManager } from '../Toast/ToastManager';
+import { Button } from '../../../Button';
+import { Box } from '../../../Layout';
+
+interface MutedSpeechNotificationProps {
+  speechThreshold?: number;
+  speechDuration?: number;
+  cooldownPeriod?: number;
+  enabled?: boolean;
+  useBuiltInAudioLevel?: boolean;
+  customMessage?: string;
+  customDescription?: string;
+}
+
+export const MutedSpeechNotification = ({
+  speechThreshold = 25,
+  speechDuration = 2000,
+  cooldownPeriod = 10000,
+  enabled = true,
+  useBuiltInAudioLevel = true,
+  customMessage = "You're on mute. Do you want to say something?",
+  customDescription = "Please unmute to speak.",
+}: MutedSpeechNotificationProps) => {
+  const isLocalAudioEnabled = useHMSStore(selectIsLocalAudioEnabled);
+  const localPeer = useHMSStore(selectLocalPeer);
+  const localAudioTrackID = useHMSStore(selectLocalAudioTrackID);
+  const audioLevel = useHMSStore(selectTrackAudioByID(localAudioTrackID));
+  const hmsActions = useHMSActions();
+  
+  const [isDetecting, setIsDetecting] = useState(false);
+  const [speechStartTime, setSpeechStartTime] = useState<number | null>(null);
+  const [lastNotificationTime, setLastNotificationTime] = useState<number>(0);
+  const [customAudioLevel, setCustomAudioLevel] = useState<number>(0);
+  
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const mediaStreamSourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
+  const animationFrameRef = useRef<number | null>(null);
+  const speechTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const currentAudioLevel = useBuiltInAudioLevel ? (audioLevel || 0) : customAudioLevel;
+
+  useEffect(() => {
+    if (!enabled || useBuiltInAudioLevel || !localPeer?.audioTrack) return;
+
+    const initializeAudioAnalysis = async () => {
+      try {
+        audioContextRef.current = new (window.AudioContext || (window as any).webkitAudioContext)();
+        const stream = new MediaStream([localPeer.audioTrack.nativeTrack]);
+        analyserRef.current = audioContextRef.current.createAnalyser();
+        analyserRef.current.fftSize = 2048;
+        analyserRef.current.smoothingTimeConstant = 0.8;
+        mediaStreamSourceRef.current = audioContextRef.current.createMediaStreamSource(stream);
+        mediaStreamSourceRef.current.connect(analyserRef.current);
+        startCustomAudioMonitoring();
+      } catch (error) {
+        console.warn('Failed to initialize custom audio analysis for muted speech detection:', error);
+      }
+    };
+
+    initializeAudioAnalysis();
+
+    return () => {
+      cleanup();
+    };
+  }, [enabled, useBuiltInAudioLevel, localPeer?.audioTrack]);
+
+  const startCustomAudioMonitoring = () => {
+    if (!analyserRef.current) return;
+
+    const dataArray = new Uint8Array(analyserRef.current.frequencyBinCount);
+    
+    const monitorAudio = () => {
+      if (!analyserRef.current || !enabled) return;
+
+      analyserRef.current.getByteFrequencyData(dataArray);
+      let sum = 0;
+      for (let i = 0; i < dataArray.length; i++) {
+        sum += dataArray[i] * dataArray[i];
+      }
+      const rms = Math.sqrt(sum / dataArray.length);
+      const normalizedLevel = (rms / 255) * 100;
+      
+      setCustomAudioLevel(normalizedLevel);
+      
+      if (normalizedLevel > speechThreshold) {
+        handleSpeechDetected();
+      } else {
+        handleSpeechStopped();
+      }
+      
+      animationFrameRef.current = requestAnimationFrame(monitorAudio);
+    };
+
+    monitorAudio();
+  };
+
+  useEffect(() => {
+    if (!enabled || useBuiltInAudioLevel || isLocalAudioEnabled) return;
+
+    if (currentAudioLevel > speechThreshold) {
+      handleSpeechDetected();
+    } else {
+      handleSpeechStopped();
+    }
+  }, [currentAudioLevel, enabled, useBuiltInAudioLevel, isLocalAudioEnabled, speechThreshold]);
+
+  const handleSpeechDetected = () => {
+    if (!enabled || isLocalAudioEnabled) return;
+
+    const now = Date.now();
+    if (now - lastNotificationTime < cooldownPeriod) return;
+
+    if (!isDetecting) {
+      setIsDetecting(true);
+      setSpeechStartTime(now);
+      speechTimeoutRef.current = setTimeout(() => {
+        if (isDetecting && !isLocalAudioEnabled) {
+          showMutedSpeechNotification();
+          setLastNotificationTime(now);
+        }
+      }, speechDuration);
+    }
+  };
+
+  const handleSpeechStopped = () => {
+    if (speechTimeoutRef.current) {
+      clearTimeout(speechTimeoutRef.current);
+      speechTimeoutRef.current = null;
+    }
+    setIsDetecting(false);
+    setSpeechStartTime(null);
+  };
+
+  const showMutedSpeechNotification = () => {
+    const notificationId = ToastManager.addToast({
+      title: customMessage,
+      description: customDescription,
+      icon: <MicOffIcon />,
+      variant: 'warning',
+      duration: 8000,
+      action: (
+        <Box css={{ display: 'flex', gap: '$2' }}>
+          <Button
+            size="sm"
+            variant="primary"
+            onClick={() => {
+              hmsActions.setLocalAudioEnabled(true);
+              ToastManager.removeToast(notificationId);
+            }}
+          >
+            Unmute
+          </Button>
+          <Button
+            size="sm"
+            variant="standard"
+            onClick={() => ToastManager.removeToast(notificationId)}
+          >
+            Dismiss
+          </Button>
+        </Box>
+      ),
+    });
+  };
+
+  const cleanup = () => {
+    if (speechTimeoutRef.current) {
+      clearTimeout(speechTimeoutRef.current);
+    }
+    if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current);
+    }
+    if (mediaStreamSourceRef.current) {
+      mediaStreamSourceRef.current.disconnect();
+    }
+    if (audioContextRef.current) {
+      audioContextRef.current.close();
+    }
+  };
+
+  return null;
+};
+
+export default MutedSpeechNotification;

--- a/packages/roomkit-react/src/Prebuilt/components/Notifications/Notifications.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Notifications/Notifications.tsx
@@ -20,6 +20,7 @@ import { TrackBulkUnmuteModal } from './TrackBulkUnmuteModal';
 import { TrackNotifications } from './TrackNotifications';
 import { TrackUnmuteModal } from './TrackUnmuteModal';
 import { TranscriptionNotifications } from './TranscriptionNotifications';
+import { MutedSpeechNotification } from './MutedSpeechNotification';
 // @ts-ignore: No implicit Any
 import { useIsNotificationDisabled } from '../AppData/useUISettings';
 import { ROLE_CHANGE_DECLINED } from '../../common/constants';
@@ -59,6 +60,7 @@ export function Notifications() {
       <ChatNotifications />
       <HandRaisedNotifications />
       <TranscriptionNotifications />
+      <MutedSpeechNotification />
       <DeviceInUseError />
     </>
   );


### PR DESCRIPTION
**Title:**
feat: Add muted speech detection popup

**Description:**
This PR adds a feature to detect when a participant in a meeting is speaking while their microphone is muted. When speech is detected, a non-intrusive popup notification appears with the message:

"You’re on mute. Do you want to say something? Please unmute."

**Changes included:**

Monitors local audio levels using built-in or custom audio analysis.

Tracks speech duration and applies a cooldown period before showing notifications.

Displays a toast notification with Unmute and Dismiss actions.

Handles cleanup of audio contexts and timers to prevent memory leaks.

**How to test:**

Join a meeting with the SDK.

Mute your microphone.

Start speaking.

Verify that the popup appears after speech is detected.

Test both Unmute and Dismiss buttons to ensure correct behavior.

**Additional notes:**

This improves UX by reminding participants they are muted without being intrusive.

Works with both built-in audio level monitoring and custom audio analysis for maximum flexibility.

<!-- Links -->

[Documentation]: https://www.100ms.live/docs