### PR TITLE
fix(store): never gate audio playout on the subscribe-state round trip

### DIFF
--- a/packages/hms-video-store/src/audio-sink-manager/AudioSinkManager.test.ts
+++ b/packages/hms-video-store/src/audio-sink-manager/AudioSinkManager.test.ts
@@ -1,0 +1,92 @@
+import { AudioSinkManager } from './AudioSinkManager';
+import { DeviceManager } from '../device-manager';
+import { EventBus } from '../events/EventBus';
+import { HMSRemoteAudioTrack } from '../media/tracks';
+import { HMSRemotePeer } from '../sdk/models/peer';
+import { Store } from '../sdk/store';
+
+/**
+ * Reproduces the Aug 2026 silent-recording incident: the SFU never answered the
+ * `prefer-audio-track-state` request for a peer that was already publishing when
+ * the beam joined, so the audio element was never attached to the sink.
+ */
+type SubscribeOutcome = 'resolves' | 'never-settles' | 'rejects';
+
+const buildTrack = (subscribe: SubscribeOutcome) => {
+  const nativeTrack = { id: 'native-1', kind: 'audio', enabled: true } as MediaStreamTrack;
+  let audioElement: HTMLAudioElement | null = null;
+  return {
+    trackId: 'track-1',
+    nativeTrack,
+    getAudioElement: () => audioElement,
+    setAudioElement: (element: HTMLAudioElement | null) => {
+      audioElement = element;
+    },
+    setVolume: () => {
+      if (subscribe === 'never-settles') {
+        return new Promise<void>(() => undefined);
+      }
+      return subscribe === 'rejects' ? Promise.reject(new Error('No response from SFU')) : Promise.resolve();
+    },
+    setOutputDevice: () => Promise.resolve(),
+    getSinkId: () => undefined,
+  } as unknown as HMSRemoteAudioTrack;
+};
+
+describe('AudioSinkManager', () => {
+  let audioSinkManager: AudioSinkManager;
+  let eventBus: EventBus;
+  const peer = { peerId: 'peer-1' } as HMSRemotePeer;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    window.MediaStream = jest.fn().mockImplementation((tracks: MediaStreamTrack[]) => ({
+      id: 'stream-1',
+      tracks,
+    })) as unknown as typeof MediaStream;
+    eventBus = new EventBus();
+    const store = { updateAudioOutputVolume: jest.fn() } as unknown as Store;
+    const deviceManager = { outputDevice: undefined } as unknown as DeviceManager;
+    audioSinkManager = new AudioSinkManager(store, deviceManager, eventBus);
+    audioSinkManager.init();
+    jest.spyOn(window.HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    audioSinkManager.cleanup();
+    jest.restoreAllMocks();
+  });
+
+  const sinkChildren = () => document.querySelectorAll('[id^="HMS-SDK-audio-sink-"] audio');
+
+  it('attaches the audio element when the subscribe round trip resolves', async () => {
+    const track = buildTrack('resolves');
+
+    await eventBus.audioTrackAdded.publish({ track, peer });
+
+    expect(sinkChildren().length).toBe(1);
+    expect(track.getAudioElement()?.srcObject).toBeTruthy();
+  });
+
+  it('attaches the audio element even when the subscribe round trip never resolves', async () => {
+    const track = buildTrack('never-settles');
+
+    await eventBus.audioTrackAdded.publish({ track, peer });
+
+    expect(sinkChildren().length).toBe(1);
+    expect(track.getAudioElement()?.srcObject).toBeTruthy();
+  });
+
+  it('does not reject when the subscribe round trip fails', async () => {
+    const track = buildTrack('rejects');
+    const unhandled = jest.fn();
+    process.on('unhandledRejection', unhandled);
+
+    await eventBus.audioTrackAdded.publish({ track, peer });
+    await new Promise(resolve => setTimeout(resolve, 0));
+    process.off('unhandledRejection', unhandled);
+
+    expect(unhandled).not.toHaveBeenCalled();
+    expect(sinkChildren().length).toBe(1);
+  });
+});

