### PR TITLE
fix: read noise-cancellation level from the plugin

### DIFF
--- a/packages/roomkit-react/package.json
+++ b/packages/roomkit-react/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@100mslive/hls-player": "0.4.4",
-    "@100mslive/hms-noise-cancellation": "0.1.1-alpha.1",
+    "@100mslive/hms-noise-cancellation": "0.1.1-alpha.2",
     "@100mslive/hms-virtual-background": "1.14.4",
     "@100mslive/hms-whiteboard": "0.1.4",
     "@100mslive/react-icons": "0.11.4",

--- a/packages/roomkit-react/package.json
+++ b/packages/roomkit-react/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@100mslive/hls-player": "0.4.4",
-    "@100mslive/hms-noise-cancellation": "0.1.1-alpha.0",
+    "@100mslive/hms-noise-cancellation": "0.1.1-alpha.1",
     "@100mslive/hms-virtual-background": "1.14.4",
     "@100mslive/hms-whiteboard": "0.1.4",
     "@100mslive/react-icons": "0.11.4",

--- a/packages/roomkit-react/package.json
+++ b/packages/roomkit-react/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@100mslive/hls-player": "0.4.4",
-    "@100mslive/hms-noise-cancellation": "0.1.1-alpha.2",
+    "@100mslive/hms-noise-cancellation": "0.1.1",
     "@100mslive/hms-virtual-background": "1.14.4",
     "@100mslive/hms-whiteboard": "0.1.4",
     "@100mslive/react-icons": "0.11.4",

--- a/packages/roomkit-react/package.json
+++ b/packages/roomkit-react/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@100mslive/hls-player": "0.4.4",
-    "@100mslive/hms-noise-cancellation": "0.1.0",
+    "@100mslive/hms-noise-cancellation": "0.1.1-alpha.0",
     "@100mslive/hms-virtual-background": "1.14.4",
     "@100mslive/hms-whiteboard": "0.1.4",
     "@100mslive/react-icons": "0.11.4",

