### PR TITLE
fix(store): keep a peer silenced with setVolume(0) across their mute/unmute

### DIFF
--- a/packages/hms-video-store/src/media/tracks/HMSAudioTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSAudioTrack.ts
@@ -8,6 +8,11 @@ export class HMSAudioTrack extends HMSTrack {
   readonly type: HMSTrackType = HMSTrackType.AUDIO;
   private audioElement: HTMLAudioElement | null = null;
   private outputDevice?: MediaDeviceInfo;
+  /**
+   * Last volume asked for, kept off the audio element so it survives the element being torn down
+   * and rebuilt. Only 0 vs non-zero is acted on - it decides whether audio stays unsubscribed.
+   */
+  private requestedVolume = 100;
 
   constructor(stream: HMSMediaStream, track: MediaStreamTrack, source?: string) {
     super(stream, track, source as HMSTrackSource);
@@ -25,11 +30,20 @@ export class HMSAudioTrack extends HMSTrack {
     if (value < 0 || value > 100) {
       throw Error('Please pass a valid number between 0-100');
     }
+    this.requestedVolume = value;
     // Don't subscribe to audio when volume is 0
     await this.subscribeToAudio(value === 0 ? false : this.enabled);
     if (this.audioElement) {
       this.audioElement.volume = value / 100;
     }
+  }
+
+  /**
+   * setVolume(0) silences the peer by unsubscribing, so anything that resubscribes has to check
+   * this first or it hands back audio the user asked not to hear.
+   */
+  protected isSilenced() {
+    return this.requestedVolume === 0;
   }
 
   setAudioElement(element: HTMLAudioElement | null) {

--- a/packages/hms-video-store/src/media/tracks/HMSRemoteAudioTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSRemoteAudioTrack.ts
@@ -6,6 +6,7 @@ export class HMSRemoteAudioTrack extends HMSAudioTrack {
       return;
     }
     await super.setEnabled(value);
-    await this.subscribeToAudio(value);
+    // the peer unmuting must not resubscribe audio the user silenced with setVolume(0)
+    await this.subscribeToAudio(value && !this.isSilenced());
   }
 }

--- a/packages/hms-video-store/src/media/tracks/remoteAudioSilenced.test.ts
+++ b/packages/hms-video-store/src/media/tracks/remoteAudioSilenced.test.ts
@@ -1,0 +1,74 @@
+import HMSSubscribeConnection from '../../connection/subscribe/subscribeConnection';
+import { HMSRemoteStream } from '../streams';
+import { HMSRemoteAudioTrack } from '../tracks';
+
+/**
+ * setVolume(0) is how "mute for you" silences a peer - it unsubscribes from their audio rather
+ * than only turning the element down. The peer muting and unmuting their own mic runs setEnabled,
+ * which resubscribes, so without a check there the peer comes back audible while the app still
+ * shows them silenced.
+ */
+describe('HMSRemoteAudioTrack silenced with setVolume(0)', () => {
+  let track: HMSRemoteAudioTrack;
+  let stream: HMSRemoteStream;
+  let audioElement: HTMLAudioElement;
+
+  beforeEach(() => {
+    audioElement = document.createElement('audio');
+    const connection = {
+      sendOverApiDataChannelWithResponse: jest.fn().mockResolvedValue({}),
+    } as unknown as HMSSubscribeConnection;
+    stream = new HMSRemoteStream({ id: 'stream-1' } as MediaStream, connection);
+    const nativeTrack = {
+      id: 'track-1',
+      kind: 'audio',
+      enabled: true,
+      addEventListener: jest.fn(),
+    } as unknown as MediaStreamTrack;
+    track = new HMSRemoteAudioTrack(stream, nativeTrack, 'regular');
+    track.setAudioElement(audioElement);
+  });
+
+  /** The reported bug: silenced, peer toggles their mic, audio is back. */
+  it('stays unsubscribed when the peer mutes and unmutes', async () => {
+    await track.setVolume(0);
+    expect(stream.isAudioSubscribed()).toBe(false);
+
+    await track.setEnabled(false);
+    await track.setEnabled(true);
+
+    expect(stream.isAudioSubscribed()).toBe(false);
+  });
+
+  /** A peer who was never silenced has to come back audible, otherwise unmute is broken. */
+  it('resubscribes when the peer unmutes and was not silenced', async () => {
+    await track.setVolume(50);
+
+    await track.setEnabled(false);
+    await track.setEnabled(true);
+
+    expect(stream.isAudioSubscribed()).toBe(true);
+  });
+
+  /** Raising the volume again clears it - the next unmute has to be audible. */
+  it('resubscribes once the volume is turned back up', async () => {
+    await track.setVolume(0);
+    await track.setVolume(100);
+    expect(stream.isAudioSubscribed()).toBe(true);
+
+    await track.setEnabled(false);
+    await track.setEnabled(true);
+
+    expect(stream.isAudioSubscribed()).toBe(true);
+  });
+
+  /** Silencing while the peer is already muted is the exact repro path that was reported. */
+  it('stays unsubscribed when silenced while the peer is already muted', async () => {
+    await track.setEnabled(false);
+    await track.setVolume(0);
+
+    await track.setEnabled(true);
+
+    expect(stream.isAudioSubscribed()).toBe(false);
+  });
+});


### PR DESCRIPTION
`setVolume(0)` — what "mute for you" calls — silences a peer by unsubscribing from their audio, not just by turning the element down. `HMSRemoteAudioTrack.setEnabled` then resubscribed unconditionally, so the moment that peer toggled their own mic the audio came back while the app still showed them silenced.

The requested volume is now remembered on the track rather than read back off the audio element, and the resubscribe on unmute is skipped while it is 0. Turning the volume back up clears it, so an ordinary unmute is still audible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)