### PR TITLE
fix(media): destroyed-guard for VideoElementManager observer callbacks

### DIFF
--- a/packages/hms-video-store/src/media/tracks/VideoElementManager.ts
+++ b/packages/hms-video-store/src/media/tracks/VideoElementManager.ts
@@ -14,7 +14,6 @@ import { isBrowser } from '../../utils/support';
  */
 export class VideoElementManager {
   private readonly TAG = '[VideoElementManager]';
-  private isDestroyed = false;
   private resizeObserver?: typeof HMSResizeObserver;
   private intersectionObserver?: typeof HMSIntersectionObserver;
   private videoElements = new Set<HTMLVideoElement>();
@@ -91,7 +90,10 @@ export class VideoElementManager {
   }
 
   private handleIntersection = async (entry: IntersectionObserverEntry) => {
-    if (this.isDestroyed) return;
+    // cleanup() nulls the observer fields; treat that as the destroyed signal.
+    if (!this.intersectionObserver) {
+      return;
+    }
     const isVisibile = getComputedStyle(entry.target).visibility === 'visible';
     // .contains check is needed for pip component as the video tiles are not mounted to dom element
     if (this.track.enabled && ((entry.isIntersecting && isVisibile) || !document.contains(entry.target))) {
@@ -106,7 +108,9 @@ export class VideoElementManager {
   };
 
   private handleResize = async (entry: ResizeObserverEntry) => {
-    if (this.isDestroyed) return;
+    if (!this.resizeObserver) {
+      return;
+    }
     if (!this.track.enabled || !(this.track instanceof HMSRemoteVideoTrack)) {
       return;
     }
@@ -173,7 +177,6 @@ export class VideoElementManager {
   }
 
   cleanup = () => {
-    this.isDestroyed = true;
     this.videoElements.forEach(videoElement => {
       videoElement.srcObject = null;
       this.resizeObserver?.unobserve(videoElement);

--- a/packages/hms-video-store/src/media/tracks/VideoElementManager.ts
+++ b/packages/hms-video-store/src/media/tracks/VideoElementManager.ts
@@ -14,6 +14,7 @@ import { isBrowser } from '../../utils/support';
  */
 export class VideoElementManager {
   private readonly TAG = '[VideoElementManager]';
+  private isDestroyed = false;
   private resizeObserver?: typeof HMSResizeObserver;
   private intersectionObserver?: typeof HMSIntersectionObserver;
   private videoElements = new Set<HTMLVideoElement>();
@@ -90,6 +91,7 @@ export class VideoElementManager {
   }
 
   private handleIntersection = async (entry: IntersectionObserverEntry) => {
+    if (this.isDestroyed) return;
     const isVisibile = getComputedStyle(entry.target).visibility === 'visible';
     // .contains check is needed for pip component as the video tiles are not mounted to dom element
     if (this.track.enabled && ((entry.isIntersecting && isVisibile) || !document.contains(entry.target))) {
@@ -104,6 +106,7 @@ export class VideoElementManager {
   };
 
   private handleResize = async (entry: ResizeObserverEntry) => {
+    if (this.isDestroyed) return;
     if (!this.track.enabled || !(this.track instanceof HMSRemoteVideoTrack)) {
       return;
     }
@@ -170,6 +173,7 @@ export class VideoElementManager {
   }
 
   cleanup = () => {
+    this.isDestroyed = true;
     this.videoElements.forEach(videoElement => {
       videoElement.srcObject = null;
       this.resizeObserver?.unobserve(videoElement);

--- a/packages/hms-video-store/src/media/tracks/observerAfterCleanup.test.ts
+++ b/packages/hms-video-store/src/media/tracks/observerAfterCleanup.test.ts
@@ -1,7 +1,7 @@
-import { VideoElementManager } from '../../../media/tracks/VideoElementManager';
-import { HMSRemoteVideoTrack } from '../../../media/tracks/HMSRemoteVideoTrack';
-import { HMSRemoteStream } from '../../../media/streams/HMSRemoteStream';
-import HMSSubscribeConnection from '../../../connection/subscribe/subscribeConnection';
+import { HMSRemoteVideoTrack } from './HMSRemoteVideoTrack';
+import { VideoElementManager } from './VideoElementManager';
+import HMSSubscribeConnection from '../../connection/subscribe/subscribeConnection';
+import { HMSRemoteStream } from '../streams/HMSRemoteStream';
 
 const makeRemoteVideoTrack = () => {
   const sendOverApiDataChannelWithResponse = jest.fn();

--- a/packages/hms-video-store/src/test/unit/tracks/observerAfterCleanup.test.ts
+++ b/packages/hms-video-store/src/test/unit/tracks/observerAfterCleanup.test.ts
@@ -1,0 +1,44 @@
+import { VideoElementManager } from '../../../media/tracks/VideoElementManager';
+import { HMSRemoteVideoTrack } from '../../../media/tracks/HMSRemoteVideoTrack';
+import { HMSRemoteStream } from '../../../media/streams/HMSRemoteStream';
+import HMSSubscribeConnection from '../../../connection/subscribe/subscribeConnection';
+
+const makeRemoteVideoTrack = () => {
+  const sendOverApiDataChannelWithResponse = jest.fn();
+  const connection = { sendOverApiDataChannelWithResponse } as unknown as HMSSubscribeConnection;
+  const stream = new HMSRemoteStream({ id: 'stream-1' } as MediaStream, connection);
+  const nativeTrack = {
+    id: 'track-1',
+    kind: 'video',
+    enabled: true,
+    getSettings: jest.fn(() => ({})),
+    addEventListener: jest.fn(),
+  } as unknown as MediaStreamTrack;
+  return new HMSRemoteVideoTrack(stream, nativeTrack, 'regular');
+};
+
+describe('VideoElementManager handlers fire after cleanup()', () => {
+  it('handleIntersection is a no-op after cleanup() — does not call addSink', async () => {
+    const track = makeRemoteVideoTrack();
+    const addSinkSpy = jest.spyOn(track, 'addSink').mockResolvedValue(undefined as any);
+    const removeSinkSpy = jest.spyOn(track, 'removeSink').mockResolvedValue(undefined as any);
+
+    const manager = new VideoElementManager(track);
+    const elem = document.createElement('video');
+    await manager.addVideoElement(elem);
+
+    manager.cleanup();
+    addSinkSpy.mockClear();
+    removeSinkSpy.mockClear();
+
+    const handleIntersection = (manager as any).handleIntersection;
+    await handleIntersection({
+      target: elem,
+      isIntersecting: true,
+      boundingClientRect: { width: 640, height: 360 },
+    } as unknown as IntersectionObserverEntry);
+
+    expect(addSinkSpy).not.toHaveBeenCalled();
+    expect(removeSinkSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
`VideoElementManager.cleanup()` nulls its observer fields but the module-level `HMSResizeObserver`/`HMSIntersectionObserver` keep the captured handler functions alive until the element is GC'd. A layout change in the meantime fires `handleResize`/`handleIntersection` on a torn-down manager and ends up calling `setPreferredLayer`/`addSink` on the track. Add an `isDestroyed` flag set in `cleanup()` and check it at the top of both handlers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8MWCfQ9JZ5RD9GCPXVx9p)_