--- a/packages/roomkit-react/src/Prebuilt/components/AudioVideoToggle.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/AudioVideoToggle.tsx
@@ -222,7 +222,11 @@ export const NoiseCancellation = ({
 };
 
 const NoiseCancellationLevelSlider = () => {
-  const [level, setLevel] = useState(100);
+  // Initialise from the plugin so the slider reflects the active level when
+  // the dropdown remounts. Krisp retains the level on its filter node;
+  // re-mounting the slider used to reset the UI to 100% even though audio
+  // was still being suppressed at the user's last picked level.
+  const [level, setLevel] = useState(() => krispPlugin.getNoiseSuppressionLevel());
 
   return (
     <Dropdown.Item

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@100mslive/hms-noise-cancellation@0.1.1-alpha.1":
-  version "0.1.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-noise-cancellation/-/hms-noise-cancellation-0.1.1-alpha.1.tgz#dd13774ee0de57ed60f4b3d888c46ccf5b58d74d"
-  integrity sha512-y9KE8TffqstbAsrNXFr5F8DmtmNEwEQhO5VzlHKpY+XbGnnico92pDDtZ2c2ybI7fmPDW3cQ7ni64U0vACG1IQ==
+"@100mslive/hms-noise-cancellation@0.1.1-alpha.2":
+  version "0.1.1-alpha.2"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-noise-cancellation/-/hms-noise-cancellation-0.1.1-alpha.2.tgz#6548b9d13d5fc1c58d85cee2c362895077130d10"
+  integrity sha512-lHvCvQSlMLif4Ml0eVVRYD9dS7rHlIrRGGXAGGFcrCCiQy+0RjRy8uVmD3R7FcPOvVcCKcAjFtryIMehZjzo2Q==
 
 "@100mslive/types-prebuilt@0.12.12":
   version "0.12.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@100mslive/hms-noise-cancellation@0.1.1-alpha.0":
-  version "0.1.1-alpha.0"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-noise-cancellation/-/hms-noise-cancellation-0.1.1-alpha.0.tgz#f09faeb2e01f940f341dcf985b9299732b324ab6"
-  integrity sha512-RI3m9Lcs6Kq13wicD495FO3C4+KwrrxbD7ssSHzfDuqKFHUJ1mhA5xkE4OYWLOtxDyyh1opt+NGhxtkzXtD/Gg==
+"@100mslive/hms-noise-cancellation@0.1.1-alpha.1":
+  version "0.1.1-alpha.1"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-noise-cancellation/-/hms-noise-cancellation-0.1.1-alpha.1.tgz#dd13774ee0de57ed60f4b3d888c46ccf5b58d74d"
+  integrity sha512-y9KE8TffqstbAsrNXFr5F8DmtmNEwEQhO5VzlHKpY+XbGnnico92pDDtZ2c2ybI7fmPDW3cQ7ni64U0vACG1IQ==
 
 "@100mslive/types-prebuilt@0.12.12":
   version "0.12.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@100mslive/hms-noise-cancellation@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-noise-cancellation/-/hms-noise-cancellation-0.1.0.tgz#9a441975f57cf14cb3d6869ea8c26c9b2e61445d"
-  integrity sha512-EA5vf/DHgnBb0ZAvzlp54MvWFdeEra1OGwrnZtk9bbQKKcGwrwJwdct9OyQo5ubFmafUowkujLJ9Drg1CBol7w==
+"@100mslive/hms-noise-cancellation@0.1.1-alpha.0":
+  version "0.1.1-alpha.0"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-noise-cancellation/-/hms-noise-cancellation-0.1.1-alpha.0.tgz#f09faeb2e01f940f341dcf985b9299732b324ab6"
+  integrity sha512-RI3m9Lcs6Kq13wicD495FO3C4+KwrrxbD7ssSHzfDuqKFHUJ1mhA5xkE4OYWLOtxDyyh1opt+NGhxtkzXtD/Gg==
 
 "@100mslive/types-prebuilt@0.12.12":
   version "0.12.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@100mslive/hms-noise-cancellation@0.1.1-alpha.2":
-  version "0.1.1-alpha.2"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-noise-cancellation/-/hms-noise-cancellation-0.1.1-alpha.2.tgz#6548b9d13d5fc1c58d85cee2c362895077130d10"
-  integrity sha512-lHvCvQSlMLif4Ml0eVVRYD9dS7rHlIrRGGXAGGFcrCCiQy+0RjRy8uVmD3R7FcPOvVcCKcAjFtryIMehZjzo2Q==
+"@100mslive/hms-noise-cancellation@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-noise-cancellation/-/hms-noise-cancellation-0.1.1.tgz#29f4d312f7d4c506788312551d04888e48914e3d"
+  integrity sha512-ggKxE8O5Dlkuej93eaQRLEABxe+8ybdvtrAdt9kNpAm7hoOzVBdt0mBdxznaYxxGf5Am0ujqVnP6bEAQdodxoA==
 
 "@100mslive/types-prebuilt@0.12.12":
   version "0.12.12"


### PR DESCRIPTION
## Summary
The Audio Settings dropdown remounts \`NoiseCancellationLevelSlider\` every time it opens. \`useState(100)\` was snapping the UI back to 100% on each open, even though Krisp had retained the user's actual suppression level on the filter node — audio stayed correctly suppressed, only the React state got reset.

Initialise from \`krispPlugin.getNoiseSuppressionLevel()\` (added in \`@100mslive/hms-noise-cancellation@0.1.1-alpha.0\`). Falls back to the Krisp default when the plugin isn't yet attached to a track.

Bumps \`@100mslive/hms-noise-cancellation\` from 0.1.0 → 0.1.1-alpha.0 (alpha for now; switch to the stable 0.1.1 once that ships).