### PR TITLE
fix: replace prettier with lint:fix in svg-build for idempotent builds

### DIFF
--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -24,7 +24,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "svg-build": "svgr --icon --typescript --replace-attr-values '#fff=currentColor' --svg-props width='24px' --svg-props height='24px' -d src assets && yarn format",
+    "svg-build": "svgr --icon --typescript --replace-attr-values '#fff=currentColor' --svg-props width='24px' --svg-props height='24px' -d src assets && yarn lint:fix",
     "build": "yarn svg-build && node ../../scripts/build.js && yarn types:build",
     "types:build": "tsc -p tsconfig.json",
     "format": "prettier -w src/**",


### PR DESCRIPTION
## Summary
- Replace `yarn format` (prettier) with `yarn lint:fix` (eslint --fix) in the `svg-build` script
- eslint already runs prettier via the prettier plugin, so the separate step was redundant
- This ensures import sorting is applied after svgr generation, making builds idempotent

## Test plan
- [x] `yarn build` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)