### PR TITLE
fix(react-sdk): leave on HMSRoomProvider unmount when owning the store

### DIFF
--- a/packages/react-sdk/src/primitives/HmsRoomProvider.ts
+++ b/packages/react-sdk/src/primitives/HmsRoomProvider.ts
@@ -121,13 +121,18 @@ export const HMSRoomProvider = <T extends HMSGenericTypes = { sessionStore: Reco
     return () => {};
   }, [leaveOnUnload, providerProps]);
 
-  // When the provider owns the store (no external actions/store passed in)
-  // and leaveOnUnload is on, also leave on React unmount or providerProps
-  // identity change. Without this, consumers that toggle key={roomId} or
-  // conditionally render the provider leak the SDK instance: the previous
-  // signal WebSocket, RTCPeerConnections, ping-pong loop, and any local
-  // media tracks remain alive until tab close. leave() is safe when not
-  // connected (logs a warning, no network call).
+  /*
+   * When the provider owns the store (no external actions/store passed in)
+   * and leaveOnUnload is on, also leave on React unmount or providerProps
+   * identity change. Without this, consumers that toggle key={roomId} or
+   * conditionally render the provider leak the SDK instance: the previous
+   * signal WebSocket, RTCPeerConnections, ping-pong loop, and any local
+   * media tracks remain alive until tab close. leave() is safe when not
+   * connected (logs a warning, no network call).
+   *
+   * External-store branch (consumer passed actions/store) is intentionally
+   * not touched: ownsStore evaluates false and the effect returns early.
+   */
   const ownsStore = !actions && !store;
   useEffect(() => {
     if (!ownsStore || !isBrowser || !leaveOnUnload) {

--- a/packages/react-sdk/src/primitives/HmsRoomProvider.ts
+++ b/packages/react-sdk/src/primitives/HmsRoomProvider.ts
@@ -121,6 +121,23 @@ export const HMSRoomProvider = <T extends HMSGenericTypes = { sessionStore: Reco
     return () => {};
   }, [leaveOnUnload, providerProps]);
 
+  // When the provider owns the store (no external actions/store passed in)
+  // and leaveOnUnload is on, also leave on React unmount or providerProps
+  // identity change. Without this, consumers that toggle key={roomId} or
+  // conditionally render the provider leak the SDK instance: the previous
+  // signal WebSocket, RTCPeerConnections, ping-pong loop, and any local
+  // media tracks remain alive until tab close. leave() is safe when not
+  // connected (logs a warning, no network call).
+  const ownsStore = !actions && !store;
+  useEffect(() => {
+    if (!ownsStore || !isBrowser || !leaveOnUnload) {
+      return;
+    }
+    return () => {
+      providerProps.actions.leave();
+    };
+  }, [ownsStore, leaveOnUnload, providerProps]);
+
   return React.createElement(HMSContext.Provider, { value: providerProps }, children);
 };
 


### PR DESCRIPTION
When `HMSRoomProvider` creates its own `HMSReactiveStore` (no external `actions`/`store` passed in), it never released that instance on React unmount or when the memoized provider value changed identity. Consumers using `key={roomId}` or conditionally rendering the provider leaked the entire SDK: signal WebSocket, RTCPeerConnections, ping-pong loop, and local media tracks remained alive until tab close, while biz saw no `peer.leave` so the prior peer lingered in the room.

Adds a `useEffect` cleanup that calls `actions.leave()` in this case, gated behind `leaveOnUnload`. The external-store branch is untouched — when callers pass their own actions/store they own the lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)