--- a/packages/hms-video-store/src/audio-sink-manager/AudioSinkManager.ts
+++ b/packages/hms-video-store/src/audio-sink-manager/AudioSinkManager.ts
@@ -152,7 +152,6 @@ export class AudioSinkManager {
       }
     };
     track.setAudioElement(audioEl);
-    await track.setVolume(this.volume);
     HMSLogger.d(this.TAG, 'Audio track added', `${track}`);
     this.init(); // call to create sink element if not already created
     this.audioSink?.append(audioEl);
@@ -160,6 +159,16 @@ export class AudioSinkManager {
     audioEl.srcObject = new MediaStream([track.nativeTrack]);
     callListener && this.listener?.onTrackUpdate(HMSTrackUpdate.TRACK_ADDED, track, peer);
     await this.handleAutoplayError(track);
+    /**
+     * setVolume applies the subscription state over the API data channel, a round trip to the SFU.
+     * Audio is subscribed by default, so this is an optimisation - attaching and playing the track
+     * must never wait on it or fail with it, or a lost response leaves the track silent forever.
+     */
+    try {
+      await track.setVolume(this.volume);
+    } catch (error) {
+      HMSLogger.w(this.TAG, 'Could not apply audio subscription state', `${track}`, error);
+    }
   };
 
   private handleAutoplayError = async (track: HMSRemoteAudioTrack) => {

--- a/packages/hms-video-store/src/audio-sink-manager/AudioSinkManager.ts
+++ b/packages/hms-video-store/src/audio-sink-manager/AudioSinkManager.ts
@@ -164,11 +164,9 @@ export class AudioSinkManager {
      * Audio is subscribed by default, so this is an optimisation - attaching and playing the track
      * must never wait on it or fail with it, or a lost response leaves the track silent forever.
      */
-    try {
-      await track.setVolume(this.volume);
-    } catch (error) {
-      HMSLogger.w(this.TAG, 'Could not apply audio subscription state', `${track}`, error);
-    }
+    track
+      .setVolume(this.volume)
+      .catch(error => HMSLogger.w(this.TAG, 'Could not apply audio subscription state', `${track}`, error));
   };
 
   private handleAutoplayError = async (track: HMSRemoteAudioTrack) => {

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
@@ -1,0 +1,64 @@
+import ISubscribeConnectionObserver from './ISubscribeConnectionObserver';
+import HMSSubscribeConnection from './subscribeConnection';
+import JsonRpcSignal from '../../signal/jsonrpc';
+import { API_DATA_CHANNEL } from '../../utils/constants';
+
+/**
+ * The Aug 2026 silent-recording incident: the SFU never answered the first
+ * `prefer-audio-track-state` request of a session, so the caller waited forever.
+ */
+describe('HMSSubscribeConnection api data channel', () => {
+  let connection: HMSSubscribeConnection;
+  let sent: string[];
+
+  beforeEach(() => {
+    sent = [];
+    window.RTCPeerConnection = jest.fn().mockImplementation(() => ({})) as unknown as typeof RTCPeerConnection;
+    const signal = { trickle: jest.fn() } as unknown as JsonRpcSignal;
+    const observer = { onApiChannelMessage: jest.fn() } as unknown as ISubscribeConnectionObserver;
+    connection = new HMSSubscribeConnection({}, signal, observer);
+
+    const nativeChannel = {
+      label: API_DATA_CHANNEL,
+      readyState: 'open',
+      send: (message: string) => sent.push(message),
+    } as unknown as RTCDataChannel;
+    connection.nativeConnection.ondatachannel?.({ channel: nativeChannel } as RTCDataChannelEvent);
+  });
+
+  const respondTo = (request: string) => {
+    const { id } = JSON.parse(request);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (connection as any).eventEmitter.emit(
+      'message',
+      JSON.stringify({ id, jsonrpc: '2.0', result: { track_id: 'track-1' } }),
+    );
+  };
+
+  it('resolves when the SFU answers', async () => {
+    const promise = connection.sendOverApiDataChannelWithResponse({
+      method: 'prefer-audio-track-state',
+      params: { subscribed: true, track_id: 'track-1' },
+    });
+    await Promise.resolve();
+    respondTo(sent[0]);
+
+    await expect(promise).resolves.toBeDefined();
+  });
+
+  it('settles instead of hanging when the SFU never answers', async () => {
+    jest.useFakeTimers();
+    const promise = connection
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-audio-track-state',
+        params: { subscribed: true, track_id: 'track-1' },
+      })
+      .catch((error: Error) => error);
+
+    await jest.advanceTimersByTimeAsync(120_000);
+    const result = await promise;
+
+    expect(result).toBeInstanceOf(Error);
+    jest.useRealTimers();
+  }, 10_000);
+});

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'eventemitter2';
+import EventEmitter, { WaitForOptions } from 'eventemitter2';
 import { v4 as uuid } from 'uuid';
 import ISubscribeConnectionObserver from './ISubscribeConnectionObserver';
 import { HMSRemoteStream, HMSSimulcastLayer } from '../../internal';
