### PR TITLE
feat(stats): report audio echo-cancellation metrics in publisher stats

### DIFF
--- a/packages/hms-video-store/src/analytics/stats/BaseStatsAnalytics.ts
+++ b/packages/hms-video-store/src/analytics/stats/BaseStatsAnalytics.ts
@@ -1,4 +1,5 @@
 import {
+  LocalAudioSample,
   LocalAudioTrackAnalytics,
   LocalBaseSample,
   LocalVideoSample,
@@ -146,7 +147,12 @@ export abstract class RunningTrackAnalytics {
 
   abstract shouldCreateSample: () => boolean;
 
-  protected abstract collateSample: () => LocalBaseSample | LocalVideoSample | RemoteAudioSample | RemoteVideoSample;
+  protected abstract collateSample: () =>
+    | LocalBaseSample
+    | LocalAudioSample
+    | LocalVideoSample
+    | RemoteAudioSample
+    | RemoteVideoSample;
 
   protected abstract toAnalytics: () =>
     | LocalAudioTrackAnalytics
@@ -160,6 +166,12 @@ export abstract class RunningTrackAnalytics {
 
   protected getFirstStat() {
     return this.tempStats[0];
+  }
+
+  protected collectNumericValues(key: keyof TempStats): number[] {
+    return this.tempStats
+      .map(stat => stat[key])
+      .filter((value): value is number => typeof value === 'number' && Number.isFinite(value));
   }
 
   protected calculateSum(key: keyof TempStats) {

--- a/packages/hms-video-store/src/analytics/stats/PublishStatsAnalytics.test.ts
+++ b/packages/hms-video-store/src/analytics/stats/PublishStatsAnalytics.test.ts
@@ -1,0 +1,116 @@
+import { TempStats } from './BaseStatsAnalytics';
+import { LocalAudioSample, LocalVideoSample } from './interfaces';
+import { RunningLocalTrackAnalytics } from './PublishStatsAnalytics';
+
+// The aggregator only reaches for trackId/source and the two optional metric getters, so a
+// plain object stands in for HMSTrack rather than a full media-stack fixture.
+const fakeTrack = () => ({
+  trackId: 'track-1',
+  source: 'regular',
+  getMediaTrackSettings: () => ({ echoCancellation: true }),
+  getPluginsMetrics: () => ({}),
+});
+
+const makeAnalytics = (kind: string) =>
+  new RunningLocalTrackAnalytics({
+    track: fakeTrack(),
+    ssrc: '1',
+    kind,
+    sampleWindowSize: 30,
+  });
+
+const collate = (kind: string, stats: Partial<TempStats>[]) => {
+  const analytics = makeAnalytics(kind);
+  stats.forEach((stat, index) => analytics.pushTempStat({ timestamp: 1000 + index * 1000, ...stat } as TempStats));
+  analytics.createSample();
+  return analytics.samples[0] as LocalAudioSample & LocalVideoSample;
+};
+
+describe('RunningLocalTrackAnalytics — audio source stats', () => {
+  test('does not emit video frame counters on audio samples', () => {
+    // Audio tracks resolve a media-source (for ERLE), which sets sourceStatsAvailable. The
+    // frame counters coerce missing values to 0, so without a kind gate they would ship as
+    // a real "0 frames captured" on every audio sample.
+    const sample = collate('audio', [
+      { sourceStatsAvailable: true, sourceTotalAudioEnergy: 1 },
+      { sourceStatsAvailable: true, sourceTotalAudioEnergy: 3 },
+    ]);
+
+    expect(sample).not.toHaveProperty('source_total_frames');
+    expect(sample).not.toHaveProperty('source_total_frames_dropped');
+    expect(sample).not.toHaveProperty('source_avg_fps');
+    expect(sample).not.toHaveProperty('source_resolution');
+  });
+
+  test('reports capture energy even when the canceller reports no ERL/ERLE', () => {
+    // echoCancellation: false — no canceller means no ERL/ERLE, but "was the mic live"
+    // is exactly the question being asked of that cohort, so energy must survive.
+    // These are cumulative counters: the first window reports the total since track start,
+    // every later window reports the delta against the previous window's last stat.
+    const analytics = makeAnalytics('audio');
+    analytics.pushTempStat({ timestamp: 1000, sourceTotalAudioEnergy: 2, sourceTotalSamplesDuration: 10 } as TempStats);
+    analytics.pushTempStat({ timestamp: 2000, sourceTotalAudioEnergy: 8, sourceTotalSamplesDuration: 40 } as TempStats);
+    analytics.createSample();
+
+    analytics.pushTempStat({
+      timestamp: 3000,
+      sourceTotalAudioEnergy: 15,
+      sourceTotalSamplesDuration: 70,
+    } as TempStats);
+    analytics.createSample();
+
+    const [first, second] = analytics.samples as LocalAudioSample[];
+    expect(first.total_audio_energy).toBe(8);
+    expect(first.total_samples_duration_sec).toBe(40);
+    expect(second.total_audio_energy).toBe(7);
+    expect(second.total_samples_duration_sec).toBe(30);
+    expect(first.erle_db_min).toBeUndefined();
+    expect(first.erle_distinct_count).toBeUndefined();
+  });
+
+  test('aggregates capture level as a range', () => {
+    const sample = collate('audio', [{ sourceAudioLevel: 0.4 }, { sourceAudioLevel: 0.05 }, { sourceAudioLevel: 0.9 }]);
+
+    expect(sample.audio_level_min).toBe(0.05);
+    expect(sample.audio_level_max).toBe(0.9);
+  });
+
+  test('omits energy entirely when the browser never reported it, rather than sending 0', () => {
+    // A missing counter must not be indistinguishable from measured silence.
+    const sample = collate('audio', [{ sourceAudioLevel: 0.1 }, { sourceAudioLevel: 0.2 }]);
+
+    expect(sample.total_audio_energy).toBeUndefined();
+    expect(sample.total_samples_duration_sec).toBeUndefined();
+  });
+
+  test('separates a pinned canceller from an adapting one via erle_distinct_count', () => {
+    const pinned = collate('audio', [
+      { echoReturnLoss: -30, echoReturnLossEnhancement: 0.1755 },
+      { echoReturnLoss: -30, echoReturnLossEnhancement: 0.1755 },
+    ]);
+    const adapting = collate('audio', [
+      { echoReturnLoss: -12, echoReturnLossEnhancement: 4.2 },
+      { echoReturnLoss: -18, echoReturnLossEnhancement: 11.6 },
+    ]);
+
+    expect(pinned.erle_distinct_count).toBe(1);
+    expect(pinned.erl_db_min).toBe(-30);
+    expect(pinned.erl_db_max).toBe(-30);
+
+    expect(adapting.erle_distinct_count).toBe(2);
+    expect(adapting.erle_db_min).toBe(4.2);
+    expect(adapting.erle_db_max).toBe(11.6);
+  });
+
+  test('does not emit audio fields on video samples, and keeps frame counters there', () => {
+    const sample = collate('video', [
+      { sourceStatsAvailable: true, sourceFrames: 100, framesEncoded: 90 },
+      { sourceStatsAvailable: true, sourceFrames: 400, framesEncoded: 360 },
+    ]);
+
+    expect(sample).not.toHaveProperty('audio_level_min');
+    expect(sample).not.toHaveProperty('audio_level_max');
+    expect(sample).not.toHaveProperty('total_audio_energy');
+    expect(sample.source_total_frames).toBe(400);
+  });
+});

--- a/packages/hms-video-store/src/analytics/stats/PublishStatsAnalytics.test.ts
+++ b/packages/hms-video-store/src/analytics/stats/PublishStatsAnalytics.test.ts
@@ -64,15 +64,66 @@ describe('RunningLocalTrackAnalytics — audio source stats', () => {
     expect(first.total_samples_duration_sec).toBe(40);
     expect(second.total_audio_energy).toBe(7);
     expect(second.total_samples_duration_sec).toBe(30);
-    expect(first.erle_db_min).toBeUndefined();
-    expect(first.erle_distinct_count).toBeUndefined();
+    expect(first).not.toHaveProperty('erle_db_min');
+    expect(first).not.toHaveProperty('erle_distinct_count');
   });
 
-  test('aggregates capture level as a range', () => {
+  test('omits the energy delta when the media-source is replaced mid-call', () => {
+    // A device switch or audio-plugin toggle swaps the sender track, so the browser's
+    // cumulative counters restart at 0 while this analytics object survives (trackId is
+    // pinned to firstTrackId). The delta would go large-negative, and two negatives divide
+    // to a positive RMS — a confident "loud healthy mic" reading during silence.
+    const analytics = makeAnalytics('audio');
+    analytics.pushTempStat({ timestamp: 1000, sourceTotalAudioEnergy: 8, sourceTotalSamplesDuration: 30 } as TempStats);
+    analytics.createSample();
+
+    analytics.pushTempStat({
+      timestamp: 2000,
+      sourceTotalAudioEnergy: 0.02,
+      sourceTotalSamplesDuration: 2,
+    } as TempStats);
+    analytics.createSample();
+
+    const [, second] = analytics.samples as LocalAudioSample[];
+    expect(second).not.toHaveProperty('total_audio_energy');
+    expect(second).not.toHaveProperty('total_samples_duration_sec');
+  });
+
+  test('omits the energy delta when the counter stops being reported mid-window', () => {
+    // The window's last poll carries no media-source (replaceTrack teardown). Guarding the
+    // whole window instead of the two values the subtraction reads would emit 0 - 40 = -40.
+    const analytics = makeAnalytics('audio');
+    analytics.pushTempStat({ timestamp: 1000, sourceTotalAudioEnergy: 40 } as TempStats);
+    analytics.createSample();
+
+    analytics.pushTempStat({ timestamp: 2000, sourceTotalAudioEnergy: 41 } as TempStats);
+    analytics.pushTempStat({ timestamp: 3000 } as TempStats);
+    analytics.createSample();
+
+    const [, second] = analytics.samples as LocalAudioSample[];
+    expect(second).not.toHaveProperty('total_audio_energy');
+  });
+
+  test('aggregates capture level as a range with an observation count', () => {
     const sample = collate('audio', [{ sourceAudioLevel: 0.4 }, { sourceAudioLevel: 0.05 }, { sourceAudioLevel: 0.9 }]);
 
     expect(sample.audio_level_min).toBe(0.05);
     expect(sample.audio_level_max).toBe(0.9);
+    expect(sample.audio_level_observed_count).toBe(3);
+  });
+
+  test('preserves a measured zero, which is not the same as an absent metric', () => {
+    // Silent capture is the diagnosis these metrics exist to support, so a genuine 0 must
+    // survive. A `filter(Boolean)` style cleanup would erase it with every other test green.
+    const analytics = makeAnalytics('audio');
+    analytics.pushTempStat({ timestamp: 1000, sourceAudioLevel: 0, sourceTotalAudioEnergy: 5 } as TempStats);
+    analytics.createSample();
+    analytics.pushTempStat({ timestamp: 2000, sourceAudioLevel: 0, sourceTotalAudioEnergy: 5 } as TempStats);
+    analytics.createSample();
+
+    const [, second] = analytics.samples as LocalAudioSample[];
+    expect(second).toHaveProperty('audio_level_max', 0);
+    expect(second).toHaveProperty('total_audio_energy', 0);
   });
 
   test('omits energy entirely when the browser never reported it, rather than sending 0', () => {
@@ -94,12 +145,39 @@ describe('RunningLocalTrackAnalytics — audio source stats', () => {
     ]);
 
     expect(pinned.erle_distinct_count).toBe(1);
+    expect(pinned.erle_observed_count).toBe(2);
     expect(pinned.erl_db_min).toBe(-30);
     expect(pinned.erl_db_max).toBe(-30);
 
     expect(adapting.erle_distinct_count).toBe(2);
+    expect(adapting.erle_observed_count).toBe(2);
     expect(adapting.erle_db_min).toBe(4.2);
     expect(adapting.erle_db_max).toBe(11.6);
+  });
+
+  test('a single ERLE observation is distinguishable from a pinned canceller', () => {
+    // Both score erle_distinct_count: 1. Only the observation count separates "the canceller
+    // held steady across the window" from "we saw it once and cannot say".
+    const single = collate('audio', [{ echoReturnLossEnhancement: 0.1755 }, {}, {}]);
+
+    expect(single.erle_distinct_count).toBe(1);
+    expect(single.erle_observed_count).toBe(1);
+  });
+
+  test('resets the ERLE range per window rather than accumulating across samples', () => {
+    const analytics = makeAnalytics('audio');
+    analytics.pushTempStat({ timestamp: 1000, echoReturnLossEnhancement: 4.2 } as TempStats);
+    analytics.pushTempStat({ timestamp: 2000, echoReturnLossEnhancement: 11.6 } as TempStats);
+    analytics.createSample();
+
+    analytics.pushTempStat({ timestamp: 3000, echoReturnLossEnhancement: 0.1755 } as TempStats);
+    analytics.pushTempStat({ timestamp: 4000, echoReturnLossEnhancement: 0.1755 } as TempStats);
+    analytics.createSample();
+
+    const [first, second] = analytics.samples as LocalAudioSample[];
+    expect(first.erle_distinct_count).toBe(2);
+    expect(second.erle_distinct_count).toBe(1);
+    expect(second.erle_db_max).toBe(0.1755);
   });
 
   test('does not emit audio fields on video samples, and keeps frame counters there', () => {

--- a/packages/hms-video-store/src/analytics/stats/PublishStatsAnalytics.ts
+++ b/packages/hms-video-store/src/analytics/stats/PublishStatsAnalytics.ts
@@ -4,6 +4,7 @@ import {
   hasResolutionChanged,
   removeUndefinedFromObject,
   RunningTrackAnalytics,
+  TempStats,
 } from './BaseStatsAnalytics';
 import {
   LocalAudioSample,
@@ -114,7 +115,7 @@ const maxOf = (values: number[]) => (values.length ? Math.max(...values) : undef
 const countDistinctValues = (values: number[]) =>
   values.length ? new Set(values.map(value => value.toFixed(3))).size : undefined;
 
-class RunningLocalTrackAnalytics extends RunningTrackAnalytics {
+export class RunningLocalTrackAnalytics extends RunningTrackAnalytics {
   samples: (LocalAudioSample | LocalVideoSample)[] = [];
   private cpuPressureMonitor?: CPUPressureMonitor;
 
@@ -130,20 +131,33 @@ class RunningLocalTrackAnalytics extends RunningTrackAnalytics {
     this.cpuPressureMonitor = params.cpuPressureMonitor;
   }
 
+  // Counter delta across the window, or undefined when the browser never reported the
+  // counter. calculateDifferenceForSample coerces a missing value to 0, which would ship
+  // an absent metric as a real zero — indistinguishable from genuine silence.
+  private differenceIfReported = (key: keyof TempStats) =>
+    this.collectNumericValues(key).length ? this.calculateDifferenceForSample(key) : undefined;
+
   private getAudioSourceStats = (): Partial<LocalAudioSample> => {
-    const erl = this.collectNumericValues('echoReturnLoss');
-    const erle = this.collectNumericValues('echoReturnLossEnhancement');
-    if (erl.length === 0 && erle.length === 0) {
+    if (this.kind !== 'audio') {
       return {};
     }
+    const audioLevel = this.collectNumericValues('sourceAudioLevel');
+    const erl = this.collectNumericValues('echoReturnLoss');
+    const erle = this.collectNumericValues('echoReturnLossEnhancement');
+    // Energy is reported independently of ERL/ERLE, not gated behind them. ERL/ERLE only
+    // exist while a software canceller is running, so gating would drop the capture-level
+    // evidence for exactly the tracks published with echoCancellation disabled — the case
+    // where "was the mic live at all" is the question being asked.
     return {
+      audio_level_min: minOf(audioLevel),
+      audio_level_max: maxOf(audioLevel),
+      total_audio_energy: this.differenceIfReported('sourceTotalAudioEnergy'),
+      total_samples_duration_sec: this.differenceIfReported('sourceTotalSamplesDuration'),
       erl_db_min: minOf(erl),
       erl_db_max: maxOf(erl),
       erle_db_min: minOf(erle),
       erle_db_max: maxOf(erle),
       erle_distinct_count: countDistinctValues(erle),
-      total_audio_energy: this.calculateDifferenceForSample('sourceTotalAudioEnergy'),
-      total_samples_duration_sec: this.calculateDifferenceForSample('sourceTotalSamplesDuration'),
     };
   };
 
@@ -158,8 +172,12 @@ class RunningLocalTrackAnalytics extends RunningTrackAnalytics {
     );
   };
 
+  // Frame-counter stats, video only. sourceStatsAvailable alone is not a sufficient gate:
+  // audio tracks now resolve a media-source too, and the frame counters below coerce to 0
+  // rather than undefined, so an ungated call ships source_total_frames: 0 on every audio
+  // sample.
   private getSourceStats = (latestStat: HMSTrackStats) => {
-    if (!latestStat.sourceStatsAvailable) {
+    if (this.kind !== 'video' || !latestStat.sourceStatsAvailable) {
       return {};
     }
     const source_resolution = latestStat.sourceFrameHeight

--- a/packages/hms-video-store/src/analytics/stats/PublishStatsAnalytics.ts
+++ b/packages/hms-video-store/src/analytics/stats/PublishStatsAnalytics.ts
@@ -15,7 +15,6 @@ import {
 } from './interfaces';
 import { HMSTrackStats } from '../../interfaces';
 import { HMSWebrtcStats } from '../../rtc-stats';
-import { PUBLISH_STATS_SAMPLE_WINDOW } from '../../utils/constants';
 import { CPUPressureMonitor } from '../../utils/cpu-pressure-monitor';
 import AnalyticsEventFactory from '../AnalyticsEventFactory';
 
@@ -44,7 +43,7 @@ export class PublishStatsAnalytics extends BaseStatsAnalytics {
       video,
       joined_at: this.store.getRoom()?.joinedAt?.getTime()!,
       sequence_num: this.sequenceNum++,
-      max_window_sec: PUBLISH_STATS_SAMPLE_WINDOW,
+      max_window_sec: this.sampleWindowSize,
     };
   }
 
@@ -111,9 +110,10 @@ const minOf = (values: number[]) => (values.length ? Math.min(...values) : undef
 
 const maxOf = (values: number[]) => (values.length ? Math.max(...values) : undefined);
 
-// Rounded before counting so float noise in an otherwise stable reading is not read as adaptation.
-const countDistinctValues = (values: number[]) =>
-  values.length ? new Set(values.map(value => value.toFixed(3))).size : undefined;
+const countDistinctValues = (values: number[]) => (values.length ? new Set(values).size : undefined);
+
+const finiteOrUndefined = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 
 export class RunningLocalTrackAnalytics extends RunningTrackAnalytics {
   samples: (LocalAudioSample | LocalVideoSample)[] = [];
@@ -131,11 +131,32 @@ export class RunningLocalTrackAnalytics extends RunningTrackAnalytics {
     this.cpuPressureMonitor = params.cpuPressureMonitor;
   }
 
-  // Counter delta across the window, or undefined when the browser never reported the
-  // counter. calculateDifferenceForSample coerces a missing value to 0, which would ship
-  // an absent metric as a real zero — indistinguishable from genuine silence.
-  private differenceIfReported = (key: keyof TempStats) =>
-    this.collectNumericValues(key).length ? this.calculateDifferenceForSample(key) : undefined;
+  // Delta for a cumulative counter, or undefined when the delta cannot be trusted.
+  // Guards the two values the subtraction actually reads — this window's last stat and the
+  // previous window's last stat — rather than the window as a whole. Guarding the whole
+  // window would let a counter that stops being reported partway through emit a fabricated
+  // 0 (indistinguishable from measured silence) or a negative.
+  private differenceIfReported = (key: keyof TempStats) => {
+    const latest = finiteOrUndefined(this.getLatestStat()?.[key]);
+    if (latest === undefined) {
+      return undefined;
+    }
+    if (this.prevLatestStat === undefined) {
+      // First window of a track: the counter is cumulative since capture start, not a window
+      // delta. Emitted as-is rather than dropped — RMS stays correct because energy and
+      // duration are inflated identically, and dropping it would leave short calls with no
+      // audio evidence at all.
+      return latest;
+    }
+    const previous = finiteOrUndefined(this.prevLatestStat[key]);
+    if (previous === undefined) {
+      return undefined;
+    }
+    // A cumulative counter moving backwards means the media-source was replaced — a device
+    // switch or an audio plugin toggle both swap the sender track. The window's true delta
+    // is unknowable, which is not the same as zero.
+    return latest < previous ? undefined : latest - previous;
+  };
 
   private getAudioSourceStats = (): Partial<LocalAudioSample> => {
     if (this.kind !== 'audio') {
@@ -144,13 +165,14 @@ export class RunningLocalTrackAnalytics extends RunningTrackAnalytics {
     const audioLevel = this.collectNumericValues('sourceAudioLevel');
     const erl = this.collectNumericValues('echoReturnLoss');
     const erle = this.collectNumericValues('echoReturnLossEnhancement');
-    // Energy is reported independently of ERL/ERLE, not gated behind them. ERL/ERLE only
-    // exist while a software canceller is running, so gating would drop the capture-level
-    // evidence for exactly the tracks published with echoCancellation disabled — the case
-    // where "was the mic live at all" is the question being asked.
+    // Energy is reported independently of ERL/ERLE, not gated behind them. ERL/ERLE exist
+    // only while a canceller is applied to the capture path, so gating would drop the
+    // capture-level evidence for exactly the tracks published with echoCancellation
+    // disabled — the case where "was the mic live at all" is the question being asked.
     return {
       audio_level_min: minOf(audioLevel),
       audio_level_max: maxOf(audioLevel),
+      audio_level_observed_count: audioLevel.length || undefined,
       total_audio_energy: this.differenceIfReported('sourceTotalAudioEnergy'),
       total_samples_duration_sec: this.differenceIfReported('sourceTotalSamplesDuration'),
       erl_db_min: minOf(erl),
@@ -158,6 +180,7 @@ export class RunningLocalTrackAnalytics extends RunningTrackAnalytics {
       erle_db_min: minOf(erle),
       erle_db_max: maxOf(erle),
       erle_distinct_count: countDistinctValues(erle),
+      erle_observed_count: erle.length || undefined,
     };
   };
 
@@ -172,12 +195,13 @@ export class RunningLocalTrackAnalytics extends RunningTrackAnalytics {
     );
   };
 
-  // Frame-counter stats, video only. sourceStatsAvailable alone is not a sufficient gate:
-  // audio tracks now resolve a media-source too, and the frame counters below coerce to 0
-  // rather than undefined, so an ungated call ships source_total_frames: 0 on every audio
-  // sample.
+  // Frame-counter stats. The counters below coerce a missing value to 0, so an audio track
+  // reaching them ships source_total_frames: 0 on every sample. Two guards, deliberately:
+  // buildAudioSourceStats no longer sets sourceStatsAvailable, and audio is excluded here
+  // too. Excluding audio rather than requiring video keeps video stats that arrive without a
+  // `kind` behaving exactly as they did before this gate existed.
   private getSourceStats = (latestStat: HMSTrackStats) => {
-    if (this.kind !== 'video' || !latestStat.sourceStatsAvailable) {
+    if (this.kind === 'audio' || !latestStat.sourceStatsAvailable) {
       return {};
     }
     const source_resolution = latestStat.sourceFrameHeight
@@ -246,7 +270,7 @@ export class RunningLocalTrackAnalytics extends RunningTrackAnalytics {
     const prevStat = this.tempStats[length - 2];
 
     return (
-      length === PUBLISH_STATS_SAMPLE_WINDOW ||
+      length === this.sampleWindowSize ||
       hasEnabledStateChanged(newStat, prevStat) ||
       (newStat.kind === 'video' && hasResolutionChanged(newStat, prevStat))
     );

--- a/packages/hms-video-store/src/analytics/stats/PublishStatsAnalytics.ts
+++ b/packages/hms-video-store/src/analytics/stats/PublishStatsAnalytics.ts
@@ -6,8 +6,8 @@ import {
   RunningTrackAnalytics,
 } from './BaseStatsAnalytics';
 import {
+  LocalAudioSample,
   LocalAudioTrackAnalytics,
-  LocalBaseSample,
   LocalVideoSample,
   LocalVideoTrackAnalytics,
   PublishAnalyticPayload,
@@ -106,8 +106,16 @@ export class PublishStatsAnalytics extends BaseStatsAnalytics {
   }
 }
 
+const minOf = (values: number[]) => (values.length ? Math.min(...values) : undefined);
+
+const maxOf = (values: number[]) => (values.length ? Math.max(...values) : undefined);
+
+// Rounded before counting so float noise in an otherwise stable reading is not read as adaptation.
+const countDistinctValues = (values: number[]) =>
+  values.length ? new Set(values.map(value => value.toFixed(3))).size : undefined;
+
 class RunningLocalTrackAnalytics extends RunningTrackAnalytics {
-  samples: (LocalBaseSample | LocalVideoSample)[] = [];
+  samples: (LocalAudioSample | LocalVideoSample)[] = [];
   private cpuPressureMonitor?: CPUPressureMonitor;
 
   constructor(params: {
@@ -121,6 +129,23 @@ class RunningLocalTrackAnalytics extends RunningTrackAnalytics {
     super(params);
     this.cpuPressureMonitor = params.cpuPressureMonitor;
   }
+
+  private getAudioSourceStats = (): Partial<LocalAudioSample> => {
+    const erl = this.collectNumericValues('echoReturnLoss');
+    const erle = this.collectNumericValues('echoReturnLossEnhancement');
+    if (erl.length === 0 && erle.length === 0) {
+      return {};
+    }
+    return {
+      erl_db_min: minOf(erl),
+      erl_db_max: maxOf(erl),
+      erle_db_min: minOf(erle),
+      erle_db_max: maxOf(erle),
+      erle_distinct_count: countDistinctValues(erle),
+      total_audio_energy: this.calculateDifferenceForSample('sourceTotalAudioEnergy'),
+      total_samples_duration_sec: this.calculateDifferenceForSample('sourceTotalSamplesDuration'),
+    };
+  };
 
   private getQualityLimitation = (latestStat: HMSTrackStats) => {
     const qualityLimitationDurations = latestStat.qualityLimitationDurations;
@@ -153,7 +178,7 @@ class RunningLocalTrackAnalytics extends RunningTrackAnalytics {
     };
   };
 
-  protected collateSample = (): LocalBaseSample | LocalVideoSample => {
+  protected collateSample = (): LocalAudioSample | LocalVideoSample => {
     const firstStat = this.getFirstStat();
     const latestStat = this.getLatestStat();
 
@@ -193,6 +218,7 @@ class RunningLocalTrackAnalytics extends RunningTrackAnalytics {
       track_settings,
       effects_metrics: effects_metrics && Object.keys(effects_metrics).length > 0 ? effects_metrics : undefined,
       ...this.getSourceStats(latestStat),
+      ...this.getAudioSourceStats(),
     });
   };
 

--- a/packages/hms-video-store/src/analytics/stats/SubscribeStatsAnalytics.ts
+++ b/packages/hms-video-store/src/analytics/stats/SubscribeStatsAnalytics.ts
@@ -16,7 +16,7 @@ import {
 import { HMSTrackStats } from '../../interfaces';
 import { HMSRemoteVideoTrack } from '../../internal';
 import { HMSWebrtcStats } from '../../rtc-stats';
-import { MAX_SAFE_INTEGER, SUBSCRIBE_STATS_SAMPLE_WINDOW } from '../../utils/constants';
+import { MAX_SAFE_INTEGER } from '../../utils/constants';
 import AnalyticsEventFactory from '../AnalyticsEventFactory';
 
 export class SubscribeStatsAnalytics extends BaseStatsAnalytics {
@@ -37,7 +37,7 @@ export class SubscribeStatsAnalytics extends BaseStatsAnalytics {
       video,
       joined_at: this.store.getRoom()?.joinedAt?.getTime()!,
       sequence_num: this.sequenceNum++,
-      max_window_sec: SUBSCRIBE_STATS_SAMPLE_WINDOW,
+      max_window_sec: this.sampleWindowSize,
     };
   }
 
@@ -188,7 +188,7 @@ class RunningRemoteTrackAnalytics extends RunningTrackAnalytics {
     const prevStat = this.tempStats[length - 2];
 
     return (
-      length === SUBSCRIBE_STATS_SAMPLE_WINDOW ||
+      length === this.sampleWindowSize ||
       hasEnabledStateChanged(newStat, prevStat) ||
       (newStat.kind === 'video' && hasResolutionChanged(newStat, prevStat))
     );

--- a/packages/hms-video-store/src/analytics/stats/interfaces.ts
+++ b/packages/hms-video-store/src/analytics/stats/interfaces.ts
@@ -6,7 +6,7 @@ interface BaseStatsPayload {
 }
 
 export interface PublishAnalyticPayload extends BaseStatsPayload {
-  video: Array<LocalAudioTrackAnalytics>; // Each element represents a video track that the peer is uploading
+  video: Array<LocalVideoTrackAnalytics>; // Each element represents a video track that the peer is uploading
   audio: Array<LocalAudioTrackAnalytics>; // Each element represents an audio track that the peer is uploading
 }
 
@@ -51,30 +51,51 @@ export interface LocalBaseSample {
   effects_metrics?: Record<string, Record<string, unknown> | undefined>; // Metrics from attached plugins (e.g., effects SDK)
 }
 
+/**
+ * Audio capture metrics for one sample window, from the audio `media-source` stat.
+ *
+ * Every field is optional in the "browser did not report it" sense, which is distinct from a
+ * reported zero — an absent counter must never be read as measured silence.
+ *
+ * Ranges rather than averages: ERLE legitimately drops to 0 during double-talk and silence,
+ * so a window mean makes an idle canceller and a working one look alike. No level average is
+ * reported either, because RMS is recoverable as
+ * `sqrt(total_audio_energy / total_samples_duration_sec)` — integrated across the window
+ * rather than sampled at poll time. That identity is from the spec
+ * (https://www.w3.org/TR/webrtc-stats/#dom-rtcaudiosourcestats-totalaudioenergy) and needs
+ * `total_samples_duration_sec` to be present and non-zero.
+ */
 export interface LocalAudioSample extends LocalBaseSample {
-  /**
-   * Echo canceller health, from the audio `media-source` stat.
-   * A window average is not enough on its own: ERLE legitimately drops to 0 during
-   * double-talk and silence, so averaging makes an idle canceller and a working one
-   * look alike. `erle_distinct_count` is 1 when the value never moves across the
-   * window, which is what separates "no software AEC running" from "AEC running".
-   */
+  /** Echo return loss, dB. Absent when no canceller is applied to the capture path. */
   erl_db_min?: number;
   erl_db_max?: number;
+  /** Echo return loss enhancement, dB — how much echo the canceller removed. */
   erle_db_min?: number;
   erle_db_max?: number;
+  /**
+   * Distinct ERLE readings in the window. `1` means the canceller reported a pinned value —
+   * present but not adapting. It never means "no canceller"; that case carries no ERLE fields
+   * at all. Read with `erle_observed_count`, since a single observation also scores 1.
+   */
   erle_distinct_count?: number;
+  /** Polls that carried an ERLE reading — the denominator for the fields above. */
+  erle_observed_count?: number;
+  /**
+   * Cumulative-counter deltas. The first window of a track reports the total since capture
+   * start rather than a window delta; both fields are inflated identically, so RMS is
+   * unaffected but a per-window energy figure is not.
+   */
   total_audio_energy?: number;
   total_samples_duration_sec?: number;
   /**
-   * Capture level range over the window. No average is reported: RMS level is already
-   * recoverable as sqrt(total_audio_energy / total_samples_duration_sec), and that form is
-   * integrated rather than sampled at poll time. The range is what the energy integral
-   * flattens away — `audio_level_max` near 0 means nothing was captured at all, while an
-   * elevated `audio_level_min` means the floor never fell silent.
+   * Capture level range. `audio_level_max` near 0 means nothing was captured; an elevated
+   * `audio_level_min` means the noise floor never fell silent. `1.0` is full-scale clipping,
+   * which is non-linear and therefore defeats the canceller's linear echo model.
    */
   audio_level_min?: number;
   audio_level_max?: number;
+  /** Polls that carried an audio level — the denominator for the two fields above. */
+  audio_level_observed_count?: number;
 }
 
 export interface LocalVideoSample extends LocalBaseSample {

--- a/packages/hms-video-store/src/analytics/stats/interfaces.ts
+++ b/packages/hms-video-store/src/analytics/stats/interfaces.ts
@@ -23,7 +23,7 @@ interface TrackAnalytics<Sample> {
   samples: Array<Sample>;
 }
 
-export type LocalAudioTrackAnalytics = TrackAnalytics<LocalBaseSample>;
+export type LocalAudioTrackAnalytics = TrackAnalytics<LocalAudioSample>;
 export type LocalVideoTrackAnalytics = TrackAnalytics<LocalVideoSample>;
 
 export type RemoteAudioTrackAnalytics = TrackAnalytics<RemoteAudioSample>;
@@ -49,6 +49,23 @@ export interface LocalBaseSample {
   cpu_pressure_state?: string; // CPU pressure state at the time of sample creation (nominal, fair, serious, critical)
   track_settings?: MediaTrackSettings; // Native track settings from getSettings()
   effects_metrics?: Record<string, Record<string, unknown> | undefined>; // Metrics from attached plugins (e.g., effects SDK)
+}
+
+export interface LocalAudioSample extends LocalBaseSample {
+  /**
+   * Echo canceller health, from the audio `media-source` stat.
+   * A window average is not enough on its own: ERLE legitimately drops to 0 during
+   * double-talk and silence, so averaging makes an idle canceller and a working one
+   * look alike. `erle_distinct_count` is 1 when the value never moves across the
+   * window, which is what separates "no software AEC running" from "AEC running".
+   */
+  erl_db_min?: number;
+  erl_db_max?: number;
+  erle_db_min?: number;
+  erle_db_max?: number;
+  erle_distinct_count?: number;
+  total_audio_energy?: number;
+  total_samples_duration_sec?: number;
 }
 
 export interface LocalVideoSample extends LocalBaseSample {

--- a/packages/hms-video-store/src/analytics/stats/interfaces.ts
+++ b/packages/hms-video-store/src/analytics/stats/interfaces.ts
@@ -66,6 +66,15 @@ export interface LocalAudioSample extends LocalBaseSample {
   erle_distinct_count?: number;
   total_audio_energy?: number;
   total_samples_duration_sec?: number;
+  /**
+   * Capture level range over the window. No average is reported: RMS level is already
+   * recoverable as sqrt(total_audio_energy / total_samples_duration_sec), and that form is
+   * integrated rather than sampled at poll time. The range is what the energy integral
+   * flattens away — `audio_level_max` near 0 means nothing was captured at all, while an
+   * elevated `audio_level_min` means the floor never fell silent.
+   */
+  audio_level_min?: number;
+  audio_level_max?: number;
 }
 
 export interface LocalVideoSample extends LocalBaseSample {

--- a/packages/hms-video-store/src/interfaces/webrtc-stats.ts
+++ b/packages/hms-video-store/src/interfaces/webrtc-stats.ts
@@ -110,6 +110,16 @@ export interface HMSLocalTrackStats extends BaseTrackStats, MissingOutboundStats
   sourceFramesDropped?: number;
   sourceTimestamp?: DOMHighResTimeStamp;
   sourceStatsAvailable?: boolean;
+  /**
+   * Capture stats from the audio `media-source`. `echoReturnLoss`/`echoReturnLossEnhancement`
+   * are only reported while the browser's own echo canceller is running, so their absence is
+   * itself a signal that cancellation has been delegated to the OS or the capture device.
+   */
+  sourceAudioLevel?: number;
+  sourceTotalAudioEnergy?: number;
+  sourceTotalSamplesDuration?: number;
+  echoReturnLoss?: number;
+  echoReturnLossEnhancement?: number;
 }
 
 /**

--- a/packages/hms-video-store/src/interfaces/webrtc-stats.ts
+++ b/packages/hms-video-store/src/interfaces/webrtc-stats.ts
@@ -111,9 +111,12 @@ export interface HMSLocalTrackStats extends BaseTrackStats, MissingOutboundStats
   sourceTimestamp?: DOMHighResTimeStamp;
   sourceStatsAvailable?: boolean;
   /**
-   * Capture stats from the audio `media-source`. `echoReturnLoss`/`echoReturnLossEnhancement`
-   * are only reported while the browser's own echo canceller is running, so their absence is
-   * itself a signal that cancellation has been delegated to the OS or the capture device.
+   * Capture stats from the audio `media-source`. Per spec, `echoReturnLoss` and
+   * `echoReturnLossEnhancement` exist only when the track is sourced from a microphone with
+   * echo cancellation applied — so absence means no canceller is applied to the capture path,
+   * which also covers non-microphone sources (screen-share audio, injected tracks) and
+   * engines that do not implement the stat. It does not by itself identify where any
+   * cancellation happened.
    */
   sourceAudioLevel?: number;
   sourceTotalAudioEnergy?: number;

--- a/packages/hms-video-store/src/rtc-stats/utils.test.ts
+++ b/packages/hms-video-store/src/rtc-stats/utils.test.ts
@@ -1,5 +1,7 @@
-import { getLocalPeerStatsFromReport } from './utils';
+import { getLocalPeerStatsFromReport, getLocalTrackStats } from './utils';
+import { EventBus } from '../events/EventBus';
 import { HMSPeerStats } from '../interfaces';
+import { HMSLocalTrack, HMSTrackType } from '../media/tracks';
 
 type StatEntry = Record<string, any>;
 
@@ -122,5 +124,62 @@ describe('getLocalPeerStatsFromReport — subscribe bitrate', () => {
 
     expect(nextStats).toBeDefined();
     expect(nextStats!.bitrate).toBe(1_000_000);
+  });
+});
+
+const audioMediaSource = (extra: Partial<StatEntry> = {}): StatEntry => ({
+  id: 'SA1',
+  type: 'media-source',
+  kind: 'audio',
+  trackIdentifier: 'sender-track-1',
+  audioLevel: 0.05,
+  totalAudioEnergy: 12.5,
+  totalSamplesDuration: 60,
+  echoReturnLoss: -29.08,
+  echoReturnLossEnhancement: 0.1755,
+  ...extra,
+});
+
+const audioTrack = (report: RTCStatsReport, type = HMSTrackType.AUDIO) =>
+  ({
+    type,
+    trackId: 'track-1',
+    peerId: 'peer-1',
+    enabled: true,
+    transceiver: { sender: { track: { id: 'sender-track-1' }, getStats: async () => report } },
+  } as unknown as HMSLocalTrack);
+
+const eventBus = { analytics: { publish: jest.fn() } } as unknown as EventBus;
+
+describe('getLocalTrackStats — audio echo-cancellation stats', () => {
+  test('surfaces ERL/ERLE and cumulative energy from the audio media-source stat', async () => {
+    const report = makeReport([outboundRtp(1000, 5_000_000), audioMediaSource()]);
+
+    const stats = await getLocalTrackStats(eventBus, audioTrack(report));
+
+    expect(stats?.O1.echoReturnLoss).toBe(-29.08);
+    expect(stats?.O1.echoReturnLossEnhancement).toBe(0.1755);
+    expect(stats?.O1.sourceTotalAudioEnergy).toBe(12.5);
+    expect(stats?.O1.sourceTotalSamplesDuration).toBe(60);
+    expect(stats?.O1.sourceAudioLevel).toBe(0.05);
+    expect(stats?.O1.sourceStatsAvailable).toBe(true);
+  });
+
+  test('ignores a media-source belonging to a different sender track', async () => {
+    const report = makeReport([outboundRtp(1000, 5_000_000), audioMediaSource({ trackIdentifier: 'someone-else' })]);
+
+    const stats = await getLocalTrackStats(eventBus, audioTrack(report));
+
+    expect(stats?.O1.echoReturnLossEnhancement).toBeUndefined();
+    expect(stats?.O1.sourceStatsAvailable).toBeUndefined();
+  });
+
+  test('leaves echo fields unset when the browser reports no audio media-source', async () => {
+    const report = makeReport([outboundRtp(1000, 5_000_000)]);
+
+    const stats = await getLocalTrackStats(eventBus, audioTrack(report));
+
+    expect(stats?.O1.echoReturnLoss).toBeUndefined();
+    expect(stats?.O1.echoReturnLossEnhancement).toBeUndefined();
   });
 });

--- a/packages/hms-video-store/src/rtc-stats/utils.test.ts
+++ b/packages/hms-video-store/src/rtc-stats/utils.test.ts
@@ -162,7 +162,20 @@ describe('getLocalTrackStats — audio echo-cancellation stats', () => {
     expect(stats?.O1.sourceTotalAudioEnergy).toBe(12.5);
     expect(stats?.O1.sourceTotalSamplesDuration).toBe(60);
     expect(stats?.O1.sourceAudioLevel).toBe(0.05);
-    expect(stats?.O1.sourceStatsAvailable).toBe(true);
+    // sourceStatsAvailable gates the video frame counters; audio must not set it, otherwise
+    // getSourceStats ships source_total_frames: 0 on every audio sample.
+    expect(stats?.O1.sourceStatsAvailable).toBeUndefined();
+  });
+
+  test('reads a media-source that reports mediaType instead of kind', async () => {
+    const stat = audioMediaSource();
+    delete (stat as Record<string, unknown>).kind;
+    (stat as Record<string, unknown>).mediaType = 'audio';
+    const report = makeReport([outboundRtp(1000, 5_000_000), stat]);
+
+    const stats = await getLocalTrackStats(eventBus, audioTrack(report));
+
+    expect(stats?.O1.echoReturnLossEnhancement).toBe(0.1755);
   });
 
   test('ignores a media-source belonging to a different sender track', async () => {
@@ -171,7 +184,7 @@ describe('getLocalTrackStats — audio echo-cancellation stats', () => {
     const stats = await getLocalTrackStats(eventBus, audioTrack(report));
 
     expect(stats?.O1.echoReturnLossEnhancement).toBeUndefined();
-    expect(stats?.O1.sourceStatsAvailable).toBeUndefined();
+    expect(stats?.O1.sourceAudioLevel).toBeUndefined();
   });
 
   test('leaves echo fields unset when the browser reports no audio media-source', async () => {

--- a/packages/hms-video-store/src/rtc-stats/utils.ts
+++ b/packages/hms-video-store/src/rtc-stats/utils.ts
@@ -24,6 +24,20 @@ interface MediaSourceStats {
   timestamp?: DOMHighResTimeStamp;
 }
 
+interface AudioSourceStats {
+  audioLevel?: number;
+  totalAudioEnergy?: number;
+  totalSamplesDuration?: number;
+  echoReturnLoss?: number;
+  echoReturnLossEnhancement?: number;
+}
+
+interface AudioMediaSourceStat extends AudioSourceStats {
+  type?: string;
+  kind?: string;
+  trackIdentifier?: string;
+}
+
 const isVideoMediaSourceStat = (stat: any): boolean => {
   const kind = stat.kind || stat.mediaType;
   return !kind || kind === 'video';
@@ -141,6 +155,7 @@ export const getLocalTrackStats = async (
     const outbound: Record<string, RTCOutboundRtpStreamStats> = {};
     const inbound: Record<string, RTCInboundRtpStreamStats & MissingInboundStats> = {};
     const mediaSourceStats = track.type === HMSTrackType.VIDEO ? resolveSourceStats(trackReport, track) : undefined;
+    const audioSourceStats = track.type === HMSTrackType.AUDIO ? getAudioSourceStats(trackReport, track) : undefined;
     trackReport?.forEach(stat => {
       switch (stat.type) {
         case 'outbound-rtp':
@@ -174,7 +189,7 @@ export const getLocalTrackStats = async (
       const sourceStats =
         track.type === HMSTrackType.VIDEO
           ? buildMediaSourceStats(mediaSourceStats, (outStats as any).framesEncoded, prevTrackStats?.[stat])
-          : {};
+          : buildAudioSourceStats(audioSourceStats);
       trackStats[stat] = {
         ...outStats,
         ...sourceStats,
@@ -318,6 +333,47 @@ const getMediaSourceStats = (
     return extractMediaSourceStats(mediaStat);
   }
   return undefined;
+};
+
+const getAudioSourceStats = (
+  trackReport: RTCStatsReport | undefined,
+  track: HMSLocalTrack,
+): AudioSourceStats | undefined => {
+  if (!trackReport) {
+    return undefined;
+  }
+  const senderTrackId = track.transceiver?.sender?.track?.id;
+  for (const stat of trackReport.values()) {
+    const audioStat = stat as AudioMediaSourceStat;
+    if (audioStat.type !== 'media-source' || audioStat.kind !== 'audio') {
+      continue;
+    }
+    if (!matchesSenderTrack(audioStat, senderTrackId)) {
+      continue;
+    }
+    return {
+      audioLevel: audioStat.audioLevel,
+      totalAudioEnergy: audioStat.totalAudioEnergy,
+      totalSamplesDuration: audioStat.totalSamplesDuration,
+      echoReturnLoss: audioStat.echoReturnLoss,
+      echoReturnLossEnhancement: audioStat.echoReturnLossEnhancement,
+    };
+  }
+  return undefined;
+};
+
+const buildAudioSourceStats = (audioSourceStats: AudioSourceStats | undefined): Partial<HMSLocalTrackStats> => {
+  if (!audioSourceStats) {
+    return {};
+  }
+  return {
+    sourceAudioLevel: audioSourceStats.audioLevel,
+    sourceTotalAudioEnergy: audioSourceStats.totalAudioEnergy,
+    sourceTotalSamplesDuration: audioSourceStats.totalSamplesDuration,
+    echoReturnLoss: audioSourceStats.echoReturnLoss,
+    echoReturnLossEnhancement: audioSourceStats.echoReturnLossEnhancement,
+    sourceStatsAvailable: true,
+  };
 };
 
 const computeSourceFramesDropped = (

--- a/packages/hms-video-store/src/rtc-stats/utils.ts
+++ b/packages/hms-video-store/src/rtc-stats/utils.ts
@@ -34,7 +34,8 @@ interface AudioSourceStats {
 
 interface AudioMediaSourceStat extends AudioSourceStats {
   type?: string;
-  kind?: string;
+  kind?: 'audio' | 'video';
+  mediaType?: 'audio' | 'video';
   trackIdentifier?: string;
 }
 
@@ -43,7 +44,7 @@ const isVideoMediaSourceStat = (stat: any): boolean => {
   return !kind || kind === 'video';
 };
 
-const matchesSenderTrack = (stat: any, senderTrackId?: string): boolean => {
+const matchesSenderTrack = (stat: { trackIdentifier?: string }, senderTrackId?: string): boolean => {
   if (!senderTrackId || !stat.trackIdentifier) {
     return true;
   }
@@ -335,6 +336,12 @@ const getMediaSourceStats = (
   return undefined;
 };
 
+// kind || mediaType: the video helper above already tolerates both spellings, and an engine
+// reporting only mediaType would otherwise lose every audio metric silently —
+// indistinguishable from "this browser applies no echo cancellation".
+const isAudioMediaSourceStat = (stat: AudioMediaSourceStat): boolean =>
+  stat.type === 'media-source' && (stat.kind || stat.mediaType) === 'audio';
+
 const getAudioSourceStats = (
   trackReport: RTCStatsReport | undefined,
   track: HMSLocalTrack,
@@ -345,10 +352,7 @@ const getAudioSourceStats = (
   const senderTrackId = track.transceiver?.sender?.track?.id;
   for (const stat of trackReport.values()) {
     const audioStat = stat as AudioMediaSourceStat;
-    if (audioStat.type !== 'media-source' || audioStat.kind !== 'audio') {
-      continue;
-    }
-    if (!matchesSenderTrack(audioStat, senderTrackId)) {
+    if (!isAudioMediaSourceStat(audioStat) || !matchesSenderTrack(audioStat, senderTrackId)) {
       continue;
     }
     return {
@@ -372,7 +376,6 @@ const buildAudioSourceStats = (audioSourceStats: AudioSourceStats | undefined): 
     sourceTotalSamplesDuration: audioSourceStats.totalSamplesDuration,
     echoReturnLoss: audioSourceStats.echoReturnLoss,
     echoReturnLossEnhancement: audioSourceStats.echoReturnLossEnhancement,
-    sourceStatsAvailable: true,
   };
 };
 


### PR DESCRIPTION
Adds audio capture metrics to publisher stats from the audio `media-source` stat, which was previously resolved for video tracks only: `echoReturnLoss` and `echoReturnLossEnhancement` (the only signals indicating whether a canceller is applied to the capture path and how much echo it removes), total audio energy and samples duration, and capture level — each reported as a range with an observation count.

ERL/ERLE are reported as min/max per sample window rather than an average, since ERLE legitimately drops to 0 during double-talk and silence and a window mean makes an idle canceller indistinguishable from a working one. `erle_distinct_count` is 1 when the canceller reported a pinned value, read alongside `erle_observed_count` because a single observation also scores 1. Energy is reported independently of ERL/ERLE so that tracks published with `echoCancellation` disabled still carry capture evidence, and every counter delta is omitted rather than emitted as 0 or as a negative when the browser stops reporting it or the media-source is replaced. No level average is reported, since RMS is recoverable from the energy counters.

Also fixes the publisher and subscriber sample windows, which compared against the module constant and so ignored `maxSampleWindowSize` from init config.