### PR TITLE
fix(deps): bump sigstore to 4.1.1 (certificateOIDs not enforced, high)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1567,6 +1567,11 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.1.tgz#1a5b1959a528e374e8037c4396c3e825d6cf4a83"
   integrity sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==
 
+"@gar/promise-retry@^1.0.0", "@gar/promise-retry@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@gar/promise-retry/-/promise-retry-1.0.3.tgz#65e726428e794bc4453948e0a41e6de4215ce8b0"
+  integrity sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==
+
 "@humanwhocodes/config-array@^0.11.10":
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.10.tgz#5a3ffe32cc9306365fb3fd572596cd602d5e12d2"
@@ -3713,43 +3718,43 @@
   dependencies:
     "@sigstore/protobuf-specs" "^0.5.0"
 
-"@sigstore/core@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@sigstore/core/-/core-3.1.0.tgz#b418de73f56333ad9e369b915173d8c98e9b96d5"
-  integrity sha512-o5cw1QYhNQ9IroioJxpzexmPjfCe7gzafd2RY3qnMpxr4ZEja+Jad/U8sgFpaue6bOaF+z7RVkyKVV44FN+N8A==
+"@sigstore/core@^3.2.0", "@sigstore/core@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@sigstore/core/-/core-3.2.1.tgz#4efd4ab0f59e768b6daf65612024ba925787de72"
+  integrity sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g==
 
 "@sigstore/protobuf-specs@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@sigstore/protobuf-specs/-/protobuf-specs-0.5.0.tgz#e5f029edcb3a4329853a09b603011e61043eb005"
   integrity sha512-MM8XIwUjN2bwvCg1QvrMtbBmpcSHrkhFSCu1D11NyPvDQ25HEc4oG5/OcQfd/Tlf/OxmKWERDj0zGE23jQaMwA==
 
-"@sigstore/sign@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@sigstore/sign/-/sign-4.1.0.tgz#63df15a137337b29f463a1d1c51e1f7d4c1db2f1"
-  integrity sha512-Vx1RmLxLGnSUqx/o5/VsCjkuN5L7y+vxEEwawvc7u+6WtX2W4GNa7b9HEjmcRWohw/d6BpATXmvOwc78m+Swdg==
+"@sigstore/sign@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@sigstore/sign/-/sign-4.1.1.tgz#34765fe4a190d693340c0771a3d150a397bcfc55"
+  integrity sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==
   dependencies:
+    "@gar/promise-retry" "^1.0.2"
     "@sigstore/bundle" "^4.0.0"
-    "@sigstore/core" "^3.1.0"
+    "@sigstore/core" "^3.2.0"
     "@sigstore/protobuf-specs" "^0.5.0"
-    make-fetch-happen "^15.0.3"
+    make-fetch-happen "^15.0.4"
     proc-log "^6.1.0"
-    promise-retry "^2.0.1"
 
-"@sigstore/tuf@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@sigstore/tuf/-/tuf-4.0.1.tgz#9b080390936d79ea3b6a893b64baf3123e92d6d3"
-  integrity sha512-OPZBg8y5Vc9yZjmWCHrlWPMBqW5yd8+wFNl+thMdtcWz3vjVSoJQutF8YkrzI0SLGnkuFof4HSsWUhXrf219Lw==
+"@sigstore/tuf@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@sigstore/tuf/-/tuf-4.0.2.tgz#7d2fa2abcd5afa5baf752671d14a1c6ed0ed3196"
+  integrity sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==
   dependencies:
     "@sigstore/protobuf-specs" "^0.5.0"
     tuf-js "^4.1.0"
 
-"@sigstore/verify@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@sigstore/verify/-/verify-3.1.0.tgz#4046d4186421db779501fe87fa5acaa5d4d21b08"
-  integrity sha512-mNe0Iigql08YupSOGv197YdHpPPr+EzDZmfCgMc7RPNaZTw5aLN01nBl6CHJOh3BGtnMIj83EeN4butBchc8Ag==
+"@sigstore/verify@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@sigstore/verify/-/verify-3.1.1.tgz#13c1c1cff28fe81f662de29d85ba5ae048fcbd8d"
+  integrity sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==
   dependencies:
     "@sigstore/bundle" "^4.0.0"
-    "@sigstore/core" "^3.1.0"
+    "@sigstore/core" "^3.2.1"
     "@sigstore/protobuf-specs" "^0.5.0"
 
 "@sinclair/typebox@^0.27.8":
