### PR TITLE
fix(audio): surface setSinkId failure and recover auto-paused tracks on output device change

### DIFF
--- a/packages/hms-video-store/src/audio-sink-manager/AudioSinkManager.ts
+++ b/packages/hms-video-store/src/audio-sink-manager/AudioSinkManager.ts
@@ -248,6 +248,19 @@ export class AudioSinkManager {
     await Promise.all(promises);
   };
 
+  /**
+   * Public entry point for re-driving any tracks that got auto-paused by an OS
+   * audio-session interruption (headset removal, incoming call, Bluetooth swap).
+   *
+   * Needed because the user-initiated output-device-change path (AudioOutputManager.setDevice)
+   * does not publish to eventBus.deviceChange, and even if it did, handleAudioDeviceChange
+   * short-circuits on isUserSelection — leaving autoPausedTracks stuck until an
+   * automatic devicechange event happens to fire. See LIV-254.
+   */
+  recoverAutoPausedTracks = async () => {
+    await this.unpauseAudioTracks();
+  };
+
   private removeAudioElement = (audioEl: HTMLAudioElement, track: HMSRemoteAudioTrack) => {
     if (audioEl) {
       HMSLogger.d(this.TAG, 'removing audio element', `${track}`);

--- a/packages/hms-video-store/src/audio-sink-manager/AudioSinkManager.ts
+++ b/packages/hms-video-store/src/audio-sink-manager/AudioSinkManager.ts
@@ -248,19 +248,6 @@ export class AudioSinkManager {
     await Promise.all(promises);
   };
 
-  /**
-   * Public entry point for re-driving any tracks that got auto-paused by an OS
-   * audio-session interruption (headset removal, incoming call, Bluetooth swap).
-   *
-   * Needed because the user-initiated output-device-change path (AudioOutputManager.setDevice)
-   * does not publish to eventBus.deviceChange, and even if it did, handleAudioDeviceChange
-   * short-circuits on isUserSelection — leaving autoPausedTracks stuck until an
-   * automatic devicechange event happens to fire. See LIV-254.
-   */
-  recoverAutoPausedTracks = async () => {
-    await this.unpauseAudioTracks();
-  };
-
   private removeAudioElement = (audioEl: HTMLAudioElement, track: HMSRemoteAudioTrack) => {
     if (audioEl) {
       HMSLogger.d(this.TAG, 'removing audio element', `${track}`);

--- a/packages/hms-video-store/src/device-manager/AudioOutputManager.ts
+++ b/packages/hms-video-store/src/device-manager/AudioOutputManager.ts
@@ -1,5 +1,6 @@
 import { DeviceManager } from './DeviceManager';
 import { AudioSinkManager } from '../audio-sink-manager';
+import HMSLogger from '../utils/logger';
 import { HMSAudioContextHandler } from '../utils/media';
 
 export interface IAudioOutputManager {
@@ -36,7 +37,17 @@ export class AudioOutputManager implements IAudioOutputManager {
       // the unpause path explicitly — the eventBus.deviceChange subscription
       // guards `isUserSelection` out, so unpauseAudioTracks never fires here
       // otherwise. See LIV-254.
-      await this.audioSinkManager.recoverAutoPausedTracks();
+      //
+      // Best-effort: the device selection itself has already succeeded, so
+      // don't reject setDevice if recovery fails (e.g. autoplay still blocked).
+      // The consumer's API contract is "did we switch sinks?" — not "are all
+      // paused tracks playing?" — and existing consumers before this change
+      // never saw recovery-path rejections.
+      try {
+        await this.audioSinkManager.recoverAutoPausedTracks();
+      } catch (err) {
+        HMSLogger.w('[AudioOutputManager]', 'recoverAutoPausedTracks failed after setDevice', err);
+      }
     }
     return newDevice;
   }

--- a/packages/hms-video-store/src/device-manager/AudioOutputManager.ts
+++ b/packages/hms-video-store/src/device-manager/AudioOutputManager.ts
@@ -27,8 +27,18 @@ export class AudioOutputManager implements IAudioOutputManager {
     return this.deviceManager.outputDevice;
   }
 
-  setDevice(deviceId?: string) {
-    return this.deviceManager.updateOutputDevice(deviceId, true);
+  async setDevice(deviceId?: string) {
+    const newDevice = await this.deviceManager.updateOutputDevice(deviceId, true);
+    if (newDevice) {
+      // If any remote audio tracks were auto-paused by an OS audio-session
+      // interruption (headset pull / incoming call / Bluetooth swap), the user
+      // is almost certainly picking a new speaker to recover playback. Kick
+      // the unpause path explicitly — the eventBus.deviceChange subscription
+      // guards `isUserSelection` out, so unpauseAudioTracks never fires here
+      // otherwise. See LIV-254.
+      await this.audioSinkManager.recoverAutoPausedTracks();
+    }
+    return newDevice;
   }
 
   async unblockAutoplay() {

--- a/packages/hms-video-store/src/device-manager/AudioOutputManager.ts
+++ b/packages/hms-video-store/src/device-manager/AudioOutputManager.ts
@@ -33,20 +33,16 @@ export class AudioOutputManager implements IAudioOutputManager {
     if (newDevice) {
       // If any remote audio tracks were auto-paused by an OS audio-session
       // interruption (headset pull / incoming call / Bluetooth swap), the user
-      // is almost certainly picking a new speaker to recover playback. Kick
-      // the unpause path explicitly — the eventBus.deviceChange subscription
-      // guards `isUserSelection` out, so unpauseAudioTracks never fires here
-      // otherwise. See LIV-254.
+      // is almost certainly picking a new speaker to recover playback. The
+      // eventBus.deviceChange subscription guards `isUserSelection` out, so
+      // unpauseAudioTracks never fires from this path otherwise. See LIV-254.
       //
       // Best-effort: the device selection itself has already succeeded, so
       // don't reject setDevice if recovery fails (e.g. autoplay still blocked).
-      // The consumer's API contract is "did we switch sinks?" — not "are all
-      // paused tracks playing?" — and existing consumers before this change
-      // never saw recovery-path rejections.
       try {
-        await this.audioSinkManager.recoverAutoPausedTracks();
+        await this.unblockAutoplay();
       } catch (err) {
-        HMSLogger.w('[AudioOutputManager]', 'recoverAutoPausedTracks failed after setDevice', err);
+        HMSLogger.w('[AudioOutputManager]', 'unblockAutoplay failed after setDevice', err);
       }
     }
     return newDevice;

--- a/packages/hms-video-store/src/device-manager/DeviceManager.ts
+++ b/packages/hms-video-store/src/device-manager/DeviceManager.ts
@@ -80,19 +80,29 @@ export class DeviceManager implements HMSDeviceManager {
 
   updateOutputDevice = async (deviceId?: string, isUserSelection?: boolean) => {
     const newDevice = this.audioOutput.find(device => device.deviceId === deviceId);
-    if (newDevice) {
-      this.outputDevice = newDevice;
-      await this.store.updateAudioOutputDevice(newDevice);
-      this.eventBus.analytics.publish(
-        AnalyticsEventFactory.deviceChange({
-          isUserSelection,
-          selection: { audioOutput: newDevice },
-          devices: this.getDevices(),
-          type: 'audioOutput',
-        }),
-      );
-      DeviceStorageManager.updateSelection('audioOutput', { deviceId: newDevice.deviceId, groupId: newDevice.groupId });
+    if (!newDevice) {
+      return undefined;
     }
+    // Only commit outputDevice + analytics + persisted selection AFTER the
+    // downstream setSinkId calls actually succeed. Previously the state was
+    // updated optimistically — which left the UI reporting the new sink as
+    // selected while audio kept routing to the old one (LIV-254).
+    try {
+      await this.store.updateAudioOutputDevice(newDevice);
+    } catch (error) {
+      HMSLogger.w(this.TAG, 'updateOutputDevice failed; keeping previous selection', newDevice.label, error);
+      return undefined;
+    }
+    this.outputDevice = newDevice;
+    this.eventBus.analytics.publish(
+      AnalyticsEventFactory.deviceChange({
+        isUserSelection,
+        selection: { audioOutput: newDevice },
+        devices: this.getDevices(),
+        type: 'audioOutput',
+      }),
+    );
+    DeviceStorageManager.updateSelection('audioOutput', { deviceId: newDevice.deviceId, groupId: newDevice.groupId });
     return newDevice;
   };
 

--- a/packages/hms-video-store/src/media/tracks/HMSAudioTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSAudioTrack.ts
@@ -68,21 +68,26 @@ export class HMSAudioTrack extends HMSTrack {
       this.outputDevice = device;
       return;
     }
+    // using setSinkId in firefox disables echo cancellation (introduced in Firefox 116)
+    // todo: GoogleMeet doesn't set sinkId for all 3 audio elements, how do they redirect audio then?
+    //
+    // refer: https://100ms.atlassian.net/browse/LIVE-1992
+    // refer: https://bugzilla.mozilla.org/show_bug.cgi?id=1849108
+    // refer: https://bugzilla.mozilla.org/show_bug.cgi?id=1848283
+    // refer: https://github.com/aws/amazon-chime-sdk-js/issues/2742
+    // Setting sinkId in safari(support started from 18.4) causes "robotic voice" on bluetooth device changes or setting sinkId
+    if (typeof (this.audioElement as any).setSinkId !== 'function' || !isChromiumBased) {
+      return;
+    }
     try {
-      // using setSinkId in firefox disables echo cancellation (introduced in Firefox 116)
-      // todo: GoogleMeet doesn't set sinkId for all 3 audio elements, how do they redirect audio then?
-      //
-      // refer: https://100ms.atlassian.net/browse/LIVE-1992
-      // refer: https://bugzilla.mozilla.org/show_bug.cgi?id=1849108
-      // refer: https://bugzilla.mozilla.org/show_bug.cgi?id=1848283
-      // refer: https://github.com/aws/amazon-chime-sdk-js/issues/2742
-      // Setting sinkId in safari(support started from 18.4) causes "robotic voice" on bluetooth device changes or setting sinkId
-      if (typeof (this.audioElement as any).setSinkId === 'function' && isChromiumBased) {
-        await (this.audioElement as any)?.setSinkId(device.deviceId);
-        this.outputDevice = device;
-      }
+      await (this.audioElement as any).setSinkId(device.deviceId);
+      this.outputDevice = device;
     } catch (error) {
-      HMSLogger.d('[HMSAudioTrack]', 'error in setSinkId', error);
+      // setSinkId rejects (NotFoundError / NotAllowedError / AbortError). Don't silently
+      // swallow — the caller needs to know the UI says "device X selected" but audio
+      // is still routing to the previous sink. See LIV-254.
+      HMSLogger.w('[HMSAudioTrack]', this.logIdentifier, 'setSinkId failed', `${this}`, error);
+      throw error;
     }
   }
 

--- a/packages/hms-video-store/src/sdk/store/Store.ts
+++ b/packages/hms-video-store/src/sdk/store/Store.ts
@@ -321,7 +321,17 @@ class Store {
         promises.push(track.setOutputDevice(device));
       }
     });
-    await Promise.all(promises);
+    // Don't short-circuit on the first rejection — we want to attempt the sink
+    // change on every remote track. If any fail, surface an aggregated error
+    // so the caller (DeviceManager.updateOutputDevice) can avoid persisting a
+    // selection that didn't actually route. See LIV-254.
+    const results = await Promise.all(promises.map(p => p.catch(err => err)));
+    const rejected = results.filter((r): r is Error => r instanceof Error);
+    if (rejected.length > 0) {
+      throw new Error(
+        `updateAudioOutputDevice: ${rejected.length}/${promises.length} track(s) failed to switch sink: ${rejected[0].message}`,
+      );
+    }
   }
 
   getSimulcastLayers(source: HMSTrackSource): SimulcastLayer[] {

--- a/packages/hms-video-store/src/sdk/store/Store.ts
+++ b/packages/hms-video-store/src/sdk/store/Store.ts
@@ -325,11 +325,11 @@ class Store {
     // change on every remote track. If any fail, surface an aggregated error
     // so the caller (DeviceManager.updateOutputDevice) can avoid persisting a
     // selection that didn't actually route. See LIV-254.
-    const results = await Promise.all(promises.map(p => p.catch(err => err)));
-    const rejected = results.filter((r): r is Error => r instanceof Error);
+    const results = await Promise.allSettled(promises);
+    const rejected = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
     if (rejected.length > 0) {
       throw new Error(
-        `updateAudioOutputDevice: ${rejected.length}/${promises.length} track(s) failed to switch sink: ${rejected[0].message}`,
+        `updateAudioOutputDevice: ${rejected.length}/${promises.length} track(s) failed to switch sink: ${rejected[0].reason}`,
       );
     }
   }


### PR DESCRIPTION
Two bugs in hms-video-store's audio-output routing path that can leave remote audio silent when a user switches speakers mid-session.

- **`HMSAudioTrack.setOutputDevice` now surfaces `setSinkId` failure** (rethrows, logs at warn). `Store.updateAudioOutputDevice` aggregates per-track failures and propagates them. `DeviceManager.updateOutputDevice` only commits `outputDevice` / analytics / persisted selection on success — so the UI no longer reports a device as selected when audio is still routing to the previous sink.
- **`AudioOutputManager.setDevice` now triggers `unpauseAudioTracks`** (via a new public `AudioSinkManager.recoverAutoPausedTracks`). Previously the user-initiated path didn't publish to `eventBus.deviceChange`, and even if it had, `handleAudioDeviceChange` short-circuited on `isUserSelection === true` — so tracks auto-paused by an OS audio-session interruption (headset yank, incoming call, Bluetooth swap) stayed silent until an automatic devicechange event happened to fire.