### PR TITLE
fix(transport): bail retrySignalDisconnectTask if joinParameters cleared

### DIFF
--- a/packages/hms-video-store/src/test/helpers/makeTransport.ts
+++ b/packages/hms-video-store/src/test/helpers/makeTransport.ts
@@ -1,0 +1,68 @@
+/**
+ * Minimal HMSTransport instantiator for unit tests.
+ *
+ * Builds a real `HMSTransport` with the smallest mocks that get past the
+ * constructor and its initial subscriptions. Tests can then call
+ * private/arrow-field methods directly on the instance:
+ *
+ *   const t = makeTransport();
+ *   await (t as any).retrySignalDisconnectTask();
+ *
+ * For tests that exercise specific code paths, override fields after
+ * construction:
+ *
+ *   (t as any).joinParameters = undefined;
+ *   (t as any).signal = mySignalMock;
+ *
+ * This is deliberately not a "fake biz" or full integration harness —
+ * it's the smallest scaffolding that lets us exercise the real
+ * HMSTransport methods with controlled inputs.
+ */
+
+import { AnalyticsEventsService } from '../../analytics/AnalyticsEventsService';
+import { AnalyticsTimer } from '../../analytics/AnalyticsTimer';
+import { PluginUsageTracker } from '../../common/PluginUsageTracker';
+import { DeviceManager } from '../../device-manager';
+import { EventBus } from '../../events/EventBus';
+import { Store } from '../../sdk/store';
+import HMSTransport from '../../transport';
+import ITransportObserver from '../../transport/ITransportObserver';
+import { TransportState } from '../../transport/models/TransportState';
+
+export const makeFakeObserver = (): ITransportObserver => ({
+  onNotification: jest.fn(),
+  onConnected: jest.fn(),
+  onTrackAdd: jest.fn(),
+  onTrackRemove: jest.fn(),
+  onFailure: jest.fn(),
+  onStateChange: jest.fn(async () => {}),
+});
+
+export interface MakeTransportOptions {
+  observer?: ITransportObserver;
+  store?: Partial<Store>;
+}
+
+export const makeTransport = (opts: MakeTransportOptions = {}) => {
+  const observer = opts.observer ?? makeFakeObserver();
+  const eventBus = new EventBus();
+  const store = (opts.store as Store) ?? new Store();
+  const analyticsTimer = new AnalyticsTimer();
+  const analyticsEventsService = new AnalyticsEventsService(store);
+  const pluginUsageTracker = new PluginUsageTracker(eventBus);
+  const deviceManager = new DeviceManager(store, eventBus);
+
+  const transport = new HMSTransport(
+    observer,
+    deviceManager,
+    store,
+    eventBus,
+    analyticsEventsService,
+    analyticsTimer,
+    pluginUsageTracker,
+  );
+
+  return { transport, observer, eventBus, store, analyticsTimer, deviceManager };
+};
+
+export { TransportState };

