### PR TITLE
fix: add scoped minimatch resolution for nx/devkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,8 +81,6 @@
     "**/eslint/minimatch": "^3.1.4",
     "**/babel-plugin-istanbul/test-exclude/minimatch": "^3.1.4",
     "**/typedoc/minimatch": "^9.0.7",
-    "**/nx/minimatch": "^9.0.7",
-    "**/@nx/devkit/minimatch": "^9.0.7",
     "picomatch": "^2.3.2",
     "**/tinyglobby/picomatch": "^4.0.4",
     "@tootallnate/once": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -81,6 +81,8 @@
     "**/eslint/minimatch": "^3.1.4",
     "**/babel-plugin-istanbul/test-exclude/minimatch": "^3.1.4",
     "**/typedoc/minimatch": "^9.0.7",
+    "**/nx/minimatch": "^9.0.7",
+    "**/@nx/devkit/minimatch": "^9.0.7",
     "picomatch": "^2.3.2",
     "**/tinyglobby/picomatch": "^4.0.4",
     "@tootallnate/once": "^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10331,12 +10331,12 @@ minimatch@3.1.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@9.0.3, minimatch@^9.0.0, minimatch@^9.0.7:
-  version "9.0.9"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
-  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
+minimatch@9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
+  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
   dependencies:
-    brace-expansion "^2.0.2"
+    brace-expansion "^2.0.1"
 
 minimatch@^10.0.3, minimatch@^10.1.1:
   version "10.2.5"
@@ -10351,6 +10351,13 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2, minimatc
   integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^9.0.0, minimatch@^9.0.7:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
+  dependencies:
+    brace-expansion "^2.0.2"
 
 minimist-options@4.1.0:
   version "4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10331,12 +10331,12 @@ minimatch@3.1.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@9.0.3:
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
-  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
+minimatch@9.0.3, minimatch@^9.0.0, minimatch@^9.0.7:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
   dependencies:
-    brace-expansion "^2.0.1"
+    brace-expansion "^2.0.2"
 
 minimatch@^10.0.3, minimatch@^10.1.1:
   version "10.2.5"
@@ -10351,13 +10351,6 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2, minimatc
   integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
-
-minimatch@^9.0.0, minimatch@^9.0.7:
-  version "9.0.9"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
-  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
-  dependencies:
-    brace-expansion "^2.0.2"
 
 minimist-options@4.1.0:
   version "4.1.0"


### PR DESCRIPTION
## Summary
- Add scoped yarn resolutions for `**/nx/minimatch` and `**/@nx/devkit/minimatch` to `^9.0.7`
- Resolves dependabot  (minimatch >= 9.0.0, < 9.0.7)

## Test plan
- [x] `yarn build` passes (all 10 projects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)