@@ -20,6 +20,11 @@ export default class HMSSubscribeConnection extends HMSConnection {
   private readonly remoteStreams = new Map<string, HMSRemoteStream>();
   protected readonly observer: ISubscribeConnectionObserver;
   private readonly MAX_RETRIES = 3;
+  /**
+   * The SFU answers within a few ms, but a request sent right as the data channel opens has been
+   * seen to go unanswered. Without a bound here that caller waits for the rest of the session.
+   */
+  private readonly RESPONSE_TIMEOUT = 10000;
 
   readonly nativeConnection: RTCPeerConnection;
 
@@ -176,10 +181,15 @@ export default class HMSSubscribeConnection extends HMSConnection {
     if (this.apiChannel?.readyState !== 'open') {
       await this.eventEmitter.waitFor('open');
     }
-    let response: PreferLayerResponse;
+    let response: PreferLayerResponse | undefined;
     for (let i = 0; i < this.MAX_RETRIES; i++) {
       this.apiChannel!.send(request);
-      response = await this.waitForResponse(requestId);
+      try {
+        response = await this.waitForResponse(requestId);
+      } catch {
+        HMSLogger.w(this.TAG, `No response for ${requestId}`, { request, try: i + 1 });
+        continue;
+      }
       const error = response.error;
       if (error) {
         // Don't retry or do anything, track is already removed
@@ -198,13 +208,17 @@ export default class HMSSubscribeConnection extends HMSConnection {
         break;
       }
     }
-    return response!;
+    if (!response) {
+      throw Error(`No response from SFU for ${requestId} after ${this.MAX_RETRIES} tries - ${request}`);
+    }
+    return response;
   };
 
   private waitForResponse = async (requestId: string): Promise<PreferLayerResponse> => {
-    const res = await this.eventEmitter.waitFor('message', function (value) {
-      return value.includes(requestId);
-    });
+    const res = await this.eventEmitter.waitFor('message', {
+      filter: (value: string) => value.includes(requestId),
+      timeout: this.RESPONSE_TIMEOUT,
+    } as WaitForOptions);
     const response = JSON.parse(res[0] as string);
     HMSLogger.d(this.TAG, `response for ${requestId} -`, JSON.stringify(response, null, 2));
     return response;


### PR DESCRIPTION
Attaching a remote audio track awaited `setVolume()`, which applies the subscription state over the API data channel, and the wait for that reply had no timeout — so a single unanswered `prefer-audio-track-state` response left the audio element created but never appended, never given a `srcObject` and never played, silencing that peer for the rest of the session with no error and no retry.

Remote audio is subscribed by default, so that request is an optimisation: attach and play the track first, apply the subscription state afterwards, and bound the wait so a lost reply retries instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)