### PR TITLE
fix(prebuilt): pin PDFView to gallery layout mode

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/layouts/PDFView.jsx
+++ b/packages/roomkit-react/src/Prebuilt/layouts/PDFView.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect } from 'react';
 import { usePDFShare } from '@100mslive/react-sdk';
+import { LayoutMode } from '../components/Settings/LayoutSettings';
 import { ToastManager } from '../components/Toast/ToastManager';
 import { Box } from '../../Layout';
 import { EmbedScreenShareView } from './EmbedView';
-import { usePDFConfig, useResetPDFConfig } from '../components/AppData/useUISettings';
+import { usePDFConfig, useResetPDFConfig, useSetUiSettings } from '../components/AppData/useUISettings';
+import { UI_SETTINGS } from '../common/constants';
 
 /**
  * PDFView is responsible for rendering the PDF iframe and managing the screen sharing functionality.
@@ -13,6 +15,21 @@ export const PDFView = () => {
   const resetConfig = useResetPDFConfig();
   // need to send resetConfig to clear configuration, if stop screenshare occurs.
   const { iframeRef, startPDFShare, isPDFShareInProgress } = usePDFShare(resetConfig);
+  const [layoutMode, setLayoutMode] = useSetUiSettings(UI_SETTINGS.layoutMode);
+
+  useEffect(() => {
+    // PDF view should render in gallery mode. Peer layouts (Screenshare/Whiteboard) force
+    // SIDEBAR but PDFView never mounts inside GridLayout, so nothing else reconciles it.
+    if (layoutMode === LayoutMode.GALLERY) {
+      return;
+    }
+    setLayoutMode(LayoutMode.GALLERY);
+    return () => {
+      // restore previous layout mode once PDF view closes
+      setLayoutMode(layoutMode);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     // no working in other useEffect, as return is called multiple time on state change


### PR DESCRIPTION
`PDFView` is a peer of `GridLayout` inside `VideoStreamingSection` — the `ts-pattern` chain short-circuits to `<PDFView />` before reaching `<GridLayout />`, so `ScreenshareLayout` / `WhiteboardLayout` (which are children of `GridLayout`) never mount on the local presenter while a PDF is being shared. Those are the only components that reconcile `APP_DATA.uiSettings.layoutMode`, and the value is persisted to localStorage via `useUserPreferences`, so it retains whatever the user (or a prior screenshare/whiteboard mount) last set — typically `SIDEBAR`. `SidePane.tsx` reads `layoutMode` to decide whether to render the screenshare's video tile inline (`layoutMode === GALLERY`), so the PDF iframe ends up rendering into a sidebar-shaped slot instead of the gallery layout.

Mirror the existing `ScreenshareLayout` / `WhiteboardLayout` effect shape in `PDFView`:

- no-op when `layoutMode` is already `GALLERY`
- otherwise switch to `GALLERY` on mount and restore the captured prior mode on unmount

This puts the layout-mode responsibility at the same layer the sibling peer layouts already use, rather than patching downstream consumers.

## Tests

- Manual: join a room, open Settings → Layout → set Sidebar; share a PDF — iframe now renders in gallery layout. Stop the PDF share — layout returns to Sidebar.
- Manual: start a regular screenshare (forces Sidebar), stop it, then share a PDF — PDF renders in gallery as expected.
- Manual: with default (Gallery) layout, share a PDF — no spurious app-data write (early return).