--- a/packages/hms-video-store/src/test/unit/transport/leaveDuringRetry.test.ts
+++ b/packages/hms-video-store/src/test/unit/transport/leaveDuringRetry.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Bug 4 — `retrySignalDisconnectTask` accesses `this.joinParameters!.X`
+ * synchronously when building the args to `internalConnect`. If `leave()`
+ * runs while the retry task's setTimeout is queued (or while the task is
+ * paused on an await), `joinParameters` becomes `undefined`, and the next
+ * arg-evaluation hits `undefined.authToken` → TypeError.
+ *
+ * Even when no TypeError fires, the task continues into
+ * `this.signal.trackUpdate(this.trackStates)` and `internalConnect` after
+ * leave has cleared state — issuing a doomed reconnect attempt with
+ * stale data.
+ *
+ * This test calls `retrySignalDisconnectTask` directly with
+ * `joinParameters = undefined` (the post-leave state). It must FAIL on
+ * `main` (TypeError or unexpected internalConnect call) and PASS once
+ * the task null-guards `joinParameters` / state at entry.
+ */
+
+import { makeTransport, TransportState } from '../../helpers/makeTransport';
+
+describe('Bug 4 — retrySignalDisconnectTask vs leave() race', () => {
+  it('does NOT call internalConnect or signal.trackUpdate when joinParameters is undefined (post-leave)', async () => {
+    const { transport } = makeTransport();
+    const t = transport as any;
+
+    const internalConnectSpy = jest.fn(() => Promise.resolve({}));
+    const trackUpdateSpy = jest.fn();
+
+    // Replace methods/refs to simulate the exact post-leave state:
+    //   - retryScheduler has fired the timeout, so we're now inside the task body
+    //   - leave() has cleared joinParameters
+    //   - signal.isConnected reflects "websocket already closed"
+    t.joinParameters = undefined;
+    t.state = TransportState.Leaving;
+    t.internalConnect = internalConnectSpy;
+    t.signal = {
+      get isConnected() {
+        return false;
+      },
+      trackUpdate: trackUpdateSpy,
+    };
+
+    let caught: unknown = undefined;
+    try {
+      await t.retrySignalDisconnectTask();
+    } catch (e) {
+      caught = e;
+    }
+
+    // On `main` this throws TypeError ("Cannot read properties of undefined (reading 'authToken')")
+    // because `this.joinParameters!.authToken` dereferences undefined.
+    // After the fix the task early-returns; no throw, no internalConnect, no trackUpdate.
+    expect(caught).toBeUndefined();
+    expect(internalConnectSpy).not.toHaveBeenCalled();
+    expect(trackUpdateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/hms-video-store/src/transport/index.ts
+++ b/packages/hms-video-store/src/transport/index.ts
@@ -1275,6 +1275,15 @@ export default class HMSTransport {
   };
 
   private retrySignalDisconnectTask = async () => {
+    // The retryScheduler can fire this task body asynchronously, and leave()
+    // clears `joinParameters` synchronously. If leave() races with a queued
+    // task, dereferencing `this.joinParameters!.authToken` below would throw
+    // a TypeError. Bail out cleanly in that case — leave() also resets the
+    // scheduler, so further work here is moot.
+    if (!this.joinParameters || this.state === TransportState.Leaving) {
+      return false;
+    }
+
     HMSLogger.d(TAG, 'retrySignalDisconnectTask', { signalConnected: this.signal.isConnected });
     // Check if ws is disconnected - otherwise if only publishIce fails
     // and ws connect is success then we don't need to reconnect to WebSocket

--- a/packages/hms-video-store/src/transport/index.ts
+++ b/packages/hms-video-store/src/transport/index.ts
@@ -1274,12 +1274,16 @@ export default class HMSTransport {
     return true;
   };
 
+  /**
+   * Retry path that reconnects the signal WebSocket after a disconnect.
+   *
+   * The retryScheduler can fire this body asynchronously, and `leave()`
+   * clears `joinParameters` synchronously. If leave() races with a queued
+   * task, dereferencing `this.joinParameters!.authToken` would throw a
+   * TypeError. Bail out cleanly in that case — leave() also resets the
+   * scheduler, so further work here is moot.
+   */
   private retrySignalDisconnectTask = async () => {
-    // The retryScheduler can fire this task body asynchronously, and leave()
-    // clears `joinParameters` synchronously. If leave() races with a queued
-    // task, dereferencing `this.joinParameters!.authToken` below would throw
-    // a TypeError. Bail out cleanly in that case — leave() also resets the
-    // scheduler, so further work here is moot.
     if (!this.joinParameters || this.state === TransportState.Leaving) {
       return false;
     }

--- a/packages/hms-video-store/src/transport/leaveDuringRetry.test.ts
+++ b/packages/hms-video-store/src/transport/leaveDuringRetry.test.ts
@@ -1,5 +1,5 @@
 /**
- * Bug 4 — `retrySignalDisconnectTask` accesses `this.joinParameters!.X`
+ * `retrySignalDisconnectTask` accesses `this.joinParameters!.X`
  * synchronously when building the args to `internalConnect`. If `leave()`
  * runs while the retry task's setTimeout is queued (or while the task is
  * paused on an await), `joinParameters` becomes `undefined`, and the next
@@ -11,14 +11,14 @@
  * stale data.
  *
  * This test calls `retrySignalDisconnectTask` directly with
- * `joinParameters = undefined` (the post-leave state). It must FAIL on
- * `main` (TypeError or unexpected internalConnect call) and PASS once
- * the task null-guards `joinParameters` / state at entry.
+ * `joinParameters = undefined` (the post-leave state). Without the
+ * null-guard at task entry, it throws TypeError or makes unexpected
+ * internalConnect calls.
  */
 
 import { makeTransport, TransportState } from '../test/helpers/makeTransport';
 
-describe('Bug 4 — retrySignalDisconnectTask vs leave() race', () => {
+describe('retrySignalDisconnectTask vs leave() race', () => {
   it('does NOT call internalConnect or signal.trackUpdate when joinParameters is undefined (post-leave)', async () => {
     const { transport } = makeTransport();
     const t = transport as any;
@@ -47,9 +47,9 @@ describe('Bug 4 — retrySignalDisconnectTask vs leave() race', () => {
       caught = e;
     }
 
-    // On `main` this throws TypeError ("Cannot read properties of undefined (reading 'authToken')")
+    // Without the guard this throws TypeError ("Cannot read properties of undefined (reading 'authToken')")
     // because `this.joinParameters!.authToken` dereferences undefined.
-    // After the fix the task early-returns; no throw, no internalConnect, no trackUpdate.
+    // With the guard the task early-returns; no throw, no internalConnect, no trackUpdate.
     expect(caught).toBeUndefined();
     expect(internalConnectSpy).not.toHaveBeenCalled();
     expect(trackUpdateSpy).not.toHaveBeenCalled();

--- a/packages/hms-video-store/src/transport/leaveDuringRetry.test.ts
+++ b/packages/hms-video-store/src/transport/leaveDuringRetry.test.ts
@@ -16,7 +16,7 @@
  * the task null-guards `joinParameters` / state at entry.
  */
 
-import { makeTransport, TransportState } from '../../helpers/makeTransport';
+import { makeTransport, TransportState } from '../test/helpers/makeTransport';
 
 describe('Bug 4 — retrySignalDisconnectTask vs leave() race', () => {
   it('does NOT call internalConnect or signal.trackUpdate when joinParameters is undefined (post-leave)', async () => {


### PR DESCRIPTION
\`leave()\` clears \`joinParameters\` synchronously, but the retry scheduler can fire \`retrySignalDisconnectTask\` asynchronously. If the timings cross, the task body dereferences \`this.joinParameters!.authToken\` on \`undefined\`, throwing a \`TypeError\` that propagates to the wrapping retry callback and silently resolves dependents to \`undefined\`. Early-return when \`joinParameters\` is missing or state is \`Leaving\` — the retry scheduler is already being reset by \`leave()\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)