@@ -9515,7 +9520,7 @@ make-fetch-happen@15.0.2:
     promise-retry "^2.0.1"
     ssri "^12.0.0"
 
-make-fetch-happen@^15.0.0, make-fetch-happen@^15.0.1, make-fetch-happen@^15.0.3:
+make-fetch-happen@^15.0.0, make-fetch-happen@^15.0.1:
   version "15.0.3"
   resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-15.0.3.tgz#1578d72885f2b3f9e5daa120b36a14fc31a84610"
   integrity sha512-iyyEpDty1mwW3dGlYXAJqC/azFn5PPvgKVwXayOGBSmKLxhKZ9fg4qIan2ePpp1vJIwfFiO34LAPZgq9SZW9Aw==
@@ -9530,6 +9535,24 @@ make-fetch-happen@^15.0.0, make-fetch-happen@^15.0.1, make-fetch-happen@^15.0.3:
     negotiator "^1.0.0"
     proc-log "^6.0.0"
     promise-retry "^2.0.1"
+    ssri "^13.0.0"
+
+make-fetch-happen@^15.0.4:
+  version "15.0.6"
+  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-15.0.6.tgz#079dee708c88a04a1f79735bb02789a63597840e"
+  integrity sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==
+  dependencies:
+    "@gar/promise-retry" "^1.0.0"
+    "@npmcli/agent" "^4.0.0"
+    "@npmcli/redact" "^4.0.0"
+    cacache "^20.0.1"
+    http-cache-semantics "^4.1.1"
+    minipass "^7.0.2"
+    minipass-fetch "^5.0.0"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.4"
+    negotiator "^1.0.0"
+    proc-log "^6.0.0"
     ssri "^13.0.0"
 
 makeerror@1.0.12:
@@ -11593,16 +11616,16 @@ signal-exit@^4.0.1, signal-exit@^4.1.0:
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
 sigstore@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/sigstore/-/sigstore-4.1.0.tgz#d34b92a544a05e003a2430209d26d8dfafd805a0"
-  integrity sha512-/fUgUhYghuLzVT/gaJoeVehLCgZiUxPCPMcyVNY0lIf/cTCz58K/WTI7PefDarXxp9nUKpEwg1yyz3eSBMTtgA==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/sigstore/-/sigstore-4.1.1.tgz#2959993dbf978c759a5d23d854cbd3729b6dcd97"
+  integrity sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w==
   dependencies:
     "@sigstore/bundle" "^4.0.0"
-    "@sigstore/core" "^3.1.0"
+    "@sigstore/core" "^3.2.1"
     "@sigstore/protobuf-specs" "^0.5.0"
-    "@sigstore/sign" "^4.1.0"
-    "@sigstore/tuf" "^4.0.1"
-    "@sigstore/verify" "^3.1.0"
+    "@sigstore/sign" "^4.1.1"
+    "@sigstore/tuf" "^4.0.2"
+    "@sigstore/verify" "^3.1.1"
 
 sisteransi@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
## What

Bumps `sigstore` **4.1.0 → 4.1.1** to close a high-severity Dependabot alert, plus the four sub-dependencies its new version requires.

Lockfile-only change. No `package.json` in this repo was modified.

## The vulnerability

**High — sigstore's `certificateOIDs` verification constraints are silently dropped and never enforced** (affects `<= 4.1.0`)

`sigstore` verifies signatures. Its verification policy accepts a `certificateOIDs` option used to assert *"the signing certificate must carry these specific OID values"* — the mechanism for pinning **which** identity or CI workflow was allowed to sign an artifact.

In `<= 4.1.0` that constraint was parsed and then never applied. Verification returned success for artifacts that should have failed the policy, with no error and no warning that the constraint had been ignored. Code relying on `certificateOIDs` to restrict signers had no actual protection while appearing to — a silent failure, which is worse than no check at all, because it produces a false assurance nobody has reason to re-examine.

## Blast radius here: low

`sigstore` is **not a direct dependency** and is not imported by any package source (`grep -rn sigstore packages/ --include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx'` returns nothing). It arrives transitively through lerna's publish tooling:

```
lerna → libnpmpublish / npm-registry-fetch → sigstore@^4.0.0
```

So it runs at **publish time only**. Nothing shipped to SDK consumers changes, and no published bundle is affected. Fixing it still matters — this is the code path that would verify provenance during release — but it is not a runtime exposure for anyone using the SDKs.

## Why the lockfile diff removes and re-adds whole blocks

Worth reading before reviewing the diff, because it looks larger than it is: **no dependency was removed.**

