### PR TITLE
fix(store): stop layer-request failures leaking as unhandled rejections

### DIFF
--- a/packages/hms-video-store/src/audio-sink-manager/AudioSinkManager.ts
+++ b/packages/hms-video-store/src/audio-sink-manager/AudioSinkManager.ts
@@ -166,7 +166,8 @@ export class AudioSinkManager {
      */
     track
       .setVolume(this.volume)
-      .catch(error => HMSLogger.w(this.TAG, 'Could not apply audio subscription state', `${track}`, error));
+      // error, not warn: a warn is dropped once an app calls setLogLevel(ERROR)
+      .catch(error => HMSLogger.e(this.TAG, 'Could not apply audio subscription state', `${track}`, error));
   };
 
   private handleAutoplayError = async (track: HMSRemoteAudioTrack) => {

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
@@ -9,6 +9,10 @@ jest.mock('../../utils/timer-utils', () => ({
   workerSleep: () => Promise.resolve(),
 }));
 
+interface WithEventEmitter {
+  eventEmitter: { emit: (event: string, value: string) => void };
+}
+
 /**
  * The Aug 2026 silent-recording incident: the SFU never answered the first
  * `prefer-audio-track-state` request of a session, so the caller waited forever.
@@ -32,14 +36,16 @@ describe('HMSSubscribeConnection api data channel', () => {
     connection.nativeConnection.ondatachannel?.({ channel: nativeChannel } as RTCDataChannelEvent);
   });
 
-  const respondTo = (request: string) => {
-    const { id } = JSON.parse(request);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (connection as any).eventEmitter.emit(
+  /** the emitter is private; the data channel's onMessage feeds it exactly like this */
+  const emitReply = (request: string, body: Record<string, unknown>) => {
+    const { id } = JSON.parse(request) as { id: string };
+    (connection as unknown as WithEventEmitter).eventEmitter.emit(
       'message',
-      JSON.stringify({ id, jsonrpc: '2.0', result: { track_id: 'track-1' } }),
+      JSON.stringify({ id, jsonrpc: '2.0', ...body }),
     );
   };
+
+  const respondTo = (request: string) => emitReply(request, { result: { track_id: 'track-1' } });
 
   it('resolves when the SFU answers', async () => {
     const promise = connection.sendOverApiDataChannelWithResponse({
@@ -83,12 +89,7 @@ describe('HMSSubscribeConnection api data channel', () => {
       .catch((error: Error) => error);
 
     await Promise.resolve();
-    const { id } = JSON.parse(sent[0]);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (connection as any).eventEmitter.emit(
-      'message',
-      JSON.stringify({ id, jsonrpc: '2.0', error: { code: 429, message: 'too many requests' } }),
-    );
+    emitReply(sent[0], { error: { code: 429, message: 'too many requests' } });
 
     await jest.advanceTimersByTimeAsync(120_000);
     const result = await promise;

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
@@ -3,6 +3,12 @@ import HMSSubscribeConnection from './subscribeConnection';
 import JsonRpcSignal from '../../signal/jsonrpc';
 import { API_DATA_CHANNEL } from '../../utils/constants';
 
+// the retry backoff sleeps on a worker timer, which fake timers do not advance
+jest.mock('../../utils/timer-utils', () => ({
+  ...jest.requireActual('../../utils/timer-utils'),
+  workerSleep: () => Promise.resolve(),
+}));
+
 /**
  * The Aug 2026 silent-recording incident: the SFU never answered the first
  * `prefer-audio-track-state` request of a session, so the caller waited forever.
@@ -16,7 +22,7 @@ describe('HMSSubscribeConnection api data channel', () => {
     window.RTCPeerConnection = jest.fn().mockImplementation(() => ({})) as unknown as typeof RTCPeerConnection;
     const signal = { trickle: jest.fn() } as unknown as JsonRpcSignal;
     const observer = { onApiChannelMessage: jest.fn() } as unknown as ISubscribeConnectionObserver;
-    connection = new HMSSubscribeConnection({}, signal, observer);
+    connection = new HMSSubscribeConnection(signal, {}, () => false, observer);
 
     const nativeChannel = {
       label: API_DATA_CHANNEL,
@@ -54,6 +60,35 @@ describe('HMSSubscribeConnection api data channel', () => {
         params: { subscribed: true, track_id: 'track-1' },
       })
       .catch((error: Error) => error);
+
+    await jest.advanceTimersByTimeAsync(120_000);
+    const result = await promise;
+
+    expect(result).toBeInstanceOf(Error);
+    jest.useRealTimers();
+  }, 10_000);
+
+  /**
+   * A retryable error on an early attempt must not be reported as the outcome when the later
+   * attempts time out - callers do not inspect `error` on the resolved value, so returning it
+   * reads as success.
+   */
+  it('throws rather than returning an earlier error response when later attempts time out', async () => {
+    jest.useFakeTimers();
+    const promise = connection
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-audio-track-state',
+        params: { subscribed: true, track_id: 'track-1' },
+      })
+      .catch((error: Error) => error);
+
+    await Promise.resolve();
+    const { id } = JSON.parse(sent[0]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (connection as any).eventEmitter.emit(
+      'message',
+      JSON.stringify({ id, jsonrpc: '2.0', error: { code: 429, message: 'too many requests' } }),
+    );
 
     await jest.advanceTimersByTimeAsync(120_000);
     const result = await promise;

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
@@ -97,4 +97,73 @@ describe('HMSSubscribeConnection api data channel', () => {
     expect(result).toBeInstanceOf(Error);
     jest.useRealTimers();
   }, 10_000);
+
+  /**
+   * If the data channel never opens - the connection was torn down, or replaced by a new
+   * HMSSubscribeConnection that owns the next channel - the old emitter never fires 'open' again.
+   * An unbounded wait there hangs the caller for the rest of the session just as a lost reply did.
+   */
+  it('settles instead of hanging when the data channel never opens', async () => {
+    const observer = { onApiChannelMessage: jest.fn() } as unknown as ISubscribeConnectionObserver;
+    const neverOpen = new HMSSubscribeConnection(
+      { trickle: jest.fn() } as unknown as JsonRpcSignal,
+      {},
+      () => false,
+      observer,
+    );
+
+    jest.useFakeTimers();
+    const promise = neverOpen
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-audio-track-state',
+        params: { subscribed: true, track_id: 'track-1' },
+      })
+      .catch((error: Error) => error);
+
+    await jest.advanceTimersByTimeAsync(180_000);
+    const result = await promise;
+
+    expect(result).toBeInstanceOf(Error);
+    jest.useRealTimers();
+  }, 10_000);
+
+  /** a channel that opens after the first attempt gave up should still get the request through */
+  it('recovers on a later attempt when the channel opens late', async () => {
+    const observer = { onApiChannelMessage: jest.fn() } as unknown as ISubscribeConnectionObserver;
+    const late = new HMSSubscribeConnection(
+      { trickle: jest.fn() } as unknown as JsonRpcSignal,
+      {},
+      () => false,
+      observer,
+    );
+    const lateSent: string[] = [];
+    const nativeChannel = {
+      label: API_DATA_CHANNEL,
+      readyState: 'open',
+      send: (message: string) => lateSent.push(message),
+    } as unknown as RTCDataChannel;
+
+    jest.useFakeTimers();
+    const promise = late.sendOverApiDataChannelWithResponse({
+      method: 'prefer-audio-track-state',
+      params: { subscribed: true, track_id: 'track-1' },
+    });
+
+    // let the first attempt's open wait expire
+    await jest.advanceTimersByTimeAsync(11_000);
+    expect(lateSent).toHaveLength(0);
+
+    late.nativeConnection.ondatachannel?.({ channel: nativeChannel } as RTCDataChannelEvent);
+    nativeChannel.onopen?.(new Event('open'));
+    await jest.advanceTimersByTimeAsync(100);
+
+    const { id } = JSON.parse(lateSent[0]) as { id: string };
+    (late as unknown as WithEventEmitter).eventEmitter.emit(
+      'message',
+      JSON.stringify({ id, jsonrpc: '2.0', result: { track_id: 'track-1' } }),
+    );
+
+    await expect(promise).resolves.toBeDefined();
+    jest.useRealTimers();
+  }, 10_000);
 });

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
@@ -21,10 +21,10 @@ export default class HMSSubscribeConnection extends HMSConnection {
   protected readonly observer: ISubscribeConnectionObserver;
   private readonly MAX_RETRIES = 3;
   /**
-   * A request sent in the window where the data channel is open locally but not yet on the SFU
-   * has been seen to go unanswered, which without a bound leaves the caller waiting for the whole
-   * session. Deliberately generous: a retry replays the original serialized request, so a
-   * premature one can apply stale desired state over a newer request.
+   * The first request of a session has been seen to go unanswered, which without a bound leaves
+   * that caller waiting for the rest of the session. Deliberately generous: a retry replays the
+   * original serialized request, so a premature one can apply stale desired state over a newer
+   * request.
    */
   private readonly RESPONSE_TIMEOUT = 10000;
 

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
@@ -21,11 +21,12 @@ export default class HMSSubscribeConnection extends HMSConnection {
   protected readonly observer: ISubscribeConnectionObserver;
   private readonly MAX_RETRIES = 3;
   /**
-   * The SFU answers in well under 10ms, but a request sent right as the data channel opens has
-   * been seen to go unanswered. Keep the bound tight - a remote peer unmuting re-subscribes over
-   * this channel, so every retry is time their audio stays missing. Retries are idempotent.
+   * A request sent in the window where the data channel is open locally but not yet on the SFU
+   * has been seen to go unanswered, which without a bound leaves the caller waiting for the whole
+   * session. Deliberately generous: a retry replays the original serialized request, so a
+   * premature one can apply stale desired state over a newer request.
    */
-  private readonly RESPONSE_TIMEOUT = 2000;
+  private readonly RESPONSE_TIMEOUT = 10000;
 
   readonly nativeConnection: RTCPeerConnection;
 
@@ -184,6 +185,8 @@ export default class HMSSubscribeConnection extends HMSConnection {
     }
     let response: PreferLayerResponse | undefined;
     for (let i = 0; i < this.MAX_RETRIES; i++) {
+      // a previous attempt's error response must not stand in for this attempt's outcome
+      response = undefined;
       this.apiChannel!.send(request);
       try {
         response = await this.waitForResponse(requestId);

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
@@ -27,6 +27,8 @@ export default class HMSSubscribeConnection extends HMSConnection {
    * request.
    */
   private readonly RESPONSE_TIMEOUT = 10000;
+  /** bound on waiting for the api data channel to open, applied per attempt */
+  private readonly OPEN_TIMEOUT = 10000;
 
   readonly nativeConnection: RTCPeerConnection;
 
@@ -180,13 +182,16 @@ export default class HMSSubscribeConnection extends HMSConnection {
 
   // eslint-disable-next-line complexity
   private sendMessage = async (request: string, requestId: string): Promise<PreferLayerResponse> => {
-    if (this.apiChannel?.readyState !== 'open') {
-      await this.eventEmitter.waitFor('open');
-    }
     let response: PreferLayerResponse | undefined;
     for (let i = 0; i < this.MAX_RETRIES; i++) {
       // a previous attempt's error response must not stand in for this attempt's outcome
       response = undefined;
+      try {
+        await this.waitForChannelOpen();
+      } catch (error) {
+        HMSLogger.w(this.TAG, `API data channel not open for ${requestId}`, { request, try: i + 1, error });
+        continue;
+      }
       this.apiChannel!.send(request);
       try {
         response = await this.waitForResponse(requestId);
@@ -216,6 +221,18 @@ export default class HMSSubscribeConnection extends HMSConnection {
       throw Error(`No response from SFU for ${requestId} after ${this.MAX_RETRIES} tries - ${request}`);
     }
     return response;
+  };
+
+  /**
+   * Checked per attempt rather than once up front: 'open' is emitted from the channel's onopen, so
+   * a channel that is closed or replaced never emits again and an unbounded wait here would hang
+   * the caller for the rest of the session.
+   */
+  private waitForChannelOpen = async () => {
+    if (this.apiChannel?.readyState === 'open') {
+      return;
+    }
+    await this.eventEmitter.waitFor('open', { timeout: this.OPEN_TIMEOUT } as WaitForOptions);
   };
 
   private waitForResponse = async (requestId: string): Promise<PreferLayerResponse> => {

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
@@ -21,14 +21,13 @@ export default class HMSSubscribeConnection extends HMSConnection {
   protected readonly observer: ISubscribeConnectionObserver;
   private readonly MAX_RETRIES = 3;
   /**
-   * The first request of a session has been seen to go unanswered, which without a bound leaves
-   * that caller waiting for the rest of the session. Deliberately generous: a retry replays the
-   * original serialized request, so a premature one can apply stale desired state over a newer
-   * request.
+   * Bounds both waits on the api data channel - for it to open, and for a reply. The first request
+   * of a session has been seen to go unanswered, and a channel that is closed or replaced never
+   * emits 'open' again; unbounded, either leaves that caller waiting for the rest of the session.
+   * Deliberately generous: a retry replays the original serialized request, so a premature one can
+   * apply stale desired state over a newer request.
    */
   private readonly RESPONSE_TIMEOUT = 10000;
-  /** bound on waiting for the api data channel to open, applied per attempt */
-  private readonly OPEN_TIMEOUT = 10000;
 
   readonly nativeConnection: RTCPeerConnection;
 
@@ -188,15 +187,11 @@ export default class HMSSubscribeConnection extends HMSConnection {
       response = undefined;
       try {
         await this.waitForChannelOpen();
-      } catch (error) {
-        HMSLogger.w(this.TAG, `API data channel not open for ${requestId}`, { request, try: i + 1, error });
-        continue;
-      }
-      this.apiChannel!.send(request);
-      try {
+        // send can throw too - the channel may close between the open check and here
+        this.apiChannel!.send(request);
         response = await this.waitForResponse(requestId);
       } catch (error) {
-        HMSLogger.w(this.TAG, `No response for ${requestId}`, { request, try: i + 1, error });
+        HMSLogger.w(this.TAG, `Attempt failed for ${requestId}`, { request, try: i + 1, error });
         continue;
       }
       const error = response.error;
@@ -232,7 +227,7 @@ export default class HMSSubscribeConnection extends HMSConnection {
     if (this.apiChannel?.readyState === 'open') {
       return;
     }
-    await this.eventEmitter.waitFor('open', { timeout: this.OPEN_TIMEOUT } as WaitForOptions);
+    await this.eventEmitter.waitFor('open', { timeout: this.RESPONSE_TIMEOUT } as WaitForOptions);
   };
 
   private waitForResponse = async (requestId: string): Promise<PreferLayerResponse> => {

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
@@ -190,8 +190,8 @@ export default class HMSSubscribeConnection extends HMSConnection {
       this.apiChannel!.send(request);
       try {
         response = await this.waitForResponse(requestId);
-      } catch {
-        HMSLogger.w(this.TAG, `No response for ${requestId}`, { request, try: i + 1 });
+      } catch (error) {
+        HMSLogger.w(this.TAG, `No response for ${requestId}`, { request, try: i + 1, error });
         continue;
       }
       const error = response.error;

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
@@ -21,10 +21,11 @@ export default class HMSSubscribeConnection extends HMSConnection {
   protected readonly observer: ISubscribeConnectionObserver;
   private readonly MAX_RETRIES = 3;
   /**
-   * The SFU answers within a few ms, but a request sent right as the data channel opens has been
-   * seen to go unanswered. Without a bound here that caller waits for the rest of the session.
+   * The SFU answers in well under 10ms, but a request sent right as the data channel opens has
+   * been seen to go unanswered. Keep the bound tight - a remote peer unmuting re-subscribes over
+   * this channel, so every retry is time their audio stays missing. Retries are idempotent.
    */
-  private readonly RESPONSE_TIMEOUT = 10000;
+  private readonly RESPONSE_TIMEOUT = 2000;
 
   readonly nativeConnection: RTCPeerConnection;
 

--- a/packages/hms-video-store/src/media/tracks/HMSRemoteVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSRemoteVideoTrack.ts
@@ -106,9 +106,8 @@ export class HMSRemoteVideoTrack extends HMSVideoTrack {
   }
 
   async addSink(videoElement: HTMLVideoElement, shouldSendVideoLayer = true) {
-    // if the native track is empty track, just request the preferred layer else attach it
+    // an empty track is an on-demand placeholder - request the layer, which fetches the real track
     if (isEmptyTrack(this.nativeTrack)) {
-      // on-demand tracks start empty; this request is what fetches the real one
       await this.requestLayerSafely(this.preferredLayer, 'addSink');
     } else {
       super.addSink(videoElement);
@@ -192,10 +191,12 @@ export class HMSRemoteVideoTrack extends HMSVideoTrack {
   }
 
   /**
-   * addSink and removeSink are reached from updateSinks, removeVideoElement and VideoElementManager,
-   * none of which await them, so a rejection escapes unhandled. Logged at error level because a warn
-   * is dropped once an app calls setLogLevel(ERROR), which would make this quieter than the
-   * unhandled rejection it replaces. setPreferredLayer still rejects for API callers.
+   * The promise around addSink/removeSink is discarded at the observer boundary - handleResize and
+   * handleIntersection are handed to Resize/IntersectionObserver - and by updateSinks,
+   * addVideoElement and removeVideoElement, so a rejection there escapes unhandled. Note attachVideo
+   * with autoManageVideo: false does await addSink, and no longer sees the failure; setPreferredLayer
+   * still rejects. Logged at error because a warn is dropped once an app calls setLogLevel(ERROR),
+   * which would be quieter than the unhandled rejection this replaces.
    */
   private async requestLayerSafely(layer: HMSSimulcastLayer, source: string) {
     try {

--- a/packages/hms-video-store/src/media/tracks/HMSRemoteVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSRemoteVideoTrack.ts
@@ -108,7 +108,8 @@ export class HMSRemoteVideoTrack extends HMSVideoTrack {
   async addSink(videoElement: HTMLVideoElement, shouldSendVideoLayer = true) {
     // if the native track is empty track, just request the preferred layer else attach it
     if (isEmptyTrack(this.nativeTrack)) {
-      await this.requestLayer(this.preferredLayer, 'addSink');
+      // on-demand tracks start empty; this request is what fetches the real one
+      await this.requestLayerSafely(this.preferredLayer, 'addSink');
     } else {
       super.addSink(videoElement);
       if (shouldSendVideoLayer) {
@@ -187,15 +188,20 @@ export class HMSRemoteVideoTrack extends HMSVideoTrack {
     if (!this.shouldSendVideoLayer(newLayer, source)) {
       return;
     }
-    /**
-     * Reached from addSink/removeSink, whose callers - updateSinks, removeVideoElement and
-     * VideoElementManager - do not await them, so a rejection here escapes unhandled.
-     * setPreferredLayer requests its layer directly and still rejects for API callers.
-     */
+    await this.requestLayerSafely(newLayer, source);
+  }
+
+  /**
+   * addSink and removeSink are reached from updateSinks, removeVideoElement and VideoElementManager,
+   * none of which await them, so a rejection escapes unhandled. Logged at error level because a warn
+   * is dropped once an app calls setLogLevel(ERROR), which would make this quieter than the
+   * unhandled rejection it replaces. setPreferredLayer still rejects for API callers.
+   */
+  private async requestLayerSafely(layer: HMSSimulcastLayer, source: string) {
     try {
-      await this.requestLayer(newLayer, source);
+      await this.requestLayer(layer, source);
     } catch (error) {
-      HMSLogger.w(`[Remote Track] ${this.logIdentifier} failed to request layer ${newLayer}, source=${source}`, error);
+      HMSLogger.e(`[Remote Track] ${this.logIdentifier} failed to request layer ${layer}, source=${source}`, error);
     }
   }
 

--- a/packages/hms-video-store/src/media/tracks/HMSRemoteVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSRemoteVideoTrack.ts
@@ -108,7 +108,7 @@ export class HMSRemoteVideoTrack extends HMSVideoTrack {
   async addSink(videoElement: HTMLVideoElement, shouldSendVideoLayer = true) {
     // an empty track is an on-demand placeholder - request the layer, which fetches the real track
     if (isEmptyTrack(this.nativeTrack)) {
-      await this.requestLayerSafely(this.preferredLayer, 'addSink');
+      await this.requestLayer(this.preferredLayer, 'addSink');
     } else {
       super.addSink(videoElement);
       if (shouldSendVideoLayer) {
@@ -187,23 +187,7 @@ export class HMSRemoteVideoTrack extends HMSVideoTrack {
     if (!this.shouldSendVideoLayer(newLayer, source)) {
       return;
     }
-    await this.requestLayerSafely(newLayer, source);
-  }
-
-  /**
-   * The promise around addSink/removeSink is discarded at the observer boundary - handleResize and
-   * handleIntersection are handed to Resize/IntersectionObserver - and by updateSinks,
-   * addVideoElement and removeVideoElement, so a rejection there escapes unhandled. Note attachVideo
-   * with autoManageVideo: false does await addSink, and no longer sees the failure; setPreferredLayer
-   * still rejects. Logged at error because a warn is dropped once an app calls setLogLevel(ERROR),
-   * which would be quieter than the unhandled rejection this replaces.
-   */
-  private async requestLayerSafely(layer: HMSSimulcastLayer, source: string) {
-    try {
-      await this.requestLayer(layer, source);
-    } catch (error) {
-      HMSLogger.e(`[Remote Track] ${this.logIdentifier} failed to request layer ${layer}, source=${source}`, error);
-    }
+    await this.requestLayer(newLayer, source);
   }
 
   private pushInHistory(action: string) {

--- a/packages/hms-video-store/src/media/tracks/HMSRemoteVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSRemoteVideoTrack.ts
@@ -187,7 +187,16 @@ export class HMSRemoteVideoTrack extends HMSVideoTrack {
     if (!this.shouldSendVideoLayer(newLayer, source)) {
       return;
     }
-    await this.requestLayer(newLayer, source);
+    /**
+     * Reached from addSink/removeSink, whose callers - updateSinks, removeVideoElement and
+     * VideoElementManager - do not await them, so a rejection here escapes unhandled.
+     * setPreferredLayer requests its layer directly and still rejects for API callers.
+     */
+    try {
+      await this.requestLayer(newLayer, source);
+    } catch (error) {
+      HMSLogger.w(`[Remote Track] ${this.logIdentifier} failed to request layer ${newLayer}, source=${source}`, error);
+    }
   }
 
   private pushInHistory(action: string) {

--- a/packages/hms-video-store/src/media/tracks/VideoElementManager.ts
+++ b/packages/hms-video-store/src/media/tracks/VideoElementManager.ts
@@ -19,6 +19,9 @@ export class VideoElementManager {
   private videoElements = new Set<HTMLVideoElement>();
   private entries = new WeakMap<HTMLVideoElement, DOMRectReadOnly>();
   private id: string;
+  /** Which intersection entry an element is currently acting on - see handleIntersection. */
+  private intersectionSeq = new WeakMap<HTMLVideoElement, number>();
+  private seq = 0;
 
   constructor(private track: HMSLocalVideoTrack | HMSRemoteVideoTrack) {
     this.init();
@@ -100,23 +103,42 @@ export class VideoElementManager {
     }
   }
 
+  /**
+   * The observer never awaits this, so scrolling a tile in and straight back out runs both entries
+   * at once. The add suspends on selectMaxLayer before it attaches a sink, which leaves the remove
+   * nothing to undo - it sees no sink and a layer already on none, so it sends nothing, and then
+   * the stale add resumes and asks for high, leaving the SFU streaming a tile no element renders.
+   * Stamp each entry and drop the add if a newer entry for that element arrived while it was
+   * suspended, so the last thing the user did is what decides the sink.
+   */
   private handleIntersection = async (entry: IntersectionObserverEntry) => {
     // cleanup() nulls the observer fields; treat that as the destroyed signal.
     if (!this.intersectionObserver) {
       return;
     }
+    const target = entry.target as HTMLVideoElement;
+    const seq = ++this.seq;
+    this.intersectionSeq.set(target, seq);
     const isVisibile = getComputedStyle(entry.target).visibility === 'visible';
     // .contains check is needed for pip component as the video tiles are not mounted to dom element
     if (this.track.enabled && ((entry.isIntersecting && isVisibile) || !document.contains(entry.target))) {
-      HMSLogger.d(this.TAG, 'add sink intersection', `${this.track}`, this.id);
-      this.entries.set(entry.target as HTMLVideoElement, entry.boundingClientRect);
-      await this.selectMaxLayer();
-      this.logIfRejected(this.track.addSink(entry.target as HTMLVideoElement), 'addSink');
+      await this.addSinkForEntry(target, entry.boundingClientRect, seq);
     } else {
       HMSLogger.d(this.TAG, 'remove sink intersection', `${this.track}`, this.id);
-      this.logIfRejected(this.track.removeSink(entry.target as HTMLVideoElement), 'removeSink');
+      this.logIfRejected(this.track.removeSink(target), 'removeSink');
     }
   };
+
+  private async addSinkForEntry(target: HTMLVideoElement, rect: DOMRectReadOnly, seq: number) {
+    HMSLogger.d(this.TAG, 'add sink intersection', `${this.track}`, this.id);
+    this.entries.set(target, rect);
+    await this.selectMaxLayer();
+    if (this.intersectionSeq.get(target) !== seq) {
+      HMSLogger.d(this.TAG, 'add sink superseded', `${this.track}`, this.id);
+      return;
+    }
+    this.logIfRejected(this.track.addSink(target), 'addSink');
+  }
 
   private handleResize = async (entry: ResizeObserverEntry) => {
     if (!this.resizeObserver) {

--- a/packages/hms-video-store/src/media/tracks/VideoElementManager.ts
+++ b/packages/hms-video-store/src/media/tracks/VideoElementManager.ts
@@ -180,7 +180,8 @@ export class VideoElementManager {
       try {
         await this.track.setPreferredLayer(maxLayer);
       } catch (error) {
-        HMSLogger.w(this.TAG, `failed to select layer ${maxLayer}`, `${this.track}`, error);
+        // error, not warn: a warn is dropped once an app calls setLogLevel(ERROR)
+        HMSLogger.e(this.TAG, `failed to select layer ${maxLayer}`, `${this.track}`, error);
       }
     }
   }

--- a/packages/hms-video-store/src/media/tracks/VideoElementManager.ts
+++ b/packages/hms-video-store/src/media/tracks/VideoElementManager.ts
@@ -25,12 +25,23 @@ export class VideoElementManager {
     this.id = uuid();
   }
 
+  /**
+   * addSink/removeSink reject when the layer request fails, and every call below discards the
+   * promise - updateSinks and removeVideoElement are sync, addVideoElement is discarded by
+   * HMSVideoTrack.attach, and the observers discard the handlers. Swallow here rather than inside
+   * the track, so attachVideo/detachVideo and setPreferredLayer keep reporting failures to the app.
+   * Logged at error because a warn is dropped once an app calls setLogLevel(ERROR).
+   */
+  private discard(result: void | Promise<void>, action: string) {
+    Promise.resolve(result).catch(error => HMSLogger.e(this.TAG, `${action} failed`, `${this.track}`, error));
+  }
+
   updateSinks(requestLayer = false) {
     for (const videoElement of this.videoElements) {
       if (this.track.enabled) {
-        this.track.addSink(videoElement, requestLayer);
+        this.discard(this.track.addSink(videoElement, requestLayer), 'addSink');
       } else {
-        this.track.removeSink(videoElement, requestLayer);
+        this.discard(this.track.removeSink(videoElement, requestLayer), 'removeSink');
       }
     }
   }
@@ -57,20 +68,20 @@ export class VideoElementManager {
       this.intersectionObserver.observe(videoElement, this.handleIntersection);
     } else if (isBrowser) {
       if (this.isElementInViewport(videoElement)) {
-        this.track.addSink(videoElement);
+        this.discard(this.track.addSink(videoElement), 'addSink');
       } else {
-        this.track.removeSink(videoElement);
+        this.discard(this.track.removeSink(videoElement), 'removeSink');
       }
     }
     if (this.resizeObserver) {
       this.resizeObserver.observe(videoElement, this.handleResize);
     } else if (this.track instanceof HMSRemoteVideoTrack) {
-      await this.track.setPreferredLayer(this.track.getPreferredLayer());
+      this.discard(this.track.setPreferredLayer(this.track.getPreferredLayer()), 'setPreferredLayer');
     }
   }
 
   removeVideoElement(videoElement: HTMLVideoElement): void {
-    this.track.removeSink(videoElement);
+    this.discard(this.track.removeSink(videoElement), 'removeSink');
     this.videoElements.delete(videoElement);
     this.entries.delete(videoElement);
     this.resizeObserver?.unobserve(videoElement);
@@ -100,10 +111,10 @@ export class VideoElementManager {
       HMSLogger.d(this.TAG, 'add sink intersection', `${this.track}`, this.id);
       this.entries.set(entry.target as HTMLVideoElement, entry.boundingClientRect);
       await this.selectMaxLayer();
-      await this.track.addSink(entry.target as HTMLVideoElement);
+      this.discard(this.track.addSink(entry.target as HTMLVideoElement), 'addSink');
     } else {
       HMSLogger.d(this.TAG, 'remove sink intersection', `${this.track}`, this.id);
-      await this.track.removeSink(entry.target as HTMLVideoElement);
+      this.discard(this.track.removeSink(entry.target as HTMLVideoElement), 'removeSink');
     }
   };
 

--- a/packages/hms-video-store/src/media/tracks/VideoElementManager.ts
+++ b/packages/hms-video-store/src/media/tracks/VideoElementManager.ts
@@ -32,16 +32,16 @@ export class VideoElementManager {
    * the track, so attachVideo/detachVideo and setPreferredLayer keep reporting failures to the app.
    * Logged at error because a warn is dropped once an app calls setLogLevel(ERROR).
    */
-  private discard(result: void | Promise<void>, action: string) {
+  private logIfRejected(result: void | Promise<void>, action: string) {
     Promise.resolve(result).catch(error => HMSLogger.e(this.TAG, `${action} failed`, `${this.track}`, error));
   }
 
   updateSinks(requestLayer = false) {
     for (const videoElement of this.videoElements) {
       if (this.track.enabled) {
-        this.discard(this.track.addSink(videoElement, requestLayer), 'addSink');
+        this.logIfRejected(this.track.addSink(videoElement, requestLayer), 'addSink');
       } else {
-        this.discard(this.track.removeSink(videoElement, requestLayer), 'removeSink');
+        this.logIfRejected(this.track.removeSink(videoElement, requestLayer), 'removeSink');
       }
     }
   }
@@ -68,20 +68,20 @@ export class VideoElementManager {
       this.intersectionObserver.observe(videoElement, this.handleIntersection);
     } else if (isBrowser) {
       if (this.isElementInViewport(videoElement)) {
-        this.discard(this.track.addSink(videoElement), 'addSink');
+        this.logIfRejected(this.track.addSink(videoElement), 'addSink');
       } else {
-        this.discard(this.track.removeSink(videoElement), 'removeSink');
+        this.logIfRejected(this.track.removeSink(videoElement), 'removeSink');
       }
     }
     if (this.resizeObserver) {
       this.resizeObserver.observe(videoElement, this.handleResize);
     } else if (this.track instanceof HMSRemoteVideoTrack) {
-      this.discard(this.track.setPreferredLayer(this.track.getPreferredLayer()), 'setPreferredLayer');
+      this.logIfRejected(this.track.setPreferredLayer(this.track.getPreferredLayer()), 'setPreferredLayer');
     }
   }
 
   removeVideoElement(videoElement: HTMLVideoElement): void {
-    this.discard(this.track.removeSink(videoElement), 'removeSink');
+    this.logIfRejected(this.track.removeSink(videoElement), 'removeSink');
     this.videoElements.delete(videoElement);
     this.entries.delete(videoElement);
     this.resizeObserver?.unobserve(videoElement);
@@ -111,10 +111,10 @@ export class VideoElementManager {
       HMSLogger.d(this.TAG, 'add sink intersection', `${this.track}`, this.id);
       this.entries.set(entry.target as HTMLVideoElement, entry.boundingClientRect);
       await this.selectMaxLayer();
-      this.discard(this.track.addSink(entry.target as HTMLVideoElement), 'addSink');
+      this.logIfRejected(this.track.addSink(entry.target as HTMLVideoElement), 'addSink');
     } else {
       HMSLogger.d(this.TAG, 'remove sink intersection', `${this.track}`, this.id);
-      this.discard(this.track.removeSink(entry.target as HTMLVideoElement), 'removeSink');
+      this.logIfRejected(this.track.removeSink(entry.target as HTMLVideoElement), 'removeSink');
     }
   };
 

--- a/packages/hms-video-store/src/media/tracks/VideoElementManager.ts
+++ b/packages/hms-video-store/src/media/tracks/VideoElementManager.ts
@@ -65,15 +65,7 @@ export class VideoElementManager {
     if (this.resizeObserver) {
       this.resizeObserver.observe(videoElement, this.handleResize);
     } else if (this.track instanceof HMSRemoteVideoTrack) {
-      /**
-       * HMSVideoTrack.addSink does not await this method, so a failed layer request would
-       * otherwise escape as an unhandled rejection.
-       */
-      try {
-        await this.track.setPreferredLayer(this.track.getPreferredLayer());
-      } catch (error) {
-        HMSLogger.w(this.TAG, 'failed to set preferred layer', `${this.track}`, error);
-      }
+      await this.track.setPreferredLayer(this.track.getPreferredLayer());
     }
   }
 
@@ -102,14 +94,6 @@ export class VideoElementManager {
     if (!this.intersectionObserver) {
       return;
     }
-    try {
-      await this.applyIntersection(entry);
-    } catch (error) {
-      HMSLogger.w(this.TAG, 'failed to handle intersection', `${this.track}`, error);
-    }
-  };
-
-  private async applyIntersection(entry: IntersectionObserverEntry) {
     const isVisibile = getComputedStyle(entry.target).visibility === 'visible';
     // .contains check is needed for pip component as the video tiles are not mounted to dom element
     if (this.track.enabled && ((entry.isIntersecting && isVisibile) || !document.contains(entry.target))) {
@@ -121,7 +105,7 @@ export class VideoElementManager {
       HMSLogger.d(this.TAG, 'remove sink intersection', `${this.track}`, this.id);
       await this.track.removeSink(entry.target as HTMLVideoElement);
     }
-  }
+  };
 
   private handleResize = async (entry: ResizeObserverEntry) => {
     if (!this.resizeObserver) {
@@ -131,11 +115,7 @@ export class VideoElementManager {
       return;
     }
     this.entries.set(entry.target as HTMLVideoElement, entry.contentRect);
-    try {
-      await this.selectMaxLayer();
-    } catch (error) {
-      HMSLogger.w(this.TAG, 'failed to select max layer on resize', `${this.track}`, error);
-    }
+    await this.selectMaxLayer();
   };
 
   /**
@@ -192,7 +172,16 @@ export class VideoElementManager {
     }
     if (maxLayer) {
       HMSLogger.d(this.TAG, `selecting max layer ${maxLayer} for the track`, `${this.track}`);
-      await this.track.setPreferredLayer(maxLayer);
+      /**
+       * Picking a layer is an optimisation over rendering the track, and the only callers are the
+       * resize and intersection handlers, which observers invoke without awaiting. Letting this
+       * reject would abort the sink attach and surface as an unhandled rejection.
+       */
+      try {
+        await this.track.setPreferredLayer(maxLayer);
+      } catch (error) {
+        HMSLogger.w(this.TAG, `failed to select layer ${maxLayer}`, `${this.track}`, error);
+      }
     }
   }
 

--- a/packages/hms-video-store/src/media/tracks/VideoElementManager.ts
+++ b/packages/hms-video-store/src/media/tracks/VideoElementManager.ts
@@ -65,7 +65,15 @@ export class VideoElementManager {
     if (this.resizeObserver) {
       this.resizeObserver.observe(videoElement, this.handleResize);
     } else if (this.track instanceof HMSRemoteVideoTrack) {
-      await this.track.setPreferredLayer(this.track.getPreferredLayer());
+      /**
+       * HMSVideoTrack.addSink does not await this method, so a failed layer request would
+       * otherwise escape as an unhandled rejection.
+       */
+      try {
+        await this.track.setPreferredLayer(this.track.getPreferredLayer());
+      } catch (error) {
+        HMSLogger.w(this.TAG, 'failed to set preferred layer', `${this.track}`, error);
+      }
     }
   }
 
@@ -94,6 +102,14 @@ export class VideoElementManager {
     if (!this.intersectionObserver) {
       return;
     }
+    try {
+      await this.applyIntersection(entry);
+    } catch (error) {
+      HMSLogger.w(this.TAG, 'failed to handle intersection', `${this.track}`, error);
+    }
+  };
+
+  private async applyIntersection(entry: IntersectionObserverEntry) {
     const isVisibile = getComputedStyle(entry.target).visibility === 'visible';
     // .contains check is needed for pip component as the video tiles are not mounted to dom element
     if (this.track.enabled && ((entry.isIntersecting && isVisibile) || !document.contains(entry.target))) {
@@ -105,7 +121,7 @@ export class VideoElementManager {
       HMSLogger.d(this.TAG, 'remove sink intersection', `${this.track}`, this.id);
       await this.track.removeSink(entry.target as HTMLVideoElement);
     }
-  };
+  }
 
   private handleResize = async (entry: ResizeObserverEntry) => {
     if (!this.resizeObserver) {
@@ -115,7 +131,11 @@ export class VideoElementManager {
       return;
     }
     this.entries.set(entry.target as HTMLVideoElement, entry.contentRect);
-    await this.selectMaxLayer();
+    try {
+      await this.selectMaxLayer();
+    } catch (error) {
+      HMSLogger.w(this.TAG, 'failed to select max layer on resize', `${this.track}`, error);
+    }
   };
 
   /**

--- a/packages/hms-video-store/src/media/tracks/videoLayerFailure.test.ts
+++ b/packages/hms-video-store/src/media/tracks/videoLayerFailure.test.ts
@@ -89,17 +89,34 @@ describe('VideoElementManager layer request failures', () => {
   /**
    * updateSinks is sync and discards the promises from addSink/removeSink, and it runs on every
    * remote video mute/unmute via HMSRemoteVideoTrack.setEnabled, so a rejecting layer request
-   * there has no caller to catch it.
+   * there has no caller to catch it. Asserting on the promise updateSinks discards pins that
+   * directly - a process-level unhandledRejection spy never fires under jest.
    */
-  it('does not leak an unhandled rejection from updateSinks', async () => {
+  it('does not reject from the promise updateSinks discards', async () => {
     setPreferredLayer.mockRestore();
-    const unhandled = jest.fn();
-    process.on('unhandledRejection', unhandled);
 
-    manager.updateSinks(true);
-    await new Promise(resolve => setTimeout(resolve, 0));
-    process.off('unhandledRejection', unhandled);
+    await expect(track.addSink(videoElement, true)).resolves.toBeUndefined();
+  });
 
-    expect(unhandled).not.toHaveBeenCalled();
+  /**
+   * On-demand tracks start as empty canvas tracks, and addSink takes a branch for them that asks
+   * for the layer directly instead of going through updateLayer. That request is what fetches the
+   * real track, so it is the one most exposed to an unanswered reply.
+   */
+  it('does not reject for an empty on-demand track', async () => {
+    setPreferredLayer.mockRestore();
+    const emptyTrack = new HMSRemoteVideoTrack(
+      track.stream as HMSRemoteStream,
+      {
+        id: 'empty-1',
+        kind: 'video',
+        enabled: true,
+        label: '',
+        addEventListener: jest.fn(),
+      } as unknown as MediaStreamTrack,
+      'regular',
+    );
+
+    await expect(emptyTrack.addSink(videoElement, true)).resolves.toBeUndefined();
   });
 });

--- a/packages/hms-video-store/src/media/tracks/videoLayerFailure.test.ts
+++ b/packages/hms-video-store/src/media/tracks/videoLayerFailure.test.ts
@@ -5,7 +5,9 @@ import { HMSRemoteStream } from '../streams/HMSRemoteStream';
 
 /**
  * The observer callbacks are private, but they are a real entry point - Resize/IntersectionObserver
- * invoke them exactly as these tests do, without awaiting the promise they return.
+ * call them and discard the promise they return, which is how a rejection escapes. The tests await
+ * it instead, so a rejection becomes a failing assertion. The resize path is debounced in
+ * production; calling the handler directly skips that.
  */
 interface ObserverHandlers {
   handleResize: (entry: ResizeObserverEntry) => Promise<void>;

--- a/packages/hms-video-store/src/media/tracks/videoLayerFailure.test.ts
+++ b/packages/hms-video-store/src/media/tracks/videoLayerFailure.test.ts
@@ -1,0 +1,54 @@
+import { HMSRemoteVideoTrack } from './HMSRemoteVideoTrack';
+import { VideoElementManager } from './VideoElementManager';
+import HMSSubscribeConnection from '../../connection/subscribe/subscribeConnection';
+import { HMSRemoteStream } from '../streams/HMSRemoteStream';
+
+/**
+ * A lost `prefer-video-track-state` reply makes requestLayer throw. The resize and
+ * intersection handlers are handed to observers, which never await them, so a throw
+ * there escapes as an unhandled rejection.
+ */
+describe('VideoElementManager layer request failures', () => {
+  let track: HMSRemoteVideoTrack;
+  let manager: VideoElementManager;
+  let videoElement: HTMLVideoElement;
+  let setPreferredLayer: jest.SpyInstance;
+
+  beforeEach(() => {
+    videoElement = document.createElement('video');
+    const connection = { sendOverApiDataChannelWithResponse: jest.fn() } as unknown as HMSSubscribeConnection;
+    const stream = new HMSRemoteStream({ id: 'stream-1' } as MediaStream, connection);
+    const nativeTrack = {
+      id: 'track-1',
+      kind: 'video',
+      enabled: true,
+      addEventListener: jest.fn(),
+    } as unknown as MediaStreamTrack;
+    track = new HMSRemoteVideoTrack(stream, nativeTrack, 'regular');
+    manager = new VideoElementManager(track);
+    manager.addVideoElement(videoElement);
+    setPreferredLayer = jest
+      .spyOn(track, 'setPreferredLayer')
+      .mockRejectedValue(new Error('No response from SFU for prefer-video-track-state'));
+  });
+
+  afterEach(() => {
+    manager.cleanup();
+    jest.restoreAllMocks();
+  });
+
+  const resizeEntry = {
+    target: videoElement,
+    contentRect: { width: 640, height: 360 },
+  } as unknown as ResizeObserverEntry;
+
+  it('does not reject from the resize handler when the layer request fails', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handleResize = (manager as any).handleResize as (entry: ResizeObserverEntry) => Promise<void>;
+
+    await expect(
+      handleResize({ ...resizeEntry, target: videoElement } as ResizeObserverEntry),
+    ).resolves.toBeUndefined();
+    expect(setPreferredLayer).toHaveBeenCalled();
+  });
+});

--- a/packages/hms-video-store/src/media/tracks/videoLayerFailure.test.ts
+++ b/packages/hms-video-store/src/media/tracks/videoLayerFailure.test.ts
@@ -16,7 +16,13 @@ describe('VideoElementManager layer request failures', () => {
 
   beforeEach(() => {
     videoElement = document.createElement('video');
-    const connection = { sendOverApiDataChannelWithResponse: jest.fn() } as unknown as HMSSubscribeConnection;
+    window.MediaStream = jest.fn().mockImplementation(() => ({ addTrack: jest.fn() })) as unknown as typeof MediaStream;
+    jest.spyOn(window.HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+    const connection = {
+      sendOverApiDataChannelWithResponse: jest
+        .fn()
+        .mockRejectedValue(new Error('No response from SFU for prefer-video-track-state')),
+    } as unknown as HMSSubscribeConnection;
     const stream = new HMSRemoteStream({ id: 'stream-1' } as MediaStream, connection);
     const nativeTrack = {
       id: 'track-1',
@@ -37,18 +43,64 @@ describe('VideoElementManager layer request failures', () => {
     jest.restoreAllMocks();
   });
 
-  const resizeEntry = {
-    target: videoElement,
-    contentRect: { width: 640, height: 360 },
-  } as unknown as ResizeObserverEntry;
+  // built per-test: videoElement is only assigned in beforeEach
+  const resizeEntry = () =>
+    ({ target: videoElement, contentRect: { width: 640, height: 360 } } as unknown as ResizeObserverEntry);
+
+  const intersectionEntry = () =>
+    ({
+      target: videoElement,
+      isIntersecting: true,
+      boundingClientRect: { width: 640, height: 360 },
+    } as unknown as IntersectionObserverEntry);
 
   it('does not reject from the resize handler when the layer request fails', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const handleResize = (manager as any).handleResize as (entry: ResizeObserverEntry) => Promise<void>;
 
-    await expect(
-      handleResize({ ...resizeEntry, target: videoElement } as ResizeObserverEntry),
-    ).resolves.toBeUndefined();
+    await expect(handleResize(resizeEntry())).resolves.toBeUndefined();
     expect(setPreferredLayer).toHaveBeenCalled();
+  });
+
+  it('does not reject from the intersection handler when the layer request fails', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handleIntersection = (manager as any).handleIntersection as (
+      entry: IntersectionObserverEntry,
+    ) => Promise<void>;
+
+    await expect(handleIntersection(intersectionEntry())).resolves.toBeUndefined();
+  });
+
+  /**
+   * addSink is what assigns srcObject. Selecting a layer is an optimisation on top of that, so a
+   * failed layer request must not stop the element being attached - that leaves a blank tile.
+   */
+  it('still attaches the sink when the layer request fails', async () => {
+    const addSink = jest.spyOn(track, 'addSink');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handleIntersection = (manager as any).handleIntersection as (
+      entry: IntersectionObserverEntry,
+    ) => Promise<void>;
+
+    await handleIntersection(intersectionEntry());
+
+    expect(addSink).toHaveBeenCalledWith(videoElement);
+  });
+
+  /**
+   * updateSinks is sync and discards the promises from addSink/removeSink, and it runs on every
+   * remote video mute/unmute via HMSRemoteVideoTrack.setEnabled, so a rejecting layer request
+   * there has no caller to catch it.
+   */
+  it('does not leak an unhandled rejection from updateSinks', async () => {
+    setPreferredLayer.mockRestore();
+    const unhandled = jest.fn();
+    process.on('unhandledRejection', unhandled);
+
+    manager.updateSinks(true);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    process.off('unhandledRejection', unhandled);
+
+    expect(unhandled).not.toHaveBeenCalled();
   });
 });

--- a/packages/hms-video-store/src/media/tracks/videoLayerFailure.test.ts
+++ b/packages/hms-video-store/src/media/tracks/videoLayerFailure.test.ts
@@ -1,6 +1,7 @@
 import { HMSRemoteVideoTrack } from './HMSRemoteVideoTrack';
 import { VideoElementManager } from './VideoElementManager';
 import HMSSubscribeConnection from '../../connection/subscribe/subscribeConnection';
+import HMSLogger from '../../utils/logger';
 import { HMSRemoteStream } from '../streams/HMSRemoteStream';
 
 /**
@@ -90,22 +91,31 @@ describe('VideoElementManager layer request failures', () => {
 
   /**
    * updateSinks is sync and discards the promises from addSink/removeSink, and it runs on every
-   * remote video mute/unmute via HMSRemoteVideoTrack.setEnabled, so a rejecting layer request
-   * there has no caller to catch it. Asserting on the promise updateSinks discards pins that
-   * directly - a process-level unhandledRejection spy never fires under jest.
+   * remote video mute/unmute via HMSRemoteVideoTrack.setEnabled, so a rejecting layer request there
+   * has no caller to catch it. The swallow lives at this discard point, not inside the track.
    */
-  it('does not reject from the promise updateSinks discards', async () => {
+  it('logs and swallows the promise updateSinks discards', async () => {
     setPreferredLayer.mockRestore();
+    const logError = jest.spyOn(HMSLogger, 'e').mockImplementation(() => undefined);
 
-    await expect(track.addSink(videoElement, true)).resolves.toBeUndefined();
+    manager.updateSinks(true);
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(logError).toHaveBeenCalled();
   });
 
   /**
-   * On-demand tracks start as empty canvas tracks, and addSink takes a branch for them that asks
-   * for the layer directly instead of going through updateLayer. That request is what fetches the
-   * real track, so it is the one most exposed to an unanswered reply.
+   * addSink itself must keep rejecting: attachVideo with autoManageVideo: false awaits it, and on
+   * the empty-track branch nothing is attached, so swallowing there would report a failed attach
+   * as success.
    */
-  it('does not reject for an empty on-demand track', async () => {
+  it('still rejects from addSink so awaiting callers see the failure', async () => {
+    setPreferredLayer.mockRestore();
+
+    await expect(track.addSink(videoElement, true)).rejects.toThrow('No response from SFU');
+  });
+
+  it('still rejects from addSink for an empty on-demand track', async () => {
     setPreferredLayer.mockRestore();
     const emptyTrack = new HMSRemoteVideoTrack(
       track.stream as HMSRemoteStream,
@@ -119,6 +129,6 @@ describe('VideoElementManager layer request failures', () => {
       'regular',
     );
 
-    await expect(emptyTrack.addSink(videoElement, true)).resolves.toBeUndefined();
+    await expect(emptyTrack.addSink(videoElement, true)).rejects.toThrow('No response from SFU');
   });
 });

--- a/packages/hms-video-store/src/media/tracks/videoLayerFailure.test.ts
+++ b/packages/hms-video-store/src/media/tracks/videoLayerFailure.test.ts
@@ -4,6 +4,17 @@ import HMSSubscribeConnection from '../../connection/subscribe/subscribeConnecti
 import { HMSRemoteStream } from '../streams/HMSRemoteStream';
 
 /**
+ * The observer callbacks are private, but they are a real entry point - Resize/IntersectionObserver
+ * invoke them exactly as these tests do, without awaiting the promise they return.
+ */
+interface ObserverHandlers {
+  handleResize: (entry: ResizeObserverEntry) => Promise<void>;
+  handleIntersection: (entry: IntersectionObserverEntry) => Promise<void>;
+}
+
+const handlersOf = (manager: VideoElementManager) => manager as unknown as ObserverHandlers;
+
+/**
  * A lost `prefer-video-track-state` reply makes requestLayer throw. The resize and
  * intersection handlers are handed to observers, which never await them, so a throw
  * there escapes as an unhandled rejection.
@@ -55,20 +66,12 @@ describe('VideoElementManager layer request failures', () => {
     } as unknown as IntersectionObserverEntry);
 
   it('does not reject from the resize handler when the layer request fails', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const handleResize = (manager as any).handleResize as (entry: ResizeObserverEntry) => Promise<void>;
-
-    await expect(handleResize(resizeEntry())).resolves.toBeUndefined();
+    await expect(handlersOf(manager).handleResize(resizeEntry())).resolves.toBeUndefined();
     expect(setPreferredLayer).toHaveBeenCalled();
   });
 
   it('does not reject from the intersection handler when the layer request fails', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const handleIntersection = (manager as any).handleIntersection as (
-      entry: IntersectionObserverEntry,
-    ) => Promise<void>;
-
-    await expect(handleIntersection(intersectionEntry())).resolves.toBeUndefined();
+    await expect(handlersOf(manager).handleIntersection(intersectionEntry())).resolves.toBeUndefined();
   });
 
   /**
@@ -77,12 +80,8 @@ describe('VideoElementManager layer request failures', () => {
    */
   it('still attaches the sink when the layer request fails', async () => {
     const addSink = jest.spyOn(track, 'addSink');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const handleIntersection = (manager as any).handleIntersection as (
-      entry: IntersectionObserverEntry,
-    ) => Promise<void>;
 
-    await handleIntersection(intersectionEntry());
+    await handlersOf(manager).handleIntersection(intersectionEntry());
 
     expect(addSink).toHaveBeenCalledWith(videoElement);
   });

--- a/packages/hms-video-store/src/media/tracks/videoLayerRaces.test.ts
+++ b/packages/hms-video-store/src/media/tracks/videoLayerRaces.test.ts
@@ -85,21 +85,16 @@ describe('VideoElementManager layer request races', () => {
     } as unknown as IntersectionObserverEntry);
 
   /**
-   * Known gap, unchanged by the swallow and identical on main: scrolling a tile in and straight
-   * back out leaves the SFU on high. The add suspends on selectMaxLayer before it attaches a sink,
-   * so the remove that follows sees hasSinks() false and a layer still on none, decides there is
-   * nothing to say, and returns - then the add resumes and asks for high. The SFU keeps sending a
-   * stream no element renders.
-   *
-   * it.failing so this flips red the day the ordering is fixed, rather than asserting the bug.
+   * Scrolling a tile in and straight back out. The remove is what the user ended on, so the SFU
+   * must be left on none - otherwise it keeps sending a stream no element renders.
    */
-  it.failing('leaves the SFU on none when a tile is scrolled in and straight back out', async () => {
+  it('leaves the SFU on none when a tile is scrolled in and straight back out', async () => {
     handlersOf(manager).handleIntersection(entry(true));
     handlersOf(manager).handleIntersection(entry(false));
     await settle();
 
-    expect(sent[sent.length - 1]).toBe(HMSSimulcastLayer.NONE);
     expect(track.getLayer()).toBe(HMSSimulcastLayer.NONE);
+    expect(videoElement.srcObject).toBeNull();
   });
 
   /**

--- a/packages/hms-video-store/src/media/tracks/videoLayerRaces.test.ts
+++ b/packages/hms-video-store/src/media/tracks/videoLayerRaces.test.ts
@@ -1,0 +1,211 @@
+import { HMSRemoteVideoTrack } from './HMSRemoteVideoTrack';
+import type { VideoElementManager } from './VideoElementManager';
+import HMSSubscribeConnection from '../../connection/subscribe/subscribeConnection';
+import { HMSSimulcastLayer } from '../../interfaces/simulcast-layers';
+import HMSLogger from '../../utils/logger';
+import { HMSRemoteStream } from '../streams/HMSRemoteStream';
+
+/**
+ * The observer callbacks are private, but they are the entry point the observers actually use -
+ * neither awaits the promise it gets back, so a second entry arrives while the first is still
+ * waiting on its layer request.
+ */
+interface ObserverHandlers {
+  handleIntersection: (entry: IntersectionObserverEntry) => Promise<void>;
+}
+
+const handlersOf = (manager: VideoElementManager) => manager as unknown as ObserverHandlers;
+
+/**
+ * Nothing awaits addSink/removeSink, so a quick scroll in/out or a remote peer mashing their
+ * camera button leaves two layer requests overlapping. What must hold is that the request the SFU
+ * sees last matches what the user ended on - an add landing after a remove keeps the SFU sending a
+ * stream nothing renders, and a remove landing after an add leaves a blank tile.
+ */
+describe('VideoElementManager layer request races', () => {
+  let track: HMSRemoteVideoTrack;
+  let manager: VideoElementManager;
+  let videoElement: HTMLVideoElement;
+  let sent: HMSSimulcastLayer[];
+  let send: jest.Mock;
+
+  /**
+   * Responses resolve on a later task, so a request made while another is in flight genuinely
+   * overlaps it. Waiting longer than that lets every pending chain finish before asserting.
+   */
+  const settle = () => new Promise(resolve => setTimeout(resolve, 50));
+
+  /** Just enough to let updateSinks run for one setEnabled, while its response is still in flight. */
+  const tick = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
+  beforeEach(() => {
+    sent = [];
+    videoElement = document.createElement('video');
+    // handleIntersection treats a detached element as always-visible, so the remove branch is only
+    // reachable once the element is in the document.
+    document.body.appendChild(videoElement);
+    window.MediaStream = jest.fn().mockImplementation(() => ({ addTrack: jest.fn() })) as unknown as typeof MediaStream;
+    jest.spyOn(window.HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+    jest.spyOn(HMSLogger, 'e').mockImplementation(() => undefined);
+
+    send = jest.fn().mockImplementation(({ params }) => {
+      sent.push(params.max_spatial_layer);
+      return new Promise(resolve => setTimeout(() => resolve({}), 5));
+    });
+    const connection = { sendOverApiDataChannelWithResponse: send } as unknown as HMSSubscribeConnection;
+
+    const stream = new HMSRemoteStream({ id: 'stream-1' } as MediaStream, connection);
+    const nativeTrack = {
+      id: 'track-1',
+      kind: 'video',
+      enabled: true,
+      addEventListener: jest.fn(),
+    } as unknown as MediaStreamTrack;
+    track = new HMSRemoteVideoTrack(stream, nativeTrack, 'regular');
+    // the track builds its own VideoElementManager and setEnabled drives that one - a manager
+    // constructed here would never be the one updateSinks runs against.
+    manager = track.videoHandler;
+    manager.addVideoElement(videoElement);
+  });
+
+  afterEach(() => {
+    manager.cleanup();
+    videoElement.remove();
+    jest.restoreAllMocks();
+  });
+
+  const entry = (isIntersecting: boolean) =>
+    ({
+      target: videoElement,
+      isIntersecting,
+      boundingClientRect: { width: 640, height: 360 },
+    } as unknown as IntersectionObserverEntry);
+
+  /**
+   * Known gap, unchanged by the swallow and identical on main: scrolling a tile in and straight
+   * back out leaves the SFU on high. The add suspends on selectMaxLayer before it attaches a sink,
+   * so the remove that follows sees hasSinks() false and a layer still on none, decides there is
+   * nothing to say, and returns - then the add resumes and asks for high. The SFU keeps sending a
+   * stream no element renders.
+   *
+   * it.failing so this flips red the day the ordering is fixed, rather than asserting the bug.
+   */
+  it.failing('leaves the SFU on none when a tile is scrolled in and straight back out', async () => {
+    handlersOf(manager).handleIntersection(entry(true));
+    handlersOf(manager).handleIntersection(entry(false));
+    await settle();
+
+    expect(sent[sent.length - 1]).toBe(HMSSimulcastLayer.NONE);
+    expect(track.getLayer()).toBe(HMSSimulcastLayer.NONE);
+  });
+
+  /**
+   * The reverse - out then straight back in. The add is what the user ended on, so the element must
+   * be attached and the SFU left on a real layer.
+   */
+  it('leaves the tile attached when it is scrolled out and straight back in', async () => {
+    handlersOf(manager).handleIntersection(entry(false));
+    handlersOf(manager).handleIntersection(entry(true));
+    await settle();
+
+    expect(sent[sent.length - 1]).not.toBe(HMSSimulcastLayer.NONE);
+    expect(track.getLayer()).not.toBe(HMSSimulcastLayer.NONE);
+    expect(videoElement.srcObject).not.toBeNull();
+  });
+
+  /**
+   * A remote peer toggling their camera. setEnabled runs updateSinks, which fires addSink or
+   * removeSink and discards the promise, so a quick mute/unmute overlaps two layer requests.
+   */
+  it('ends on a real layer when a remote peer mutes and unmutes quickly', async () => {
+    await handlersOf(manager).handleIntersection(entry(true));
+    await settle();
+    sent.length = 0;
+
+    track.setEnabled(false);
+    track.setEnabled(true);
+    await settle();
+
+    expect(track.getLayer()).not.toBe(HMSSimulcastLayer.NONE);
+    expect(videoElement.srcObject).not.toBeNull();
+  });
+
+  /**
+   * The mirror of the above - unmute then mute. The SFU must end on none so it stops sending a
+   * stream for a peer whose camera is off.
+   */
+  it('ends on none when a remote peer unmutes and mutes quickly', async () => {
+    await handlersOf(manager).handleIntersection(entry(true));
+    await track.setEnabled(false);
+    await settle();
+    sent.length = 0;
+
+    track.setEnabled(true);
+    track.setEnabled(false);
+    await settle();
+
+    expect(track.getLayer()).toBe(HMSSimulcastLayer.NONE);
+  });
+
+  /**
+   * Toggling back before updateSinks has run coalesces to nothing rather than sending a redundant
+   * pair - the second updateSinks sees the layer the first one already asked for.
+   */
+  it('coalesces a mute and unmute that land in the same tick', async () => {
+    await handlersOf(manager).handleIntersection(entry(true));
+    await settle();
+    sent.length = 0;
+
+    track.setEnabled(false);
+    track.setEnabled(true);
+    await settle();
+
+    expect(sent).toEqual([]);
+    expect(track.getLayer()).toBe(HMSSimulcastLayer.HIGH);
+    expect(videoElement.srcObject).not.toBeNull();
+  });
+
+  /**
+   * Once the mute's request is on the wire, the unmute's has to follow it in that order - the send
+   * happens before the response is awaited, so a slow first response cannot let the second overtake
+   * it.
+   */
+  it('sends overlapping requests in the order they were made', async () => {
+    await handlersOf(manager).handleIntersection(entry(true));
+    await settle();
+    sent.length = 0;
+
+    track.setEnabled(false);
+    await tick();
+    track.setEnabled(true);
+    await settle();
+
+    expect(sent).toEqual([HMSSimulcastLayer.NONE, HMSSimulcastLayer.HIGH]);
+  });
+
+  /**
+   * A failing request must not swallow the one that follows it, and must not reject out of
+   * setEnabled - updateSinks discards the promise, so nothing downstream would catch it.
+   */
+  it('still sends the later request when the earlier one fails', async () => {
+    await handlersOf(manager).handleIntersection(entry(true));
+    await settle();
+    sent.length = 0;
+    send.mockImplementationOnce(({ params }) => {
+      sent.push(params.max_spatial_layer);
+      return Promise.reject(new Error('No response from SFU for prefer-video-track-state'));
+    });
+
+    const muted = track.setEnabled(false);
+    await tick();
+    const unmuted = track.setEnabled(true);
+    await settle();
+
+    await expect(Promise.all([muted, unmuted])).resolves.toBeDefined();
+    expect(sent).toEqual([HMSSimulcastLayer.NONE, HMSSimulcastLayer.HIGH]);
+    expect(videoElement.srcObject).not.toBeNull();
+  });
+});


### PR DESCRIPTION
#3737 added a timeout to the data-channel response wait, turning a silent infinite hang into a thrown error. That error escapes as an unhandled rejection wherever a layer request comes from code nobody awaits — `updateSinks` (every remote video mute/unmute), `removeVideoElement`, and the resize/intersection observer handlers. Those call sites now catch and log; `addSink` and `setPreferredLayer` still reject, so `attachVideo` with `autoManageVideo: false` and direct API callers keep seeing failures. Attaching the sink no longer depends on the layer request succeeding, so a failed request can't leave a blank video tile.

`waitFor('open')` was the other unbounded wait: a channel that never opens — closed, or replaced by a new `HMSSubscribeConnection` owning the next one — hung the caller for the rest of the session, and no catch helps because a hang never rejects. It is now bounded and re-checked per retry attempt, so a channel that opens after the first attempt gave up still gets the request through. A stale error response from an earlier attempt is no longer returned as success.

Scrolling a tile in and straight back out used to leave the SFU on high. The add suspends on `selectMaxLayer` before it attaches a sink, so the remove behind it finds no sink and a layer still on none, sends nothing, and the stale add then resumes and asks for high — the SFU keeps streaming a tile nothing renders. Each intersection entry is now stamped per element, and an add whose entry has been superseded drops out.

Failures log at error rather than warn: `HMSLogger` drops warn once an app calls `setLogLevel(ERROR)`, which would have made the catch quieter than the unhandled rejection it replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
