### PR TITLE
fix(media): stop prior processedTrack AFTER sender.replaceTrack lands

### DIFF
--- a/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.test.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.test.ts
@@ -66,4 +66,193 @@ describe('HMSLocalVideoTrack', () => {
       expect(replaceSpy).toHaveBeenCalledTimes(1);
     });
   });
+
+  // The cheap single-plugin path is covered above. Real-world usage layers
+  // multiple media-stream plugins (e.g. virtual background + brightness),
+  // and processPlugins runs the whole chain on every add/remove. The chain's
+  // *final* output is what becomes `processedTrack`; if that final output
+  // isn't stopped before being overwritten on a re-run, the previous chain's
+  // canvas-captureStream leaks until GC.
+  describe('removeOrReplaceProcessedTrack with chained media-stream plugins', () => {
+    type FakeMediaStreamCtor = new (tracks: MediaStreamTrack[]) => MediaStream;
+
+    let originalMediaStream: FakeMediaStreamCtor | undefined;
+
+    beforeAll(() => {
+      // jsdom doesn't ship MediaStream; processPlugins calls
+      // `new MediaStream([nativeTrack])` so we polyfill the minimum surface.
+      originalMediaStream = (global as any).MediaStream;
+      (global as any).MediaStream = class {
+        tracks: MediaStreamTrack[];
+        constructor(tracks: MediaStreamTrack[] = []) {
+          this.tracks = tracks;
+        }
+        getVideoTracks() {
+          return this.tracks.filter(t => t.kind === 'video');
+        }
+        getTracks() {
+          return this.tracks;
+        }
+      };
+    });
+
+    afterAll(() => {
+      (global as any).MediaStream = originalMediaStream;
+    });
+
+    const makeFakeTrack = (id: string): MediaStreamTrack => {
+      return { id, kind: 'video', stop: jest.fn() } as any;
+    };
+
+    const makeFakePlugin = (name: string) => {
+      let count = 0;
+      const outputs: MediaStreamTrack[] = [];
+      const plugin = {
+        getName: () => name,
+        apply: jest.fn((_stream: MediaStream) => {
+          count += 1;
+          const out = makeFakeTrack(`${name}-out-${count}`);
+          outputs.push(out);
+          return new (global as any).MediaStream([out]);
+        }),
+        stop: jest.fn(),
+      };
+      return { plugin, outputs };
+    };
+
+    it('two plugins → adding a third stops the prior chain output', async () => {
+      const track = makeLocalVideoTrack();
+      jest.spyOn(track as any, 'replaceSenderTrack').mockResolvedValue(undefined);
+      jest.spyOn((track as any).videoHandler, 'updateSinks').mockImplementation(() => {});
+
+      const a = makeFakePlugin('A');
+      const b = makeFakePlugin('B');
+
+      await track.addStreamPlugins([a.plugin, b.plugin] as any);
+
+      // After the first chain run, processedTrack is the LAST plugin's output.
+      const firstChainOutput = (track as any).processedTrack;
+      expect(firstChainOutput).toBe(b.outputs[0]);
+      expect(firstChainOutput.id).toBe('B-out-1');
+
+      // Adding a third plugin re-runs the entire chain → A applies again, B
+      // applies again on A's new output, C applies on B's new output. The
+      // PRIOR processedTrack (B-out-1) must be stopped before being swapped
+      // out for the new chain's final output.
+      const c = makeFakePlugin('C');
+      await track.addStreamPlugins([c.plugin] as any);
+
+      expect(firstChainOutput.stop).toHaveBeenCalledTimes(1);
+      expect((track as any).processedTrack).toBe(c.outputs[0]);
+      expect((track as any).processedTrack.id).toBe('C-out-1');
+
+      // Sanity: each plugin's apply ran twice (once per chain run).
+      expect(a.plugin.apply).toHaveBeenCalledTimes(2);
+      expect(b.plugin.apply).toHaveBeenCalledTimes(2);
+      expect(c.plugin.apply).toHaveBeenCalledTimes(1);
+    });
+
+    it('two plugins → removing all stops the chain output and clears processedTrack', async () => {
+      const track = makeLocalVideoTrack();
+      jest.spyOn(track as any, 'replaceSenderTrack').mockResolvedValue(undefined);
+      jest.spyOn((track as any).videoHandler, 'updateSinks').mockImplementation(() => {});
+
+      const a = makeFakePlugin('A');
+      const b = makeFakePlugin('B');
+
+      await track.addStreamPlugins([a.plugin, b.plugin] as any);
+      const chainOutput = (track as any).processedTrack;
+      expect(chainOutput).toBe(b.outputs[0]);
+
+      await track.removeStreamPlugins([a.plugin, b.plugin] as any);
+
+      expect(chainOutput.stop).toHaveBeenCalledTimes(1);
+      expect((track as any).processedTrack).toBeUndefined();
+    });
+  });
+
+  // The earlier fix stopped the prior processedTrack BEFORE awaiting
+  // sender.replaceTrack. That left the RTCRtpSender briefly wired to an
+  // ended source — the encoder would stop producing while replaceTrack
+  // landed, and the remote side would see a frame stutter on plugin swap.
+  // The current ordering swaps the sender first, then stops the old track,
+  // so the encoder never sees an ended source. These tests pin the order.
+  describe('removeOrReplaceProcessedTrack ordering: swap sender before stopping old', () => {
+    it('replaceSenderTrack resolves BEFORE old.stop() when overwriting', async () => {
+      const track = makeLocalVideoTrack();
+
+      const events: string[] = [];
+      let resolveReplace!: () => void;
+      jest.spyOn(track as any, 'replaceSenderTrack').mockImplementation(
+        () =>
+          new Promise<void>(resolve => {
+            events.push('replaceSenderTrack:enter');
+            resolveReplace = () => {
+              events.push('replaceSenderTrack:resolve');
+              resolve();
+            };
+          }),
+      );
+
+      const oldProcessed = {
+        stop: jest.fn(() => events.push('oldProcessed.stop')),
+      } as unknown as MediaStreamTrack;
+      const newProcessed = { stop: jest.fn() } as unknown as MediaStreamTrack;
+
+      (track as any).processedTrack = oldProcessed;
+      const p = (track as any).removeOrReplaceProcessedTrack(newProcessed);
+
+      // Run the function up to its first await on replaceSenderTrack.
+      await Promise.resolve();
+
+      // We're suspended inside removeOrReplaceProcessedTrack at the await.
+      // The old track must NOT have been stopped yet — sender swap hasn't
+      // landed.
+      expect(events).toEqual(['replaceSenderTrack:enter']);
+      expect(oldProcessed.stop).not.toHaveBeenCalled();
+
+      // Resolve the sender swap; the function continues and stops the old.
+      resolveReplace();
+      await p;
+
+      expect(events).toEqual(['replaceSenderTrack:enter', 'replaceSenderTrack:resolve', 'oldProcessed.stop']);
+      expect(oldProcessed.stop).toHaveBeenCalledTimes(1);
+      expect((track as any).processedTrack).toBe(newProcessed);
+    });
+
+    it('replaceSenderTrack resolves BEFORE old.stop() when clearing to undefined', async () => {
+      const track = makeLocalVideoTrack();
+
+      const events: string[] = [];
+      let resolveReplace!: () => void;
+      jest.spyOn(track as any, 'replaceSenderTrack').mockImplementation(
+        () =>
+          new Promise<void>(resolve => {
+            events.push('replaceSenderTrack:enter');
+            resolveReplace = () => {
+              events.push('replaceSenderTrack:resolve');
+              resolve();
+            };
+          }),
+      );
+
+      const oldProcessed = {
+        stop: jest.fn(() => events.push('oldProcessed.stop')),
+      } as unknown as MediaStreamTrack;
+
+      (track as any).processedTrack = oldProcessed;
+      const p = (track as any).removeOrReplaceProcessedTrack(undefined);
+
+      await Promise.resolve();
+
+      expect(events).toEqual(['replaceSenderTrack:enter']);
+      expect(oldProcessed.stop).not.toHaveBeenCalled();
+
+      resolveReplace();
+      await p;
+
+      expect(events).toEqual(['replaceSenderTrack:enter', 'replaceSenderTrack:resolve', 'oldProcessed.stop']);
+      expect((track as any).processedTrack).toBeUndefined();
+    });
+  });
 });

