### PR TITLE
fix(media): three small track-surface lifecycle fixes

### DIFF
--- a/packages/hms-video-store/src/media/settings/HMSAudioTrackSettings.ts
+++ b/packages/hms-video-store/src/media/settings/HMSAudioTrackSettings.ts
@@ -92,10 +92,12 @@ export class HMSAudioTrackSettings implements IHMSAudioTrackSettings, IAnalytics
     this.deviceId = deviceId;
     this.advanced = advanced;
     this.audioMode = audioMode;
-    // Honor an explicit caller-provided maxBitrate; only fall back to the
-    // audioMode default when none was passed. Previously the constructor
-    // unconditionally overwrote the argument with the audioMode default,
-    // making the parameter dead code.
+    /*
+     * Honor an explicit caller-provided maxBitrate; only fall back to the
+     * audioMode default when none was passed. Previously the constructor
+     * unconditionally overwrote the argument with the audioMode default,
+     * making the parameter dead code.
+     */
     if (maxBitrate !== undefined) {
       this.maxBitrate = maxBitrate;
     } else if (this.audioMode === HMSAudioMode.MUSIC) {

--- a/packages/hms-video-store/src/media/settings/HMSAudioTrackSettings.ts
+++ b/packages/hms-video-store/src/media/settings/HMSAudioTrackSettings.ts
@@ -89,18 +89,11 @@ export class HMSAudioTrackSettings implements IHMSAudioTrackSettings, IAnalytics
   ) {
     this.volume = volume;
     this.codec = codec;
+    this.maxBitrate = maxBitrate;
     this.deviceId = deviceId;
     this.advanced = advanced;
     this.audioMode = audioMode;
-    /*
-     * Honor an explicit caller-provided maxBitrate; only fall back to the
-     * audioMode default when none was passed. Previously the constructor
-     * unconditionally overwrote the argument with the audioMode default,
-     * making the parameter dead code.
-     */
-    if (maxBitrate !== undefined) {
-      this.maxBitrate = maxBitrate;
-    } else if (this.audioMode === HMSAudioMode.MUSIC) {
+    if (this.audioMode === HMSAudioMode.MUSIC) {
       this.maxBitrate = 320;
     } else {
       this.maxBitrate = 32;

--- a/packages/hms-video-store/src/media/settings/HMSAudioTrackSettings.ts
+++ b/packages/hms-video-store/src/media/settings/HMSAudioTrackSettings.ts
@@ -89,11 +89,16 @@ export class HMSAudioTrackSettings implements IHMSAudioTrackSettings, IAnalytics
   ) {
     this.volume = volume;
     this.codec = codec;
-    this.maxBitrate = maxBitrate;
     this.deviceId = deviceId;
     this.advanced = advanced;
     this.audioMode = audioMode;
-    if (this.audioMode === HMSAudioMode.MUSIC) {
+    // Honor an explicit caller-provided maxBitrate; only fall back to the
+    // audioMode default when none was passed. Previously the constructor
+    // unconditionally overwrote the argument with the audioMode default,
+    // making the parameter dead code.
+    if (maxBitrate !== undefined) {
+      this.maxBitrate = maxBitrate;
+    } else if (this.audioMode === HMSAudioMode.MUSIC) {
       this.maxBitrate = 320;
     } else {
       this.maxBitrate = 32;

--- a/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.test.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.test.ts
@@ -1,0 +1,95 @@
+import { HMSLocalVideoTrack } from './HMSLocalVideoTrack';
+import HMSPublishConnection from '../../connection/publish/publishConnection';
+import { EventBus } from '../../events/EventBus';
+import { HMSVideoTrackSettings, HMSVideoTrackSettingsBuilder } from '../settings';
+import { HMSLocalStream } from '../streams/HMSLocalStream';
+
+const streamId = 'stream-1';
+const trackId = 'track-1';
+
+const makeLocalVideoTrack = () => {
+  const nativeStream = { id: streamId, getTracks: () => [] } as unknown as MediaStream;
+  const stream = new HMSLocalStream(nativeStream);
+  stream.setConnection({} as unknown as HMSPublishConnection);
+  const nativeTrack = {
+    id: trackId,
+    kind: 'video',
+    enabled: true,
+    getSettings: jest.fn(() => ({})),
+    addEventListener: jest.fn(),
+  } as unknown as MediaStreamTrack;
+  const settings = new HMSVideoTrackSettingsBuilder().build();
+  return new HMSLocalVideoTrack(stream, nativeTrack, 'regular', new EventBus(), settings);
+};
+
+describe('HMSLocalVideoTrack', () => {
+  describe('removeOrReplaceProcessedTrack', () => {
+    it('stops the previous processedTrack before overwriting with a new one', async () => {
+      const track = makeLocalVideoTrack();
+      jest.spyOn(track as any, 'replaceSenderTrack').mockResolvedValue(undefined);
+
+      const oldProcessed = { stop: jest.fn() } as unknown as MediaStreamTrack;
+      const newProcessed = { stop: jest.fn() } as unknown as MediaStreamTrack;
+
+      (track as any).processedTrack = oldProcessed;
+      await (track as any).removeOrReplaceProcessedTrack(newProcessed);
+
+      expect(oldProcessed.stop).toHaveBeenCalledTimes(1);
+      expect(newProcessed.stop).not.toHaveBeenCalled();
+      expect((track as any).processedTrack).toBe(newProcessed);
+    });
+
+    it('stops the previous processedTrack when reset to undefined', async () => {
+      const track = makeLocalVideoTrack();
+      jest.spyOn(track as any, 'replaceSenderTrack').mockResolvedValue(undefined);
+
+      const oldProcessed = { stop: jest.fn() } as unknown as MediaStreamTrack;
+      (track as any).processedTrack = oldProcessed;
+
+      await (track as any).removeOrReplaceProcessedTrack(undefined);
+
+      expect(oldProcessed.stop).toHaveBeenCalledTimes(1);
+      expect((track as any).processedTrack).toBeUndefined();
+    });
+
+    it('is a no-op when processedTrack is the same instance', async () => {
+      const track = makeLocalVideoTrack();
+      const replaceSpy = jest.spyOn(track as any, 'replaceSenderTrack').mockResolvedValue(undefined);
+
+      const same = { stop: jest.fn() } as unknown as MediaStreamTrack;
+      (track as any).processedTrack = same;
+
+      await (track as any).removeOrReplaceProcessedTrack(same);
+
+      expect(same.stop).not.toHaveBeenCalled();
+      expect((track as any).processedTrack).toBe(same);
+      expect(replaceSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('handleDeviceChange', () => {
+    it('does not mutate the caller-supplied settings object', async () => {
+      const track = makeLocalVideoTrack();
+
+      jest.spyOn(track as any, 'replaceTrackWith').mockResolvedValue({
+        getSettings: jest.fn(() => ({ deviceId: 'new-device' })),
+      } as unknown as MediaStreamTrack);
+      jest.spyOn(track as any, 'replaceSender').mockResolvedValue(undefined);
+      jest.spyOn(track as any, 'processPlugins').mockResolvedValue(undefined);
+      jest.spyOn(track['videoHandler'], 'updateSinks').mockReturnValue(undefined as any);
+
+      const inputSettings = {
+        ...track.settings,
+        deviceId: 'new-device',
+        facingMode: 'user',
+      } as unknown as HMSVideoTrackSettings;
+      const beforeFacingMode = inputSettings.facingMode;
+
+      await (track as any).handleDeviceChange(inputSettings, false);
+
+      // The fix copies the settings object before stripping facingMode for
+      // replaceTrackWith. The caller's reference must not be mutated.
+      expect(inputSettings.facingMode).toBe(beforeFacingMode);
+    });
+  });
+});

--- a/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.test.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.test.ts
@@ -1,7 +1,7 @@
 import { HMSLocalVideoTrack } from './HMSLocalVideoTrack';
 import HMSPublishConnection from '../../connection/publish/publishConnection';
 import { EventBus } from '../../events/EventBus';
-import { HMSVideoTrackSettings, HMSVideoTrackSettingsBuilder } from '../settings';
+import { HMSVideoTrackSettingsBuilder } from '../settings';
 import { HMSLocalStream } from '../streams/HMSLocalStream';
 
 const streamId = 'stream-1';
@@ -64,32 +64,6 @@ describe('HMSLocalVideoTrack', () => {
       expect(same.stop).not.toHaveBeenCalled();
       expect((track as any).processedTrack).toBe(same);
       expect(replaceSpy).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('handleDeviceChange', () => {
-    it('does not mutate the caller-supplied settings object', async () => {
-      const track = makeLocalVideoTrack();
-
-      jest.spyOn(track as any, 'replaceTrackWith').mockResolvedValue({
-        getSettings: jest.fn(() => ({ deviceId: 'new-device' })),
-      } as unknown as MediaStreamTrack);
-      jest.spyOn(track as any, 'replaceSender').mockResolvedValue(undefined);
-      jest.spyOn(track as any, 'processPlugins').mockResolvedValue(undefined);
-      jest.spyOn(track['videoHandler'], 'updateSinks').mockReturnValue(undefined as any);
-
-      const inputSettings = {
-        ...track.settings,
-        deviceId: 'new-device',
-        facingMode: 'user',
-      } as unknown as HMSVideoTrackSettings;
-      const beforeFacingMode = inputSettings.facingMode;
-
-      await (track as any).handleDeviceChange(inputSettings, false);
-
-      // The fix copies the settings object before stripping facingMode for
-      // replaceTrackWith. The caller's reference must not be mutated.
-      expect(inputSettings.facingMode).toBe(beforeFacingMode);
     });
   });
 });

--- a/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
@@ -537,8 +537,10 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
 
     if (hasPropertyChanged('deviceId') && this.source === 'regular') {
       if (this.enabled) {
-        delete settings.facingMode;
-        const track = await this.replaceTrackWith(settings);
+        // Don't mutate the caller's settings object — copy and strip facingMode
+        // for replaceTrackWith so the caller's reference isn't surprise-modified.
+        const settingsForReplace = { ...settings, facingMode: undefined };
+        const track = await this.replaceTrackWith(settingsForReplace as HMSVideoTrackSettings);
         await this.replaceSender(track, this.enabled);
         this.nativeTrack = track;
         await this.processPlugins();
@@ -616,8 +618,13 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
   private removeOrReplaceProcessedTrack = async (processedTrack?: MediaStreamTrack) => {
     // if all plugins are removed reset everything back to native track
     if (!processedTrack) {
+      this.processedTrack?.stop();
       this.processedTrack = undefined;
     } else if (processedTrack !== this.processedTrack) {
+      // Stop the previous processed track (a canvas captureStream) before
+      // overwriting — otherwise the old canvas stream stays alive consuming
+      // GPU resources until GC.
+      this.processedTrack?.stop();
       this.processedTrack = processedTrack;
     }
     await this.replaceSenderTrack(this.processedTrack || this.nativeTrack);

--- a/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
@@ -537,12 +537,8 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
 
     if (hasPropertyChanged('deviceId') && this.source === 'regular') {
       if (this.enabled) {
-        /*
-         * Don't mutate the caller's settings object — copy and strip facingMode
-         * for replaceTrackWith so the caller's reference isn't surprise-modified.
-         */
-        const settingsForReplace = { ...settings, facingMode: undefined };
-        const track = await this.replaceTrackWith(settingsForReplace as HMSVideoTrackSettings);
+        delete settings.facingMode;
+        const track = await this.replaceTrackWith(settings);
         await this.replaceSender(track, this.enabled);
         this.nativeTrack = track;
         await this.processPlugins();

--- a/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
@@ -537,8 +537,10 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
 
     if (hasPropertyChanged('deviceId') && this.source === 'regular') {
       if (this.enabled) {
-        // Don't mutate the caller's settings object — copy and strip facingMode
-        // for replaceTrackWith so the caller's reference isn't surprise-modified.
+        /*
+         * Don't mutate the caller's settings object — copy and strip facingMode
+         * for replaceTrackWith so the caller's reference isn't surprise-modified.
+         */
         const settingsForReplace = { ...settings, facingMode: undefined };
         const track = await this.replaceTrackWith(settingsForReplace as HMSVideoTrackSettings);
         await this.replaceSender(track, this.enabled);
@@ -621,9 +623,11 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
       this.processedTrack?.stop();
       this.processedTrack = undefined;
     } else if (processedTrack !== this.processedTrack) {
-      // Stop the previous processed track (a canvas captureStream) before
-      // overwriting — otherwise the old canvas stream stays alive consuming
-      // GPU resources until GC.
+      /*
+       * Stop the previous processed track (a canvas captureStream) before
+       * overwriting — otherwise the old canvas stream stays alive consuming
+       * GPU resources until GC.
+       */
       this.processedTrack?.stop();
       this.processedTrack = processedTrack;
     }

--- a/packages/hms-video-store/src/media/tracks/HMSRemoteVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSRemoteVideoTrack.ts
@@ -47,7 +47,7 @@ export class HMSRemoteVideoTrack extends HMSVideoTrack {
       return;
     }
 
-    super.setEnabled(value);
+    await super.setEnabled(value);
     this.videoHandler.updateSinks(true);
   }
 

--- a/packages/hms-video-store/src/media/tracks/RemoteVideoTrack.test.ts
+++ b/packages/hms-video-store/src/media/tracks/RemoteVideoTrack.test.ts
@@ -1,4 +1,5 @@
 import { HMSRemoteVideoTrack } from './HMSRemoteVideoTrack';
+import { HMSVideoTrack } from './HMSVideoTrack';
 import HMSSubscribeConnection from '../../connection/subscribe/subscribeConnection';
 import { HMSSimulcastLayer } from '../../interfaces';
 import { HMSRemoteStream } from '../streams/HMSRemoteStream';
@@ -214,5 +215,33 @@ describe('HMSRemoteVideoTrack with disableNoneLayerRequest', () => {
 
     await track.removeSink(videoElement);
     expectLayersSent([HMSSimulcastLayer.HIGH]);
+  });
+
+  test('setEnabled awaits super.setEnabled before calling videoHandler.updateSinks', async () => {
+    let resolveSuper!: () => void;
+    const superSpy = jest.spyOn(HMSVideoTrack.prototype, 'setEnabled').mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveSuper = resolve;
+        }),
+    );
+    const updateSinksSpy = jest.spyOn(track['videoHandler'], 'updateSinks').mockImplementation(() => {});
+
+    const setEnabledPromise = track.setEnabled(false);
+
+    // Yield once for the microtask after super starts
+    await Promise.resolve();
+
+    expect(superSpy).toHaveBeenCalledWith(false);
+    // updateSinks must NOT have run yet — we're still awaiting super
+    expect(updateSinksSpy).not.toHaveBeenCalled();
+
+    resolveSuper();
+    await setEnabledPromise;
+
+    // After super resolves, updateSinks runs
+    expect(updateSinksSpy).toHaveBeenCalledWith(true);
+
+    superSpy.mockRestore();
   });
 });

--- a/packages/hms-video-store/src/sdk/LocalTrackManager.ts
+++ b/packages/hms-video-store/src/sdk/LocalTrackManager.ts
@@ -197,9 +197,11 @@ export class LocalTrackManager {
           await stream.getVideoTracks()[0].applyConstraints(videoConstraint);
         }
       } finally {
-        // Release the temporary video element's reference to the stream so
-        // the element can be GC'd promptly instead of holding the
-        // screenshare stream alive longer than necessary.
+        /*
+         * Release the temporary video element's reference to the stream so
+         * the element can be GC'd promptly instead of holding the
+         * screenshare stream alive longer than necessary.
+         */
         videoElement.srcObject = null;
       }
     });

--- a/packages/hms-video-store/src/sdk/LocalTrackManager.ts
+++ b/packages/hms-video-store/src/sdk/LocalTrackManager.ts
@@ -177,23 +177,30 @@ export class LocalTrackManager {
     const videoElement = document.createElement('video');
     videoElement.srcObject = stream;
     videoElement.addEventListener('loadedmetadata', async () => {
-      const { videoWidth, videoHeight } = videoElement;
-      const screen = publishParams.screen;
-      const pixels = screen.width * screen.height;
-      const actualAspectRatio = videoWidth / videoHeight;
-      const currentAspectRatio = screen.width / screen.height;
-      if (actualAspectRatio > currentAspectRatio) {
-        const videoConstraint = constraints.video as MediaTrackConstraints;
-        const ratio = actualAspectRatio / currentAspectRatio;
-        const sqrt_ratio = Math.sqrt(ratio);
-        if (videoWidth * videoHeight > pixels) {
-          videoConstraint.width = videoWidth / sqrt_ratio;
-          videoConstraint.height = videoHeight / sqrt_ratio;
-        } else {
-          videoConstraint.height = videoHeight * sqrt_ratio;
-          videoConstraint.width = videoWidth * sqrt_ratio;
+      try {
+        const { videoWidth, videoHeight } = videoElement;
+        const screen = publishParams.screen;
+        const pixels = screen.width * screen.height;
+        const actualAspectRatio = videoWidth / videoHeight;
+        const currentAspectRatio = screen.width / screen.height;
+        if (actualAspectRatio > currentAspectRatio) {
+          const videoConstraint = constraints.video as MediaTrackConstraints;
+          const ratio = actualAspectRatio / currentAspectRatio;
+          const sqrt_ratio = Math.sqrt(ratio);
+          if (videoWidth * videoHeight > pixels) {
+            videoConstraint.width = videoWidth / sqrt_ratio;
+            videoConstraint.height = videoHeight / sqrt_ratio;
+          } else {
+            videoConstraint.height = videoHeight * sqrt_ratio;
+            videoConstraint.width = videoWidth * sqrt_ratio;
+          }
+          await stream.getVideoTracks()[0].applyConstraints(videoConstraint);
         }
-        await stream.getVideoTracks()[0].applyConstraints(videoConstraint);
+      } finally {
+        // Release the temporary video element's reference to the stream so
+        // the element can be GC'd promptly instead of holding the
+        // screenshare stream alive longer than necessary.
+        videoElement.srcObject = null;
       }
     });
   }


### PR DESCRIPTION
Three small fixes on the local track surface:

- `HMSLocalVideoTrack.removeOrReplaceProcessedTrack` now stops the previous `processedTrack` (a canvas captureStream) before overwriting it, so the old canvas isn't kept alive until GC.
- `LocalTrackManager.optimizeScreenShareConstraint` nulls the temporary `<video>` element's `srcObject` in a `finally` after `loadedmetadata`, releasing the stream reference promptly.
- `HMSRemoteVideoTrack.setEnabled` awaits `super.setEnabled`, in line with the local-track and remote-audio counterparts.