### PR TITLE
ci: use DOCKER_GIT_TOKEN for 100ms-links dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,7 +112,7 @@ jobs:
         if: success()
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.DOCKER_GIT_TOKEN }}
           repository: 100mslive/100ms-links
           event-type: alpha-publish
           client-payload: '{"bump": "${{ github.event.inputs.publishFlag }}"}'


### PR DESCRIPTION
## Summary
`publish.yml` → `notify_100ms_links` has been failing with "Bad credentials" on every alpha/latest publish because `secrets.PAT` is stale/revoked. This switches the token to `secrets.DOCKER_GIT_TOKEN`, which already has the required repo-write scope and is used successfully elsewhere in the same workflow file.

Once this merges, the downstream `alpha-publish` repository_dispatch into `100mslive/100ms-links` should fire automatically, removing the manual `create-release-pr.yml` trigger we've been doing after each publish.

## Test plan
- [ ] Next alpha publish from `update-noise-cancellation-alpha` (or any other release branch) completes without the notify_100ms_links step failing
- [ ] A `build: updated sdk versions` PR auto-appears in `100mslive/100ms-links` within a minute of publish