### PR TITLE
fix(signal): pingPongLoop generation guard on reschedule

### DIFF
--- a/packages/hms-video-store/src/signal/jsonrpc/index.ts
+++ b/packages/hms-video-store/src/signal/jsonrpc/index.ts
@@ -617,7 +617,11 @@ export default class JsonRpcSignal {
           this.setIsConnected(false, 'ping pong failure');
         }
       } else {
-        setTimeout(() => this.pingPongLoop(id), window.HMS?.PING_INTERVAL || DEFAULT_SIGNAL_PING_INTERVAL);
+        setTimeout(() => {
+          if (this.id === id) {
+            this.pingPongLoop(id);
+          }
+        }, window.HMS?.PING_INTERVAL || DEFAULT_SIGNAL_PING_INTERVAL);
       }
     }
   }

--- a/packages/hms-video-store/src/signal/jsonrpc/pingPongGenGuard.test.ts
+++ b/packages/hms-video-store/src/signal/jsonrpc/pingPongGenGuard.test.ts
@@ -1,4 +1,4 @@
-import JsonRpcSignal from '../../../signal/jsonrpc';
+import JsonRpcSignal from '.';
 
 describe('pingPongLoop generation guard on reschedule', () => {
   beforeEach(() => jest.useFakeTimers());

--- a/packages/hms-video-store/src/test/unit/signal/pingPongGenGuard.test.ts
+++ b/packages/hms-video-store/src/test/unit/signal/pingPongGenGuard.test.ts
@@ -1,0 +1,30 @@
+import JsonRpcSignal from '../../../signal/jsonrpc';
+
+describe('pingPongLoop generation guard on reschedule', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('does not run a second iteration after id is incremented (close+reopen) on success path', async () => {
+    const pingSpy = jest.fn(() => Promise.resolve(10));
+    const pingPongLoop = (JsonRpcSignal.prototype as any).pingPongLoop as (this: any, id: number) => Promise<void>;
+    const fakeThis: any = {
+      isConnected: true,
+      id: 1,
+      pongResponseTimes: { enqueue: jest.fn() },
+      ping: pingSpy,
+      setIsConnected: jest.fn(),
+      TAG: '[test]',
+    };
+    fakeThis.pingPongLoop = pingPongLoop.bind(fakeThis);
+
+    await fakeThis.pingPongLoop(1);
+    expect(pingSpy).toHaveBeenCalledTimes(1);
+
+    fakeThis.id = 2;
+    jest.runOnlyPendingTimers();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(pingSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
The successful-pong branch of `pingPongLoop` scheduled the next iteration without checking that `this.id === id`, so a stale loop could re-arm after `close()+open()`. The pong-timeout branch already had this guard; mirror it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8MWCfQ9JZ5RD9GCPXVx9p)_