### PR TITLE
fix(store): set transport listener on first init

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      # Pinned to v6: v7 runs `yarn cache dir` after writing the registry-url .npmrc,
+      # and yarn aborts on the unresolved ${NODE_AUTH_TOKEN} placeholder (auth here is
+      # OIDC, so that variable is never set). Broke every publish since #3717.
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'yarn'

--- a/packages/hms-video-store/src/sdk/index.ts
+++ b/packages/hms-video-store/src/sdk/index.ts
@@ -245,6 +245,13 @@ export class HMSSdk implements HMSInterface {
       this.analyticsTimer,
       this.pluginUsageTracker,
     );
+    /**
+     * Unlike the other managers, transport takes no listener in its constructor, so it has to be
+     * set explicitly here too. Without this it stays unset on the first init (a join with no
+     * preview, or a rejoin after leave since cleanup resets sdkState) and transport-emitted
+     * updates - onSFUMigration in particular - are silently dropped.
+     */
+    this.transport.setListener(this.listener);
     // add diagnostics callbacks if present
     if ('onInitSuccess' in listener) {
       this.transport.setConnectivityListener(listener);

--- a/packages/hms-video-store/src/sdk/initStoreAndManagers.test.ts
+++ b/packages/hms-video-store/src/sdk/initStoreAndManagers.test.ts
@@ -1,0 +1,59 @@
+import { HMSSdk } from './index';
+import { HMSUpdateListener } from '../interfaces';
+
+const makeListener = () =>
+  ({
+    onJoin: jest.fn(),
+    onPreview: jest.fn(),
+    onRoomUpdate: jest.fn(),
+    onPeerUpdate: jest.fn(),
+    onTrackUpdate: jest.fn(),
+    onMessageReceived: jest.fn(),
+    onError: jest.fn(),
+    onReconnected: jest.fn(),
+    onReconnecting: jest.fn(),
+    onRoleChangeRequest: jest.fn(),
+    onRoleUpdate: jest.fn(),
+    onDeviceChange: jest.fn(),
+    onChangeTrackStateRequest: jest.fn(),
+    onChangeMultiTrackStateRequest: jest.fn(),
+    onRemovedFromRoom: jest.fn(),
+    onNetworkQuality: jest.fn(),
+    onSessionStoreUpdate: jest.fn(),
+    onPollsUpdate: jest.fn(),
+    onWhiteboardUpdate: jest.fn(),
+    onSFUMigration: jest.fn(),
+  } as unknown as HMSUpdateListener);
+
+/**
+ * transport is the only manager that doesn't take the listener in its constructor. When it was
+ * only set in the already-initialised branch, a join with no preview left it unset and every
+ * transport-emitted update (onSFUMigration) was dropped - the reactive store then kept the
+ * pre-migration local track ids for the rest of the session.
+ */
+describe('HMSSdk.initStoreAndManagers', () => {
+  it('sets the transport listener on first init (join without preview)', () => {
+    const sdk = new HMSSdk();
+    const listener = makeListener();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (sdk as any).initStoreAndManagers(listener);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((sdk as any).transport.listener).toBe(listener);
+  });
+
+  it('updates the transport listener on a second init (preview then join)', () => {
+    const sdk = new HMSSdk();
+    const previewListener = makeListener();
+    const joinListener = makeListener();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (sdk as any).initStoreAndManagers(previewListener);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (sdk as any).initStoreAndManagers(joinListener);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((sdk as any).transport.listener).toBe(joinListener);
+  });
+});


### PR DESCRIPTION
`transport` is the only manager that doesn't receive the update listener in its constructor, and it was only assigned in the already-initialised branch of `initStoreAndManagers`. A join without a preceding `preview()` — or a rejoin after `leave()` — therefore left it unset, so transport-emitted updates were silently dropped.

The visible effect was `onSFUMigration` never reaching the store: after an SFU migration the SDK republished local tracks correctly, but the reactive store kept the pre-migration ids, leaving `localPeer.videoTrack` pointing at a track that no longer exists and the local video element blank.

Also pins `actions/setup-node` back to v6 in the publish workflow. v7 runs the yarn cache step after writing the `registry-url` `.npmrc` and aborts on the unresolved `${NODE_AUTH_TOKEN}` placeholder (auth is OIDC, so that variable is never set), which has been failing every publish.