A yarn v1 lockfile entry is keyed by *the semver range a parent requested*, not by package name. `"@sigstore/core@^3.1.0":` means "whoever asks for `^3.1.0` resolves to this block." It records resolution decisions; it does not declare dependencies.

`sigstore` 4.1.1 tightened four sub-dep ranges at once, and every one of them was pinned at the **lowest** version satisfying the old range — so none satisfied the new one:

| package | 4.1.0 asked | 4.1.1 asks | was locked at | now |
|---|---|---|---|---|
| `@sigstore/core` | `^3.1.0` | `^3.2.1` | 3.1.0 | **3.2.1** |
| `@sigstore/sign` | `^4.1.0` | `^4.1.1` | 4.1.0 | **4.1.1** |
| `@sigstore/tuf` | `^4.0.1` | `^4.0.2` | 4.0.1 | **4.0.2** |
| `@sigstore/verify` | `^3.1.0` | `^3.1.1` | 3.1.0 | **3.1.1** |

No entry had a key covering `^3.2.1`, and the old keys became dead once `sigstore` moved. Editing the `version:` lines in place would have meant hand-writing new range keys, `resolved` URLs, and `integrity` hashes for five interlocking packages — and hand-written integrity hashes are precisely where a wrong-artifact bug hides.

Instead the five stale blocks were deleted and `yarn install` recomputed keys, versions, and hashes itself, verifying each hash against the real tarball. This is the standard yarn v1 method for bumping a transitive dep that has no direct `package.json` entry.

Confirmed safe to re-resolve beforehand: every requester of `@sigstore/*` is another `@sigstore/*` package or `sigstore` itself — the subtree has **no external consumers**.

The cleanest illustration is the last hunk: the `sigstore@^4.0.0:` key is **unchanged**, because `libnpmpublish` still asks for `^4.0.0`. Only the resolved version moved. Net diff is **+51 / −28** — a rewrite, not a deletion.

## Also fixed for free

Two medium alerts share fix versions with this bump and will close alongside it:

- **Medium — `@sigstore/core` DSSE `payloadType` type-binding failure** → fixed in 3.2.1
- **Medium — `@sigstore/verify` insufficient verification of data authenticity** → fixed in 3.1.1

## Knock-on effects

Both originate upstream in `@sigstore/sign` 4.1.1:

1. **`@gar/promise-retry` 1.0.3 added** — upstream swapped `promise-retry` for the scoped fork. A substitution, not new surface.
2. **`make-fetch-happen` 15.0.6 entry added** — 4.1.1 requires `^15.0.4`, which the existing 15.0.3 entry cannot satisfy. This repo already carried 15.0.2 and 15.0.3 side by side, so this is a third copy of an already-duplicated dev-tooling package. No bundle impact.

## Verification

- `yarn install` — clean; every integrity hash validated against its downloaded tarball.
- Diff scope audited: all changed lockfile keys are `@sigstore/*`, `sigstore`, `@gar/promise-retry`, or `make-fetch-happen`. Nothing unrelated moved.
- All seven sigstore-family packages present and at expected versions: `sigstore` 4.1.1, `@sigstore/core` 3.2.1, `@sigstore/sign` 4.1.1, `@sigstore/tuf` 4.0.2, `@sigstore/verify` 3.1.1, `@sigstore/bundle` 4.0.0, `@sigstore/protobuf-specs` 0.5.0.
- `lerna --version` → 9.0.7, still runs.
- `require('sigstore')` loads and exports its full API (`attest`, `createVerifier`, `sign`, `verify`, …).
- `libnpmpublish` resolves to the new copy.

No test suite was run: this touches publish-time tooling that no source file imports, so the module-load and lerna checks are the meaningful verification level here.

## Scope

Deliberately limited to the sigstore alert. **Six other alerts remain open on `main`** and are not addressed here: `brace-expansion` (high, → 1.1.16 / 5.0.7), `fast-uri` (high, → 3.1.4), `immutable` (high, → 5.1.8), `shell-quote` (high, → 1.9.0), `svgo` (high, → 3.3.4), `tar` (medium, → 7.5.18).

Note there are also existing Dependabot branches for several of these (`fast-uri-3.1.4`, `immutable-5.1.9`, `svgo-3.3.4`, plus a grouped `npm-minor-and-patch` branch). Dependabot's own `sigstore-4.1.1`, `sigstore/core-3.2.1`, and `sigstore/verify-3.1.1` branches are **superseded by this PR** and can be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)