### PR TITLE
fix(store): keep capture interruptions off screenshare tracks

### DIFF
--- a/packages/hms-video-store/src/media/tracks/HMSLocalAudioTrack.test.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalAudioTrack.test.ts
@@ -49,7 +49,11 @@ const makeNativeTrack = (id: string) =>
     stop: jest.fn(),
   } as unknown as MediaStreamTrack);
 
-const makeLocalAudioTrack = (eventBus: EventBus) => {
+const makeLocalAudioTrack = (
+  eventBus: EventBus,
+  source = 'regular',
+  nativeTrack: MediaStreamTrack = makeNativeTrack('track-1'),
+) => {
   const nativeStream = {
     id: 'stream-1',
     getTracks: () => [],
@@ -59,12 +63,25 @@ const makeLocalAudioTrack = (eventBus: EventBus) => {
   const stream = new HMSLocalStream(nativeStream);
   stream.setConnection({} as unknown as HMSPublishConnection);
   const settings = new HMSAudioTrackSettingsBuilder().build();
-  return new HMSLocalAudioTrack(stream, makeNativeTrack('track-1'), 'regular', eventBus, settings);
+  return new HMSLocalAudioTrack(stream, nativeTrack, source, eventBus, settings);
 };
 
 const setVisibility = (state: 'hidden' | 'visible') => {
   Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
 };
+
+const setMicPermission = (state?: PermissionState) => {
+  Object.defineProperty(navigator, 'permissions', {
+    value: state ? { query: jest.fn(async () => ({ state, onchange: null })) } : undefined,
+    configurable: true,
+  });
+};
+
+const listenedEvents = (nativeTrack: MediaStreamTrack) =>
+  (nativeTrack.addEventListener as jest.Mock).mock.calls.map(([name]) => name);
+
+// navigator.permissions resolves on a task, not a microtask
+const flushPermissionQuery = () => new Promise(resolve => setTimeout(resolve, 0));
 
 describe('HMSLocalAudioTrack interruptions', () => {
   beforeEach(() => {
@@ -323,5 +340,52 @@ describe('HMSLocalAudioTrack interruptions', () => {
     await track.handleTrackUnmute();
 
     expect(interruptions.map(i => i.started)).toEqual([true]);
+  });
+});
+
+/**
+ * The same wiring as the video track, and the same defect for the same reason - a screenshare is
+ * not a capture device this SDK owns, so a mute published for it never gets taken back. LIV-646.
+ */
+describe('HMSLocalAudioTrack screenshare', () => {
+  afterEach(() => setMicPermission(undefined));
+
+  it('does not listen for native mute and unmute on a screenshare audio track', () => {
+    const nativeTrack = makeNativeTrack('track-1');
+    makeLocalAudioTrack(new EventBus(), 'screen', nativeTrack);
+
+    expect(listenedEvents(nativeTrack)).not.toContain('mute');
+    expect(listenedEvents(nativeTrack)).not.toContain('unmute');
+  });
+
+  it('listens for native mute and unmute on a mic track', () => {
+    const nativeTrack = makeNativeTrack('track-1');
+    makeLocalAudioTrack(new EventBus(), 'regular', nativeTrack);
+
+    expect(listenedEvents(nativeTrack)).toEqual(expect.arrayContaining(['mute', 'unmute']));
+  });
+
+  it('does not mute screenshare audio when the microphone permission is denied', async () => {
+    setMicPermission('denied');
+    const eventBus = new EventBus();
+    const enabledUpdates: boolean[] = [];
+    eventBus.localAudioEnabled.subscribe(({ enabled }) => enabledUpdates.push(enabled));
+
+    makeLocalAudioTrack(eventBus, 'screen');
+    await flushPermissionQuery();
+
+    expect(enabledUpdates).toEqual([]);
+  });
+
+  it('mutes the mic when the microphone permission is denied', async () => {
+    setMicPermission('denied');
+    const eventBus = new EventBus();
+    const enabledUpdates: boolean[] = [];
+    eventBus.localAudioEnabled.subscribe(({ enabled }) => enabledUpdates.push(enabled));
+
+    makeLocalAudioTrack(eventBus, 'regular');
+    await flushPermissionQuery();
+
+    expect(enabledUpdates).toEqual([false]);
   });
 });

--- a/packages/hms-video-store/src/media/tracks/HMSLocalAudioTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalAudioTrack.ts
@@ -452,6 +452,10 @@ export class HMSLocalAudioTrack extends HMSAudioTrack {
   }
 
   private addTrackEventListeners(track: MediaStreamTrack) {
+    // see the same guard on HMSLocalVideoTrack - screen capture mutes without pairing an unmute
+    if (this.source === 'screen') {
+      return;
+    }
     track.addEventListener('mute', this.handleTrackMute);
     track.addEventListener('unmute', this.handleTrackUnmute);
   }
@@ -461,7 +465,11 @@ export class HMSLocalAudioTrack extends HMSAudioTrack {
     track.removeEventListener('unmute', this.handleTrackUnmute);
   }
 
+  /** only the mic track is fed by the microphone permission, see the same guard on the video track */
   private trackPermissions = () => {
+    if (this.source !== 'regular') {
+      return;
+    }
     listenToPermissionChange('microphone', (state: PermissionState) => {
       this.permissionState = state;
       this.eventBus.analytics.publish(AnalyticsEventFactory.permissionChange(this.type, state));

--- a/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.test.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.test.ts
@@ -34,7 +34,11 @@ const makeNativeTrack = (id: string) =>
     stop: jest.fn(),
   } as unknown as MediaStreamTrack);
 
-const makeLocalVideoTrack = (eventBus: EventBus = new EventBus()) => {
+const makeLocalVideoTrack = (
+  eventBus: EventBus = new EventBus(),
+  source = 'regular',
+  nativeTrack: MediaStreamTrack = makeNativeTrack(trackId),
+) => {
   const nativeStream = {
     id: streamId,
     getTracks: () => [],
@@ -44,12 +48,25 @@ const makeLocalVideoTrack = (eventBus: EventBus = new EventBus()) => {
   const stream = new HMSLocalStream(nativeStream);
   stream.setConnection({} as unknown as HMSPublishConnection);
   const settings = new HMSVideoTrackSettingsBuilder().build();
-  return new HMSLocalVideoTrack(stream, makeNativeTrack(trackId), 'regular', eventBus, settings);
+  return new HMSLocalVideoTrack(stream, nativeTrack, source, eventBus, settings);
 };
 
 const setVisibility = (state: 'hidden' | 'visible') => {
   Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
 };
+
+const setCameraPermission = (state?: PermissionState) => {
+  Object.defineProperty(navigator, 'permissions', {
+    value: state ? { query: jest.fn(async () => ({ state, onchange: null })) } : undefined,
+    configurable: true,
+  });
+};
+
+const listenedEvents = (nativeTrack: MediaStreamTrack) =>
+  (nativeTrack.addEventListener as jest.Mock).mock.calls.map(([name]) => name);
+
+// navigator.permissions resolves on a task, not a microtask
+const flushPermissionQuery = () => new Promise(resolve => setTimeout(resolve, 0));
 
 // jsdom has no canvas capture, and turning the camera off replaces the track with a blank one
 beforeAll(() => {
@@ -243,6 +260,54 @@ describe('HMSLocalVideoTrack interruptions', () => {
 
     expect(getVideoTrackMock).not.toHaveBeenCalled();
     expect(interruptions).toEqual([]);
+  });
+});
+
+/**
+ * Interruption handling belongs to the camera. A screenshare is not a capture device this SDK owns,
+ * and a mute published for it is never taken back - the capture keeps running, so the sharer sees
+ * their own share while every remote peer renders a blank tile until the share ends. LIV-646.
+ */
+describe('HMSLocalVideoTrack screenshare', () => {
+  afterEach(() => setCameraPermission(undefined));
+
+  it('does not listen for native mute and unmute on a screenshare track', () => {
+    const nativeTrack = makeNativeTrack(trackId);
+    makeLocalVideoTrack(new EventBus(), 'screen', nativeTrack);
+
+    expect(listenedEvents(nativeTrack)).not.toContain('mute');
+    expect(listenedEvents(nativeTrack)).not.toContain('unmute');
+  });
+
+  it('listens for native mute and unmute on a camera track', () => {
+    const nativeTrack = makeNativeTrack(trackId);
+    makeLocalVideoTrack(new EventBus(), 'regular', nativeTrack);
+
+    expect(listenedEvents(nativeTrack)).toEqual(expect.arrayContaining(['mute', 'unmute']));
+  });
+
+  it('does not mute a screenshare when the camera permission is denied', async () => {
+    setCameraPermission('denied');
+    const eventBus = new EventBus();
+    const enabledUpdates: boolean[] = [];
+    eventBus.localVideoEnabled.subscribe(({ enabled }) => enabledUpdates.push(enabled));
+
+    makeLocalVideoTrack(eventBus, 'screen');
+    await flushPermissionQuery();
+
+    expect(enabledUpdates).toEqual([]);
+  });
+
+  it('mutes the camera when the camera permission is denied', async () => {
+    setCameraPermission('denied');
+    const eventBus = new EventBus();
+    const enabledUpdates: boolean[] = [];
+    eventBus.localVideoEnabled.subscribe(({ enabled }) => enabledUpdates.push(enabled));
+
+    makeLocalVideoTrack(eventBus, 'regular');
+    await flushPermissionQuery();
+
+    expect(enabledUpdates).toEqual([false]);
   });
 });
 

--- a/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSLocalVideoTrack.ts
@@ -589,6 +589,16 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
   };
 
   private addTrackEventListeners(track: MediaStreamTrack) {
+    /**
+     * A native mute means the capture device was taken away, and publishing it so remote peers stop
+     * rendering is right for a camera, which comes back with an unmute. Chromium also raises mute on
+     * a screen-capture track whenever the shared surface stops producing frames, with no unmute to
+     * pair with it - the share would stay muted for everyone else while the sharer, whose capture
+     * never stopped, keeps seeing it.
+     */
+    if (this.source === 'screen') {
+      return;
+    }
     track.addEventListener('mute', this.handleTrackMute);
     track.addEventListener('unmute', this.handleTrackUnmuteNatively);
   }
@@ -598,7 +608,15 @@ export class HMSLocalVideoTrack extends HMSVideoTrack {
     track.removeEventListener('unmute', this.handleTrackUnmuteNatively);
   }
 
+  /**
+   * Only the camera track is fed by the camera permission. The query resolves with the current
+   * state, so a screenshare started by someone who had blocked the camera used to publish
+   * mute=true for the share the moment its track was built, and nothing ever took that back.
+   */
   private trackPermissions = () => {
+    if (this.source !== 'regular') {
+      return;
+    }
     listenToPermissionChange('camera', (state: PermissionState) => {
       this.eventBus.analytics.publish(AnalyticsEventFactory.permissionChange(this.type, state));
       if (state === 'denied') {


### PR DESCRIPTION
Camera and microphone permission changes were wired to every local track, screenshare included. The permission query resolves with the current state, so a sharer who had blocked their camera published `mute: true` for the screen track the moment it was built and nothing ever took it back — capture kept running, so the sharer saw their own share while remote peers rendered a blank tile. Native `mute` on a screen-capture track, which Chromium raises without a paired `unmute`, ends up in the same place.

Both are now scoped to the camera and mic tracks they describe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)