--- a/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
@@ -614,20 +614,24 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
    * @param {MediaStreamTrack|undefined}processedTrack
    */
   private removeOrReplaceProcessedTrack = async (processedTrack?: MediaStreamTrack) => {
-    // if all plugins are removed reset everything back to native track
+    /*
+     * Capture the previous processedTrack BEFORE swapping the field, then
+     * stop it AFTER the sender has been pointed at the new track. Stopping
+     * before sender.replaceTrack would leave the RTCRtpSender briefly wired
+     * to an ended track — its encoder stops producing, and the remote side
+     * sees a frame stutter while replaceTrack lands. Doing the swap first,
+     * then stop, means the encoder never sees an ended source.
+     */
+    const prevProcessedTrack = this.processedTrack;
     if (!processedTrack) {
-      this.processedTrack?.stop();
       this.processedTrack = undefined;
     } else if (processedTrack !== this.processedTrack) {
-      /*
-       * Stop the previous processed track (a canvas captureStream) before
-       * overwriting — otherwise the old canvas stream stays alive consuming
-       * GPU resources until GC.
-       */
-      this.processedTrack?.stop();
       this.processedTrack = processedTrack;
     }
     await this.replaceSenderTrack(this.processedTrack || this.nativeTrack);
+    if (prevProcessedTrack && prevProcessedTrack !== this.processedTrack) {
+      prevProcessedTrack.stop();
+    }
   };
 
   // eslint-disable-next-line complexity


### PR DESCRIPTION
Follow-up to #3667.

`removeOrReplaceProcessedTrack` stopped the prior `processedTrack` *before* awaiting `sender.replaceTrack(newTrack)`. That left the `RTCRtpSender` wired to an ended source for the duration of the swap — encoder stops producing, and the remote side sees a frame stutter (~10–50ms) during plugin add/remove. Not a sustained blank tile (jitter buffer absorbs it), but observable on rapid plugin toggles and on simulcast.

Capture the old processedTrack in a local, swap the sender first, then stop the old. The encoder pipeline only ever sees a track-to-track swap, never a stop-then-swap.

## Tests

- Pin the call order (`replaceSenderTrack` resolves → `old.stop()`) for both the overwrite path and the clear-to-undefined path.
- Adds a two-plugin chain test (adding a third → removing all) exercising the realistic `addStreamPlugins` / `removeStreamPlugins` path. The single-plugin tests #3667 added didn't cover the multi-plugin chain, which is the configuration most likely to hit this in production.

All 7 tests pass.