### PR TITLE
fix: skip stale alpha versions when stable is already released

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -35,36 +35,7 @@ jobs:
 
       - name: Sync prerelease base with npm
         if: github.event.inputs.versionBump == 'prerelease'
-        run: |
-          # Set all package versions to their latest npm alpha so lerna increments from there.
-          # If stable >= alpha base (e.g. 0.13.3 stable, 0.13.3-alpha.16), skip the alpha
-          # so lerna bumps from stable to the next prerelease (0.13.4-alpha.0).
-          node -e "
-            const { execSync } = require('child_process');
-            const fs = require('fs');
-            const glob = require('glob');
-            const semver = require('semver');
-            const pkgs = glob.sync('packages/*/package.json');
-            for (const p of pkgs) {
-              const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
-              if (pkg.private) continue;
-              try {
-                const alpha = execSync('npm view ' + pkg.name + ' dist-tags.alpha 2>/dev/null', { encoding: 'utf8' }).trim();
-                const latest = execSync('npm view ' + pkg.name + ' dist-tags.latest 2>/dev/null', { encoding: 'utf8' }).trim();
-                if (!alpha) continue;
-                // Compare the base version of the alpha (without prerelease tag) against latest stable
-                const alphaBase = semver.coerce(alpha)?.version;
-                if (latest && alphaBase && semver.gte(latest, alphaBase)) {
-                  // Stable already released at or beyond the alpha base, let lerna bump from stable
-                  console.log(pkg.name + ': skipping alpha ' + alpha + ' (stable ' + latest + ' already released)');
-                  continue;
-                }
-                console.log(pkg.name + ': ' + pkg.version + ' -> ' + alpha);
-                pkg.version = alpha;
-                fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');
-              } catch(e) {}
-            }
-          "
+        run: node scripts/sync-prerelease-versions.js
 
       - name: Update versions
         env:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -36,22 +36,32 @@ jobs:
       - name: Sync prerelease base with npm
         if: github.event.inputs.versionBump == 'prerelease'
         run: |
-          # Set all package versions to their latest npm alpha so lerna increments from there
+          # Set all package versions to their latest npm alpha so lerna increments from there.
+          # If stable >= alpha base (e.g. 0.13.3 stable, 0.13.3-alpha.16), skip the alpha
+          # so lerna bumps from stable to the next prerelease (0.13.4-alpha.0).
           node -e "
             const { execSync } = require('child_process');
             const fs = require('fs');
             const glob = require('glob');
+            const semver = require('semver');
             const pkgs = glob.sync('packages/*/package.json');
             for (const p of pkgs) {
               const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
               if (pkg.private) continue;
               try {
                 const alpha = execSync('npm view ' + pkg.name + ' dist-tags.alpha 2>/dev/null', { encoding: 'utf8' }).trim();
-                if (alpha) {
-                  console.log(pkg.name + ': ' + pkg.version + ' -> ' + alpha);
-                  pkg.version = alpha;
-                  fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');
+                const latest = execSync('npm view ' + pkg.name + ' dist-tags.latest 2>/dev/null', { encoding: 'utf8' }).trim();
+                if (!alpha) continue;
+                // Compare the base version of the alpha (without prerelease tag) against latest stable
+                const alphaBase = semver.coerce(alpha)?.version;
+                if (latest && alphaBase && semver.gte(latest, alphaBase)) {
+                  // Stable already released at or beyond the alpha base, let lerna bump from stable
+                  console.log(pkg.name + ': skipping alpha ' + alpha + ' (stable ' + latest + ' already released)');
+                  continue;
                 }
+                console.log(pkg.name + ': ' + pkg.version + ' -> ' + alpha);
+                pkg.version = alpha;
+                fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');
               } catch(e) {}
             }
           "

--- a/scripts/sync-prerelease-versions.js
+++ b/scripts/sync-prerelease-versions.js
@@ -1,0 +1,43 @@
+/**
+ * Syncs package versions with the latest npm alpha tag so lerna
+ * increments from the correct base (e.g. alpha.5 -> alpha.6).
+ *
+ * Skips packages where the stable release is already at or beyond
+ * the alpha base version (e.g. stable 0.13.3, alpha 0.13.3-alpha.16)
+ * so lerna bumps to the next minor prerelease (0.13.4-alpha.0).
+ */
+const { execSync } = require('child_process');
+const fs = require('fs');
+const glob = require('glob');
+const semver = require('semver');
+
+const pkgs = glob.sync('packages/*/package.json');
+
+for (const p of pkgs) {
+  const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
+  if (pkg.private) {
+    continue;
+  }
+
+  try {
+    const tags = JSON.parse(execSync(`npm view ${pkg.name} dist-tags --json 2>/dev/null`, { encoding: 'utf8' }));
+    const alpha = tags.alpha;
+    const latest = tags.latest;
+
+    if (!alpha) {
+      continue;
+    }
+
+    const alphaBase = semver.coerce(alpha)?.version;
+    if (latest && alphaBase && semver.gte(latest, alphaBase)) {
+      console.log(`${pkg.name}: skip alpha ${alpha} (stable ${latest} already released)`);
+      continue;
+    }
+
+    console.log(`${pkg.name}: ${pkg.version} -> ${alpha}`);
+    pkg.version = alpha;
+    fs.writeFileSync(p, `${JSON.stringify(pkg, null, 2)}\n`);
+  } catch (e) {
+    // package not on npm yet, skip
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes the Create Release PR workflow to correctly bump prerelease versions when stable is already published
- When stable `0.13.3` exists and alpha tag points to `0.13.3-alpha.16`, the sync step now skips the stale alpha so lerna bumps to `0.13.4-alpha.0` instead of `0.13.3-alpha.17`

## Test plan
- [ ] Run Create Release PR with `prerelease` after a stable release and verify versions bump to `X.Y.(Z+1)-alpha.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)