### PR TITLE
fix(hms-video-store): stop counting ICE/RTCP/BWE traffic in Publish Bitrate

### DIFF
--- a/packages/hms-video-store/src/interfaces/webrtc-stats.ts
+++ b/packages/hms-video-store/src/interfaces/webrtc-stats.ts
@@ -123,6 +123,12 @@ export interface HMSTrackStats extends HMSLocalTrackStats, HMSRemoteTrackStats {
 export interface HMSPeerStats {
   publish?: RTCIceCandidatePairStats & {
     bitrate: number;
+    /**
+     * Sum of `bytesSent` across active outbound-rtp streams at the time the stat was taken.
+     * Used internally to derive `bitrate` on the next sample so the value only reflects
+     * actual media traffic, not ICE/RTCP/BWE probe padding (LIV-243).
+     */
+    outboundRtpBytesSent?: number;
   };
   subscribe?: RTCIceCandidatePairStats & {
     bitrate: number;

--- a/packages/hms-video-store/src/rtc-stats/utils.test.ts
+++ b/packages/hms-video-store/src/rtc-stats/utils.test.ts
@@ -1,5 +1,5 @@
-import { HMSPeerStats } from '../../interfaces';
-import { getLocalPeerStatsFromReport } from '../../rtc-stats/utils';
+import { getLocalPeerStatsFromReport } from './utils';
+import { HMSPeerStats } from '../interfaces';
 
 type StatEntry = Record<string, any>;
 

--- a/packages/hms-video-store/src/rtc-stats/utils.ts
+++ b/packages/hms-video-store/src/rtc-stats/utils.ts
@@ -363,19 +363,48 @@ const buildMediaSourceStats = (
   };
 };
 
+export const sumOutboundRtpBytesSent = (report?: RTCStatsReport): number => {
+  let total = 0;
+  report?.forEach(stat => {
+    if (stat.type === 'outbound-rtp') {
+      total += stat.bytesSent || 0;
+    }
+  });
+  return total;
+};
+
 export const getLocalPeerStatsFromReport = (
   type: PeerConnectionType,
   report?: RTCStatsReport,
   prevStats?: HMSPeerStats,
-): (RTCIceCandidatePairStats & { bitrate: number }) | undefined => {
+): (RTCIceCandidatePairStats & { bitrate: number; outboundRtpBytesSent?: number }) | undefined => {
   const activeCandidatePair = getActiveCandidatePairFromReport(report);
-  const bitrate = computeBitrate(
-    (type === 'publish' ? 'bytesSent' : 'bytesReceived') as any,
-    activeCandidatePair,
-    prevStats && prevStats[type],
-  );
+  if (!activeCandidatePair) {
+    return undefined;
+  }
 
-  return activeCandidatePair && Object.assign(activeCandidatePair, { bitrate });
+  if (type === 'publish') {
+    // Compute publish bitrate from the sum of `bytesSent` across active outbound-rtp streams,
+    // not from the ICE candidate pair. The candidate pair's `bytesSent` also counts RTCP,
+    // STUN keepalives, and BWE probe padding — on Chrome and Firefox that's ~1 Mbps of
+    // phantom traffic even when nothing is being published, which surfaced as a wrong
+    // "Publish Bitrate" in Stats for Nerds (LIV-243). Candidate-pair `bytesSent` is kept
+    // on the returned object so "Total Bytes Sent" still reflects transport totals.
+    const outboundRtpBytesSent = sumOutboundRtpBytesSent(report);
+    const prevOutboundRtpBytesSent = prevStats?.publish?.outboundRtpBytesSent;
+    const bitrate =
+      prevOutboundRtpBytesSent !== undefined
+        ? computeBitrate(
+            'bytesSent' as any,
+            { bytesSent: outboundRtpBytesSent, timestamp: activeCandidatePair.timestamp } as any,
+            { bytesSent: prevOutboundRtpBytesSent, timestamp: prevStats?.publish?.timestamp } as any,
+          )
+        : 0;
+    return Object.assign(activeCandidatePair, { bitrate, outboundRtpBytesSent });
+  }
+
+  const bitrate = computeBitrate('bytesReceived' as any, activeCandidatePair, prevStats && prevStats[type]);
+  return Object.assign(activeCandidatePair, { bitrate });
 };
 
 export const getActiveCandidatePairFromReport = (report?: RTCStatsReport): RTCIceCandidatePairStats | undefined => {

--- a/packages/hms-video-store/src/test/unit/getLocalPeerStatsFromReport.test.ts
+++ b/packages/hms-video-store/src/test/unit/getLocalPeerStatsFromReport.test.ts
@@ -1,0 +1,126 @@
+import { HMSPeerStats } from '../../interfaces';
+import { getLocalPeerStatsFromReport } from '../../rtc-stats/utils';
+
+type StatEntry = Record<string, any>;
+
+// Minimal RTCStatsReport-like fake: iterable via `forEach` and lookup-able via `get`, which is
+// all the SUT uses. We avoid depending on a real RTCStatsReport (not available in jsdom).
+const makeReport = (entries: StatEntry[]): RTCStatsReport => {
+  const map = new Map<string, StatEntry>(entries.map(e => [e.id as string, e]));
+  return map as unknown as RTCStatsReport;
+};
+
+const transport = (selectedCandidatePairId: string): StatEntry => ({
+  id: 'T1',
+  type: 'transport',
+  selectedCandidatePairId,
+});
+
+const candidatePair = (bytesSent: number, timestamp: number, extra: Partial<StatEntry> = {}): StatEntry => ({
+  id: 'CP1',
+  type: 'candidate-pair',
+  selected: true,
+  bytesSent,
+  bytesReceived: 0,
+  timestamp,
+  availableOutgoingBitrate: 1_000_000,
+  ...extra,
+});
+
+const outboundRtp = (bytesSent: number, timestamp: number, id = 'O1'): StatEntry => ({
+  id,
+  type: 'outbound-rtp',
+  bytesSent,
+  timestamp,
+});
+
+describe('getLocalPeerStatsFromReport — publish bitrate (LIV-243)', () => {
+  test('returns bitrate 0 when nothing is being published, even if candidate-pair bytesSent is large (BWE probing)', () => {
+    // Candidate-pair bytesSent jumps by 125_000 B/s (= 1 Mbps of phantom probing),
+    // but no outbound-rtp streams exist — bitrate must be 0.
+    const t0 = 1_000_000;
+    const t1 = t0 + 1000; // 1s later
+
+    const prevReport = makeReport([transport('CP1'), candidatePair(0, t0)]);
+    const prevStats = getLocalPeerStatsFromReport('publish', prevReport, undefined);
+
+    const nextReport = makeReport([transport('CP1'), candidatePair(125_000, t1)]);
+    const nextStats = getLocalPeerStatsFromReport('publish', nextReport, {
+      publish: prevStats,
+    } as HMSPeerStats);
+
+    expect(nextStats).toBeDefined();
+    expect(nextStats!.bitrate).toBe(0);
+    // Transport-level bytes are still reported on the pair so "Total Bytes Sent" stays correct.
+    expect(nextStats!.bytesSent).toBe(125_000);
+  });
+
+  test('returns bitrate derived from outbound-rtp bytesSent delta when publishing real media', () => {
+    const t0 = 2_000_000;
+    const t1 = t0 + 1000; // 1s later
+    // 1 Mbps of actual media = 125_000 bytes/s on outbound-rtp
+    const prevReport = makeReport([transport('CP1'), candidatePair(200_000, t0), outboundRtp(0, t0)]);
+    const prevStats = getLocalPeerStatsFromReport('publish', prevReport, undefined);
+
+    const nextReport = makeReport([transport('CP1'), candidatePair(350_000, t1), outboundRtp(125_000, t1)]);
+    const nextStats = getLocalPeerStatsFromReport('publish', nextReport, {
+      publish: prevStats,
+    } as HMSPeerStats);
+
+    expect(nextStats).toBeDefined();
+    // 125_000 bytes/s over 1s → 1 Mbps
+    expect(nextStats!.bitrate).toBe(1_000_000);
+  });
+
+  test('sums bytesSent across simulcast layers', () => {
+    const t0 = 3_000_000;
+    const t1 = t0 + 1000;
+    const prevReport = makeReport([
+      transport('CP1'),
+      candidatePair(100_000, t0),
+      outboundRtp(0, t0, 'O-high'),
+      outboundRtp(0, t0, 'O-mid'),
+      outboundRtp(0, t0, 'O-low'),
+    ]);
+    const prevStats = getLocalPeerStatsFromReport('publish', prevReport, undefined);
+
+    const nextReport = makeReport([
+      transport('CP1'),
+      candidatePair(300_000, t1),
+      outboundRtp(80_000, t1, 'O-high'),
+      outboundRtp(30_000, t1, 'O-mid'),
+      outboundRtp(15_000, t1, 'O-low'),
+    ]);
+    const nextStats = getLocalPeerStatsFromReport('publish', nextReport, {
+      publish: prevStats,
+    } as HMSPeerStats);
+
+    // (80k + 30k + 15k) = 125k bytes/s = 1 Mbps
+    expect(nextStats!.bitrate).toBe(1_000_000);
+  });
+
+  test('first sample (no prev) reports bitrate 0 rather than extrapolating from zero baseline', () => {
+    const report = makeReport([transport('CP1'), candidatePair(500_000, 4_000_000), outboundRtp(250_000, 4_000_000)]);
+    const stats = getLocalPeerStatsFromReport('publish', report, undefined);
+    expect(stats).toBeDefined();
+    expect(stats!.bitrate).toBe(0);
+    expect(stats!.outboundRtpBytesSent).toBe(250_000);
+  });
+});
+
+describe('getLocalPeerStatsFromReport — subscribe bitrate', () => {
+  test('subscribe bitrate still comes from candidate-pair bytesReceived delta (unchanged behavior)', () => {
+    const t0 = 5_000_000;
+    const t1 = t0 + 1000;
+    const prevReport = makeReport([transport('CP1'), { ...candidatePair(0, t0), bytesReceived: 0 }]);
+    const prevStats = getLocalPeerStatsFromReport('subscribe', prevReport, undefined);
+
+    const nextReport = makeReport([transport('CP1'), { ...candidatePair(0, t1), bytesReceived: 125_000 }]);
+    const nextStats = getLocalPeerStatsFromReport('subscribe', nextReport, {
+      subscribe: prevStats,
+    } as HMSPeerStats);
+
+    expect(nextStats).toBeDefined();
+    expect(nextStats!.bitrate).toBe(1_000_000);
+  });
+});


### PR DESCRIPTION
## Summary

Stats for Nerds was showing a phantom **Publish Bitrate ~900 Kb/s on Chrome** (~1.28 Mb/s on Firefox, per [LIV-243](https://100ms.atlassian.net/browse/LIV-243)) while mic + cam were muted and no tracks were being published. Per-tile video/audio bitrates correctly showed 0 — only the top-level Publish Bitrate was wrong.

### Root cause

`getLocalPeerStatsFromReport` in `packages/hms-video-store/src/rtc-stats/utils.ts` derives Publish Bitrate from the active **ICE candidate pair**'s `bytesSent`. That field counts everything going over the transport: STUN keepalives, RTCP feedback, and — the bulk of it — **BWE probe padding**. BWE continuously probes up to `availableOutgoingBitrate`, which is why the phantom Publish Bitrate tracked Available Outgoing Bitrate almost exactly in our repro (912 Kb/s vs 953 Kb/s).

### Fix

For `type === 'publish'`, compute `bitrate` from the sum of `bytesSent` across active `outbound-rtp` streams instead. Those are only non-zero when real media is being sent.

- Candidate pair's `bytesSent` stays on the returned object → `Total Bytes Sent` (a transport metric) is unchanged.
- `availableOutgoingBitrate` / RTT / `totalBytesSent` continue to come from the candidate pair.
- Subscribe bitrate is unchanged — subscribe-side `bytesReceived` on the candidate pair is dominated by real media, not probing.
- A new `outboundRtpBytesSent` field is stashed on the returned object so the next sample can compute its delta.

### Test plan

5 new unit tests in `packages/hms-video-store/src/test/unit/getLocalPeerStatsFromReport.test.ts` — all pass locally:

- [x] Publish with no outbound-rtp streams + large candidate-pair `bytesSent` delta → `bitrate === 0` (the LIV-243 case)
- [x] Publish with 1 Mbps of outbound-rtp → `bitrate === 1_000_000`
- [x] Simulcast sums across layers
- [x] First sample (no prev) → `bitrate === 0` (no extrapolation)
- [x] Subscribe bitrate unchanged — still from candidate-pair `bytesReceived` delta

Manual repro with this branch: open a preview with mic + cam muted, open Stats for Nerds → Publish Bitrate should read 0 b/s instead of ~900 Kb/s.

### Ref

- LIV-243
- Filed by Anshul Malik; reproduced on Chrome + Firefox on both QA and prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIV-243]: https://100ms.atlassian.net/browse/LIV-243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