### PR TITLE
fix: publish analytics causing leave failure 

### DIFF
--- a/packages/hms-video-store/src/analytics/stats/BaseStatsAnalytics.ts
+++ b/packages/hms-video-store/src/analytics/stats/BaseStatsAnalytics.ts
@@ -42,13 +42,13 @@ export abstract class BaseStatsAnalytics {
     this.startLoop().catch(e => HMSLogger.e('[StatsAnalytics]', e.message));
   }
 
-  stop = () => {
+  stop() {
     if (this.shouldSendEvent) {
       this.sendEvent();
     }
     this.eventBus.statsUpdate.unsubscribe(this.handleStatsUpdate.bind(this));
     this.shouldSendEvent = false;
-  };
+  }
 
   private async startLoop() {
     while (this.shouldSendEvent) {

--- a/packages/hms-video-store/src/analytics/stats/PublishStatsAnalytics.ts
+++ b/packages/hms-video-store/src/analytics/stats/PublishStatsAnalytics.ts
@@ -53,10 +53,10 @@ export class PublishStatsAnalytics extends BaseStatsAnalytics {
     super.sendEvent();
   }
 
-  stop = () => {
+  stop() {
     super.stop();
     this.cpuPressureMonitor?.stop();
-  };
+  }
 
   protected handleStatsUpdate(hmsStats: HMSWebrtcStats) {
     let shouldCreateSample = false;


### PR DESCRIPTION
…() call

Arrow function class properties are assigned to the instance, not the prototype. This means super.stop() doesn't work because super looks up the prototype chain. Converting stop to a regular method fixes the TypeError on leave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Description

_Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots._

_List which issues are fixed by this PR. You must list at least one issue._

---

## Implementation note, gotchas, related work and Future TODOs (optional)

<!-- Add any other context or additional information about the pull request.-->

-

### Pre-launch Checklist

- [ ] The [Documentation] is updated accordingly, or this PR doesn't require it.
- [ ] I updated/added relevant documentation.
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making, or this PR is test-exempt.
- [ ] All existing and new tests are passing.

### Merging:
- Squash merge to dev
- Merge commit to publish-alpha and main

<!-- Links -->

[Documentation]: https://www.100ms.live/docs