### PR TITLE
fix(store): report subscribe request failures correctly

### DIFF
--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
@@ -23,25 +23,37 @@ describe('HMSSubscribeConnection api data channel', () => {
 
   beforeEach(() => {
     sent = [];
-    window.RTCPeerConnection = jest.fn().mockImplementation(() => ({
-      close: jest.fn(),
-      getSenders: () => [],
-    })) as unknown as typeof RTCPeerConnection;
+    window.RTCPeerConnection = jest
+      .fn()
+      .mockImplementation(() => ({ close: jest.fn() })) as unknown as typeof RTCPeerConnection;
     const signal = { trickle: jest.fn() } as unknown as JsonRpcSignal;
     const observer = { onApiChannelMessage: jest.fn() } as unknown as ISubscribeConnectionObserver;
     connection = new HMSSubscribeConnection(signal, {}, () => false, observer);
 
+    let readyState = 'open';
     const nativeChannel = {
       label: API_DATA_CHANNEL,
-      readyState: 'open',
-      send: (message: string) => sent.push(message),
-      close: jest.fn(),
+      get readyState() {
+        return readyState;
+      },
+      send: (message: string) => {
+        if (readyState !== 'open') {
+          throw Error('InvalidStateError: channel is not open');
+        }
+        sent.push(message);
+      },
+      close: jest.fn(() => {
+        readyState = 'closed';
+      }),
     } as unknown as RTCDataChannel;
     connection.nativeConnection.ondatachannel?.({ channel: nativeChannel } as RTCDataChannelEvent);
   });
 
-  // a test that throws before its inline useRealTimers() would leak fake timers into the next one
   afterEach(() => {
+    // settles anything still parked, so a discarded promise cannot reject minutes later attributed
+    // to whatever suite is running by then
+    connection.close();
+    // a test that throws before its inline useRealTimers() would leak fake timers into the next one
     jest.useRealTimers();
   });
 
@@ -256,9 +268,10 @@ describe('HMSSubscribeConnection api data channel', () => {
     await jest.advanceTimersByTimeAsync(100);
 
     expect(settled).toBe(true);
-    // rejects rather than resolving: a caller that reads a torn-down connection as success keeps
-    // believing the SFU applied state it never received
-    await expect(promise).resolves.toBeInstanceOf(Error);
+    // dropped, not rejected: a leave is not a failure, and nothing survives close() to be wrong
+    // about - throwing here wrote one error per in-flight track on every normal leave
+    await expect(promise).resolves.not.toBeInstanceOf(Error);
+    await expect(promise).resolves.not.toHaveProperty('error');
   }, 10_000);
 
   /** the backoff before an attempt that will never happen only delays the throw */
@@ -296,11 +309,15 @@ describe('HMSSubscribeConnection api data channel', () => {
       params: { max_spatial_layer: 'high', track_id: 'track-1' },
     });
     await Promise.resolve();
-    // a newer request for the same track takes the claim while the first reply is in flight
-    connection.sendOverApiDataChannelWithResponse({
-      method: 'prefer-video-track-state',
-      params: { max_spatial_layer: 'low', track_id: 'track-1' },
-    });
+    // a newer request for the same track takes the claim while the first reply is in flight.
+    // Nothing answers it and this test runs on real timers, so its rejection needs a handler or it
+    // lands ~30s later attributed to whatever suite is running then.
+    connection
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-video-track-state',
+        params: { max_spatial_layer: 'low', track_id: 'track-1' },
+      })
+      .catch(() => undefined);
     await Promise.resolve();
     emitReply(sent[0], { result: { track_id: 'track-1' } });
 
@@ -331,9 +348,13 @@ describe('HMSSubscribeConnection api data channel', () => {
     connection.close();
     await jest.advanceTimersByTimeAsync(100);
 
-    await expect(stale).resolves.not.toBeInstanceOf(Error);
-    await expect(stale).resolves.not.toHaveProperty('error');
-    await expect(latest).resolves.toBeInstanceOf(Error);
+    // both drop: one because it was superseded, the other because close() is the same category.
+    // Asserting on `latest` too rather than merely awaiting it - otherwise it reads as though it
+    // is only there to keep a rejection handled.
+    for (const settled of [stale, latest]) {
+      await expect(settled).resolves.not.toBeInstanceOf(Error);
+      await expect(settled).resolves.not.toHaveProperty('error');
+    }
   }, 10_000);
 
   /**
@@ -427,7 +448,7 @@ describe('HMSSubscribeConnection api data channel', () => {
     await jest.advanceTimersByTimeAsync(100);
 
     expect(settled).toBe(true);
-    await expect(promise).resolves.toBeInstanceOf(Error);
+    await expect(promise).resolves.not.toHaveProperty('error');
   }, 10_000);
 
   /**
@@ -479,7 +500,7 @@ describe('HMSSubscribeConnection api data channel', () => {
     await jest.advanceTimersByTimeAsync(100);
 
     expect(settled).toBe(true);
-    await expect(promise).resolves.toBeInstanceOf(Error);
+    await expect(promise).resolves.not.toHaveProperty('error');
   }, 10_000);
 
   /** a channel that opens after the first attempt gave up should still get the request through */

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
@@ -158,7 +158,7 @@ describe('HMSSubscribeConnection api data channel', () => {
     await jest.advanceTimersByTimeAsync(10);
 
     expect(sent).toHaveLength(3);
-    await expect(promise).resolves.toBeInstanceOf(Error);
+    await expect(promise).resolves.toMatchObject({ message: expect.stringContaining('code=500') });
   }, 10_000);
 
   /**
@@ -332,6 +332,7 @@ describe('HMSSubscribeConnection api data channel', () => {
     await jest.advanceTimersByTimeAsync(100);
 
     await expect(stale).resolves.not.toBeInstanceOf(Error);
+    await expect(stale).resolves.not.toHaveProperty('error');
     await expect(latest).resolves.toBeInstanceOf(Error);
   }, 10_000);
 
@@ -368,8 +369,117 @@ describe('HMSSubscribeConnection api data channel', () => {
     emitReply(sent[2], { error: { code: 500, message: 'internal' } });
     await jest.advanceTimersByTimeAsync(120_000);
 
+    // both halves are needed to discriminate: main resolved `{ id, error }` (not an Error, so the
+    // class check alone passes), and a regression that throws yields an Error (which has no
+    // `error` property, so the payload check alone passes)
     await expect(stale).resolves.not.toBeInstanceOf(Error);
+    await expect(stale).resolves.not.toHaveProperty('error');
     await latest;
+  }, 10_000);
+
+  /**
+   * 404 is "the track is already gone" - nothing for the caller to act on, so it resolves rather
+   * than joining the throwing paths. That is only true because the loop returns early; falling
+   * through would now hit the error throw below it.
+   */
+  it('resolves rather than throwing when the SFU says the track is gone', async () => {
+    const promise = connection.sendOverApiDataChannelWithResponse({
+      method: 'prefer-video-track-state',
+      params: { max_spatial_layer: 'high', track_id: 'track-1' },
+    });
+    await Promise.resolve();
+    emitReply(sent[0], { error: { code: 404, message: 'track not found' } });
+
+    await expect(promise).resolves.toMatchObject({ error: { code: 404 } });
+    // and it does not burn the retry budget on a track that no longer exists
+    expect(sent).toHaveLength(1);
+  });
+
+  /**
+   * The open wait is the one close() has to interrupt on a leave or SFU migration - a request
+   * parked there has no channel to answer it, so nothing else will ever settle it.
+   */
+  it('settles a request parked on the channel-open wait when the connection is closed', async () => {
+    const observer = { onApiChannelMessage: jest.fn() } as unknown as ISubscribeConnectionObserver;
+    const neverOpen = new HMSSubscribeConnection(
+      { trickle: jest.fn() } as unknown as JsonRpcSignal,
+      {},
+      () => false,
+      observer,
+    );
+    jest.useFakeTimers();
+    let settled = false;
+    const promise = neverOpen
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-audio-track-state',
+        params: { subscribed: true, track_id: 'track-1' },
+      })
+      .catch((error: Error) => error)
+      .then(value => {
+        settled = true;
+        return value;
+      });
+
+    await jest.advanceTimersByTimeAsync(100);
+    expect(settled).toBe(false);
+
+    neverOpen.close();
+    await jest.advanceTimersByTimeAsync(100);
+
+    expect(settled).toBe(true);
+    await expect(promise).resolves.toBeInstanceOf(Error);
+  }, 10_000);
+
+  /**
+   * Racing the wait is not the same as ending it: without the cancel, eventemitter2 keeps each
+   * listener subscribed until its own timeout, on an emitter capped at 60.
+   */
+  it('leaves no listeners behind on the emitter after close', async () => {
+    jest.useFakeTimers();
+    const emitter = (connection as unknown as { eventEmitter: { listenerCount: (e: string) => number } }).eventEmitter;
+    const pending = [1, 2, 3].map(n =>
+      connection
+        .sendOverApiDataChannelWithResponse({
+          method: 'prefer-audio-track-state',
+          params: { subscribed: true, track_id: `track-${n}` },
+        })
+        .catch((error: Error) => error),
+    );
+    await jest.advanceTimersByTimeAsync(10);
+    expect(emitter.listenerCount('message')).toBeGreaterThan(0);
+
+    connection.close();
+    await jest.advanceTimersByTimeAsync(100);
+
+    expect(emitter.listenerCount('message')).toBe(0);
+    await Promise.all(pending);
+  }, 10_000);
+
+  /**
+   * close() drains the aborts, so a wait parked after it would have nothing left to settle it -
+   * the guard lives in abortOnClose rather than at the loop top so every entry is covered.
+   */
+  it('settles immediately for a request started after close', async () => {
+    jest.useFakeTimers();
+    connection.close();
+
+    let settled = false;
+    const promise = connection
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-audio-track-state',
+        params: { subscribed: true, track_id: 'track-1' },
+      })
+      .catch((error: Error) => error)
+      .then(value => {
+        settled = true;
+        return value;
+      });
+
+    // well inside RESPONSE_TIMEOUT - it must not wait one out
+    await jest.advanceTimersByTimeAsync(100);
+
+    expect(settled).toBe(true);
+    await expect(promise).resolves.toBeInstanceOf(Error);
   }, 10_000);
 
   /** a channel that opens after the first attempt gave up should still get the request through */

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
@@ -287,8 +287,8 @@ describe('HMSSubscribeConnection api data channel', () => {
 
   /**
    * A reply the SFU actually sent is the outcome, whatever happened to the claim while it was in
-   * flight. Callers read the response - requestLayer hands it back to addSink's on-demand branch -
-   * so discarding a successful one reports a request the SFU applied as dropped.
+   * flight. Nothing in the SDK reads the resolved value today, so this is about not lying in the
+   * log and not leaving `PreferLayerResponse` a shape whose `result` silently disappears.
    */
   it('returns a response that arrived even if a newer request claimed the state meanwhile', async () => {
     const first = connection.sendOverApiDataChannelWithResponse({

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
@@ -6,7 +6,7 @@ import { API_DATA_CHANNEL } from '../../utils/constants';
 // the retry backoff sleeps on a worker timer, which fake timers do not advance
 jest.mock('../../utils/timer-utils', () => ({
   ...jest.requireActual('../../utils/timer-utils'),
-  workerSleep: () => Promise.resolve(),
+  workerSleep: jest.fn(() => Promise.resolve()),
 }));
 
 interface WithEventEmitter {
@@ -23,7 +23,10 @@ describe('HMSSubscribeConnection api data channel', () => {
 
   beforeEach(() => {
     sent = [];
-    window.RTCPeerConnection = jest.fn().mockImplementation(() => ({})) as unknown as typeof RTCPeerConnection;
+    window.RTCPeerConnection = jest.fn().mockImplementation(() => ({
+      close: jest.fn(),
+      getSenders: () => [],
+    })) as unknown as typeof RTCPeerConnection;
     const signal = { trickle: jest.fn() } as unknown as JsonRpcSignal;
     const observer = { onApiChannelMessage: jest.fn() } as unknown as ISubscribeConnectionObserver;
     connection = new HMSSubscribeConnection(signal, {}, () => false, observer);
@@ -32,8 +35,14 @@ describe('HMSSubscribeConnection api data channel', () => {
       label: API_DATA_CHANNEL,
       readyState: 'open',
       send: (message: string) => sent.push(message),
+      close: jest.fn(),
     } as unknown as RTCDataChannel;
     connection.nativeConnection.ondatachannel?.({ channel: nativeChannel } as RTCDataChannelEvent);
+  });
+
+  // a test that throws before its inline useRealTimers() would leak fake timers into the next one
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   /** the emitter is private; the data channel's onMessage feeds it exactly like this */
@@ -125,6 +134,242 @@ describe('HMSSubscribeConnection api data channel', () => {
 
     expect(result).toBeInstanceOf(Error);
     jest.useRealTimers();
+  }, 10_000);
+
+  /**
+   * The retry loop exits on the last attempt without re-examining `response`, so an error that was
+   * only retryable-until-attempts-ran-out is handed back as the resolved value. No caller inspects
+   * `error` on a resolved response, so a track the SFU refused reads as a track it applied.
+   */
+  it('throws rather than returning a retryable error that arrived on the final attempt', async () => {
+    jest.useFakeTimers();
+    const promise = connection
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-audio-track-state',
+        params: { subscribed: true, track_id: 'track-1' },
+      })
+      .catch((error: Error) => error);
+
+    // every attempt gets the same retryable error, including the last one
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await jest.advanceTimersByTimeAsync(10);
+      emitReply(sent[attempt], { error: { code: 500, message: 'internal' } });
+    }
+    await jest.advanceTimersByTimeAsync(10);
+
+    expect(sent).toHaveLength(3);
+    await expect(promise).resolves.toBeInstanceOf(Error);
+  }, 10_000);
+
+  /**
+   * `error.code / 100 === 5` is exact division, so it is true only for 500 - a 503 from an SFU
+   * restarting is classified non-retryable and throws on the first attempt with no retry at all.
+   */
+  it('retries a 503 the same way it retries a 500', async () => {
+    jest.useFakeTimers();
+    const promise = connection.sendOverApiDataChannelWithResponse({
+      method: 'prefer-audio-track-state',
+      params: { subscribed: true, track_id: 'track-1' },
+    });
+
+    await jest.advanceTimersByTimeAsync(10);
+    emitReply(sent[0], { error: { code: 503, message: 'service unavailable' } });
+    await jest.advanceTimersByTimeAsync(10);
+
+    expect(sent).toHaveLength(2);
+    respondTo(sent[1]);
+    await expect(promise).resolves.toMatchObject({ result: { track_id: 'track-1' } });
+  }, 10_000);
+
+  /**
+   * The claim is checked before the open wait but not after it. A request that lost the claim while
+   * parked still reaches `send`, putting desired state the caller has moved on from on the wire -
+   * for `prefer-audio-track-state` that is an audible unsubscribe the user never asked for.
+   */
+  it('does not send a request that was superseded while waiting for the channel to open', async () => {
+    const observer = { onApiChannelMessage: jest.fn() } as unknown as ISubscribeConnectionObserver;
+    const pending = new HMSSubscribeConnection(
+      { trickle: jest.fn() } as unknown as JsonRpcSignal,
+      {},
+      () => false,
+      observer,
+    );
+    const pendingSent: string[] = [];
+    const nativeChannel = {
+      label: API_DATA_CHANNEL,
+      readyState: 'open',
+      send: (message: string) => pendingSent.push(message),
+    } as unknown as RTCDataChannel;
+
+    jest.useFakeTimers();
+    // both park on the closed channel; the second claims the state the first was going to write
+    const stale = pending
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-audio-track-state',
+        params: { subscribed: false, track_id: 'track-1' },
+      })
+      .catch((error: Error) => error);
+    const latest = pending
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-audio-track-state',
+        params: { subscribed: true, track_id: 'track-1' },
+      })
+      .catch((error: Error) => error);
+
+    pending.nativeConnection.ondatachannel?.({ channel: nativeChannel } as RTCDataChannelEvent);
+    nativeChannel.onopen?.(new Event('open'));
+    await jest.advanceTimersByTimeAsync(100);
+
+    expect(pendingSent.map(message => JSON.parse(message).params.subscribed)).toEqual([true]);
+
+    const { id } = JSON.parse(pendingSent[0]) as { id: string };
+    (pending as unknown as WithEventEmitter).eventEmitter.emit(
+      'message',
+      JSON.stringify({ id, jsonrpc: '2.0', result: { track_id: 'track-1' } }),
+    );
+    await Promise.all([stale, latest]);
+  }, 10_000);
+
+  /**
+   * close() shuts the channel but leaves the retry loops running against it, so every pending
+   * request keeps burning its full retry budget on a connection that is gone - on leave or an SFU
+   * migration that is a minute of work per track after nobody is listening.
+   */
+  it('settles pending requests when the connection is closed', async () => {
+    jest.useFakeTimers();
+    let settled = false;
+    const promise = connection
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-audio-track-state',
+        params: { subscribed: true, track_id: 'track-1' },
+      })
+      .catch((error: Error) => error)
+      .then(value => {
+        settled = true;
+        return value;
+      });
+
+    await jest.advanceTimersByTimeAsync(100);
+    expect(settled).toBe(false);
+
+    connection.close();
+    await jest.advanceTimersByTimeAsync(100);
+
+    expect(settled).toBe(true);
+    // rejects rather than resolving: a caller that reads a torn-down connection as success keeps
+    // believing the SFU applied state it never received
+    await expect(promise).resolves.toBeInstanceOf(Error);
+  }, 10_000);
+
+  /** the backoff before an attempt that will never happen only delays the throw */
+  it('does not sleep out a retry backoff after the final attempt', async () => {
+    jest.useFakeTimers();
+    const workerSleep = jest.requireMock('../../utils/timer-utils').workerSleep as jest.Mock;
+    workerSleep.mockClear();
+
+    const promise = connection
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-audio-track-state',
+        params: { subscribed: true, track_id: 'track-1' },
+      })
+      .catch((error: Error) => error);
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await jest.advanceTimersByTimeAsync(10);
+      emitReply(sent[attempt], { error: { code: 500, message: 'internal' } });
+    }
+    await jest.advanceTimersByTimeAsync(10);
+
+    await expect(promise).resolves.toBeInstanceOf(Error);
+    // one backoff between attempt 1->2 and one between 2->3, none after the last
+    expect(workerSleep).toHaveBeenCalledTimes(2);
+  }, 10_000);
+
+  /**
+   * A reply the SFU actually sent is the outcome, whatever happened to the claim while it was in
+   * flight. Callers read the response - requestLayer hands it back to addSink's on-demand branch -
+   * so discarding a successful one reports a request the SFU applied as dropped.
+   */
+  it('returns a response that arrived even if a newer request claimed the state meanwhile', async () => {
+    const first = connection.sendOverApiDataChannelWithResponse({
+      method: 'prefer-video-track-state',
+      params: { max_spatial_layer: 'high', track_id: 'track-1' },
+    });
+    await Promise.resolve();
+    // a newer request for the same track takes the claim while the first reply is in flight
+    connection.sendOverApiDataChannelWithResponse({
+      method: 'prefer-video-track-state',
+      params: { max_spatial_layer: 'low', track_id: 'track-1' },
+    });
+    await Promise.resolve();
+    emitReply(sent[0], { result: { track_id: 'track-1' } });
+
+    await expect(first).resolves.toMatchObject({ result: { track_id: 'track-1' } });
+  });
+
+  /**
+   * Leave and SFU migration both close the connection with superseded requests still parked. Those
+   * are not failures - reporting them as one puts an error in the log on every normal leave.
+   */
+  it('drops a superseded request on close rather than reporting it as a failure', async () => {
+    jest.useFakeTimers();
+    const stale = connection
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-audio-track-state',
+        params: { subscribed: false, track_id: 'track-1' },
+      })
+      .catch((error: Error) => error);
+    await jest.advanceTimersByTimeAsync(10);
+    const latest = connection
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-audio-track-state',
+        params: { subscribed: true, track_id: 'track-1' },
+      })
+      .catch((error: Error) => error);
+    await jest.advanceTimersByTimeAsync(10);
+
+    connection.close();
+    await jest.advanceTimersByTimeAsync(100);
+
+    await expect(stale).resolves.not.toBeInstanceOf(Error);
+    await expect(latest).resolves.toBeInstanceOf(Error);
+  }, 10_000);
+
+  /**
+   * The retryable-error-exhausted exit has to agree with the others: a request the newer one took
+   * over is not a failure, so it drops rather than throwing. Reaching that exit needs the claim to
+   * change hands during the *final* attempt - any earlier and the loop-top check drops it first.
+   */
+  it('drops rather than throwing when a superseded request exhausts its retries on an error', async () => {
+    jest.useFakeTimers();
+    const stale = connection
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-video-track-state',
+        params: { max_spatial_layer: 'high', track_id: 'track-1' },
+      })
+      .catch((error: Error) => error);
+
+    // burn the first two attempts while this request still owns the claim
+    for (let attempt = 0; attempt < 2; attempt++) {
+      await jest.advanceTimersByTimeAsync(10);
+      emitReply(sent[attempt], { error: { code: 500, message: 'internal' } });
+    }
+    await jest.advanceTimersByTimeAsync(10);
+    expect(sent).toHaveLength(3);
+
+    // the third attempt is now in flight; a newer request takes the claim, then the 500 lands
+    const latest = connection
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-video-track-state',
+        params: { max_spatial_layer: 'low', track_id: 'track-1' },
+      })
+      .catch((error: Error) => error);
+    await jest.advanceTimersByTimeAsync(10);
+    emitReply(sent[2], { error: { code: 500, message: 'internal' } });
+    await jest.advanceTimersByTimeAsync(120_000);
+
+    await expect(stale).resolves.not.toBeInstanceOf(Error);
+    await latest;
   }, 10_000);
 
   /** a channel that opens after the first attempt gave up should still get the request through */

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
@@ -1,4 +1,4 @@
-import EventEmitter, { WaitForOptions } from 'eventemitter2';
+import EventEmitter, { CancelablePromise, WaitForOptions } from 'eventemitter2';
 import { v4 as uuid } from 'uuid';
 import ISubscribeConnectionObserver from './ISubscribeConnectionObserver';
 import { HMSRemoteStream, HMSSimulcastLayer } from '../../internal';
@@ -14,9 +14,6 @@ import { PreferAudioLayerParams, PreferLayerResponse, PreferVideoLayerParams } f
 import HMSConnection from '../HMSConnection';
 import HMSDataChannel from '../HMSDataChannel';
 import { HMSConnectionRole } from '../model';
-
-/** eventemitter2's waitFor hands back a promise that can be cancelled; its types do not say so */
-type CancelablePromise<T> = Promise<T> & { cancel?: () => void };
 
 export default class HMSSubscribeConnection extends HMSConnection {
   private readonly TAG = '[HMSSubscribeConnection]';
@@ -40,8 +37,9 @@ export default class HMSSubscribeConnection extends HMSConnection {
   private closed = false;
   /**
    * Rejectors for the waits currently parked on the api data channel. close() fires them so a
-   * leave or an SFU migration does not leave every pending request retrying against a dead channel
-   * for its full budget - RESPONSE_TIMEOUT x MAX_RETRIES per track, long after nobody is listening.
+   * leave or an SFU migration settles every pending request at once, rather than each waiting out
+   * its RESPONSE_TIMEOUT first - the catch below breaks on `closed`, so it is one timeout per
+   * track, but that is still 10s of nothing per tile on every leave.
    */
   private pendingAborts = new Set<(error: Error) => void>();
 
@@ -209,7 +207,7 @@ export default class HMSSubscribeConnection extends HMSConnection {
       // cancel() rejects the wait, and nothing has subscribed to it yet - Promise.race below is
       // what normally does that, and we are not reaching it
       wait.catch(() => undefined);
-      wait.cancel?.();
+      wait.cancel('connection closed');
       throw Error('Subscribe connection closed');
     }
     let abort!: (error: Error) => void;
@@ -222,7 +220,7 @@ export default class HMSSubscribeConnection extends HMSConnection {
       return await Promise.race([wait, aborted]);
     } finally {
       this.pendingAborts.delete(abort);
-      wait.cancel?.();
+      wait.cancel('request settled');
     }
   };
 

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
@@ -317,11 +317,14 @@ export default class HMSSubscribeConnection extends HMSConnection {
     if (response) {
       return response;
     }
-    if (superseded()) {
+    /**
+     * close() is the same category as supersession: not a failure anyone can act on, and nothing
+     * survives it to be wrong about - clearPeerConnections() nulls the connection, and an SFU
+     * migration additionally drops every HMSRemoteStream via removeRemoteTracks(). Throwing here
+     * wrote one error per in-flight track on every normal leave, through the logIfRejected chain.
+     */
+    if (superseded() || this.closed) {
       return dropped();
-    }
-    if (this.closed) {
-      throw Error(`Subscribe connection closed before ${requestId} was answered - ${request}`);
     }
     throw Error(
       `No response from SFU for ${requestId} after ${this.MAX_RETRIES} tries - ${request}`,

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
@@ -15,6 +15,9 @@ import HMSConnection from '../HMSConnection';
 import HMSDataChannel from '../HMSDataChannel';
 import { HMSConnectionRole } from '../model';
 
+/** eventemitter2's waitFor hands back a promise that can be cancelled; its types do not say so */
+type CancelablePromise<T> = Promise<T> & { cancel?: () => void };
+
 export default class HMSSubscribeConnection extends HMSConnection {
   private readonly TAG = '[HMSSubscribeConnection]';
   private readonly remoteStreams = new Map<string, HMSRemoteStream>();
@@ -34,6 +37,13 @@ export default class HMSSubscribeConnection extends HMSConnection {
   private pendingMessageQueue: string[] = [];
   /** `${method}:${track_id}` -> the id of the newest request for it; older ones stop retrying */
   private latestRequestPerState = new Map<string, string>();
+  private closed = false;
+  /**
+   * Rejectors for the waits currently parked on the api data channel. close() fires them so a
+   * leave or an SFU migration does not leave every pending request retrying against a dead channel
+   * for its full budget - RESPONSE_TIMEOUT x MAX_RETRIES per track, long after nobody is listening.
+   */
+  private pendingAborts = new Set<(error: Error) => void>();
 
   private apiChannel?: HMSDataChannel;
   private eventEmitter = new EventEmitter({ maxListeners: 60 });
@@ -181,9 +191,32 @@ export default class HMSSubscribeConnection extends HMSConnection {
   }
 
   close() {
+    this.closed = true;
     super.close();
     this.apiChannel?.close();
+    this.pendingAborts.forEach(abort => abort(Error('Subscribe connection closed')));
+    this.pendingAborts.clear();
   }
+
+  /**
+   * Settles `wait` early if the connection is closed while it is parked on the api data channel.
+   * The wait is cancelled rather than just abandoned: eventemitter2 keeps the listener subscribed
+   * until its own timeout otherwise, and the emitter is capped at 60.
+   */
+  private abortOnClose = async <T>(wait: CancelablePromise<T>): Promise<T> => {
+    let abort!: (error: Error) => void;
+    const aborted = new Promise<never>((_, reject) => {
+      abort = reject;
+    });
+    this.pendingAborts.add(abort);
+    try {
+      // race subscribes to both, so a later rejection from the loser is never unhandled
+      return await Promise.race([wait, aborted]);
+    } finally {
+      this.pendingAborts.delete(abort);
+      wait.cancel?.();
+    }
+  };
 
   private handlePendingApiMessages = () => {
     this.eventEmitter.emit('open', true);
@@ -213,43 +246,76 @@ export default class HMSSubscribeConnection extends HMSConnection {
       if (superseded()) {
         return dropped();
       }
+      if (this.closed) {
+        break;
+      }
       try {
         await this.waitForChannelOpen();
+        // the claim can change hands while parked on the open wait, and a retry replays the bytes
+        // serialised at request time - checking only before the wait still lets stale state out
+        if (superseded()) {
+          return dropped();
+        }
         // send can throw too - the channel may close between the open check and here
         this.apiChannel!.send(request);
         response = await this.waitForResponse(requestId);
       } catch (error) {
         HMSLogger.w(this.TAG, `Attempt failed for ${requestId}`, { request, try: i + 1, error });
+        if (this.closed) {
+          break;
+        }
         continue;
       }
       const error = response.error;
       if (error) {
-        // Don't retry or do anything, track is already removed
+        // Don't retry or do anything, track is already removed - and nothing for the caller to act
+        // on either, so this stays a resolve rather than joining the throwing paths below
         if (error.code === 404) {
           HMSLogger.d(this.TAG, `Track not found ${requestId}`, { request, try: i + 1, error });
-          break;
+          return response;
         }
         HMSLogger.d(this.TAG, `Failed sending ${requestId}`, { request, try: i + 1, error });
-        const shouldRetry = error.code / 100 === 5 || error.code === 429;
+        // exact division is only ever true for 500 - a 502/503/504 from an SFU restarting has to
+        // retry the same way, not throw on the first attempt
+        const shouldRetry = Math.floor(error.code / 100) === 5 || error.code === 429;
         if (!shouldRetry) {
           if (superseded()) {
             return dropped();
           }
           throw Error(`code=${error.code}, message=${error.message}`);
         }
-        const delay = (2 + Math.random() * 2) * 1000;
-        await workerSleep(delay);
+        if (i < this.MAX_RETRIES - 1) {
+          const delay = (2 + Math.random() * 2) * 1000;
+          await workerSleep(delay);
+        }
       } else {
         break;
       }
     }
-    if (!response) {
+    /**
+     * Every exit agrees on one rule: a request the newer one took over is not a failure, and a
+     * response the SFU actually sent is the outcome. So an error is reported only when this request
+     * still owns the state, and a success is returned whatever happened to the claim meanwhile -
+     * discarding it would report a request the SFU applied as dropped.
+     */
+    if (response?.error) {
       if (superseded()) {
         return dropped();
       }
-      throw Error(`No response from SFU for ${requestId} after ${this.MAX_RETRIES} tries - ${request}`);
+      // the loop can run out of attempts still holding a retryable error, and no caller inspects
+      // `error` on a resolved response, so returning it here reads as a request the SFU applied
+      throw Error(`code=${response.error.code}, message=${response.error.message}`);
     }
-    return response;
+    if (response) {
+      return response;
+    }
+    if (superseded()) {
+      return dropped();
+    }
+    if (this.closed) {
+      throw Error(`Subscribe connection closed before ${requestId} was answered - ${request}`);
+    }
+    throw Error(`No response from SFU for ${requestId} after ${this.MAX_RETRIES} tries - ${request}`);
   };
 
   /**
@@ -261,14 +327,20 @@ export default class HMSSubscribeConnection extends HMSConnection {
     if (this.apiChannel?.readyState === 'open') {
       return;
     }
-    await this.eventEmitter.waitFor('open', { timeout: this.RESPONSE_TIMEOUT } as WaitForOptions);
+    await this.abortOnClose(
+      this.eventEmitter.waitFor('open', {
+        timeout: this.RESPONSE_TIMEOUT,
+      } as WaitForOptions) as CancelablePromise<unknown>,
+    );
   };
 
   private waitForResponse = async (requestId: string): Promise<PreferLayerResponse> => {
-    const res = await this.eventEmitter.waitFor('message', {
-      filter: (value: string) => value.includes(requestId),
-      timeout: this.RESPONSE_TIMEOUT,
-    } as WaitForOptions);
+    const res = (await this.abortOnClose(
+      this.eventEmitter.waitFor('message', {
+        filter: (value: string) => value.includes(requestId),
+        timeout: this.RESPONSE_TIMEOUT,
+      } as WaitForOptions) as CancelablePromise<unknown>,
+    )) as unknown[];
     const response = JSON.parse(res[0] as string);
     HMSLogger.d(this.TAG, `response for ${requestId} -`, JSON.stringify(response, null, 2));
     return response;

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
@@ -204,6 +204,14 @@ export default class HMSSubscribeConnection extends HMSConnection {
    * until its own timeout otherwise, and the emitter is capped at 60.
    */
   private abortOnClose = async <T>(wait: CancelablePromise<T>): Promise<T> => {
+    // close() has already drained pendingAborts, so a wait parked after it would never be settled
+    if (this.closed) {
+      // cancel() rejects the wait, and nothing has subscribed to it yet - Promise.race below is
+      // what normally does that, and we are not reaching it
+      wait.catch(() => undefined);
+      wait.cancel?.();
+      throw Error('Subscribe connection closed');
+    }
     let abort!: (error: Error) => void;
     const aborted = new Promise<never>((_, reject) => {
       abort = reject;
@@ -240,14 +248,13 @@ export default class HMSSubscribeConnection extends HMSConnection {
       return { id: requestId } as PreferLayerResponse;
     };
     let response: PreferLayerResponse | undefined;
+    /** the per-attempt detail is a warn, which an app on setLogLevel(ERROR) never sees */
+    let lastAttemptError: Error | undefined;
     for (let i = 0; i < this.MAX_RETRIES; i++) {
       // a previous attempt's error response must not stand in for this attempt's outcome
       response = undefined;
       if (superseded()) {
         return dropped();
-      }
-      if (this.closed) {
-        break;
       }
       try {
         await this.waitForChannelOpen();
@@ -260,6 +267,7 @@ export default class HMSSubscribeConnection extends HMSConnection {
         this.apiChannel!.send(request);
         response = await this.waitForResponse(requestId);
       } catch (error) {
+        lastAttemptError = error as Error;
         HMSLogger.w(this.TAG, `Attempt failed for ${requestId}`, { request, try: i + 1, error });
         if (this.closed) {
           break;
@@ -282,7 +290,7 @@ export default class HMSSubscribeConnection extends HMSConnection {
           if (superseded()) {
             return dropped();
           }
-          throw Error(`code=${error.code}, message=${error.message}`);
+          throw Error(`code=${error.code}, message=${error.message} - ${requestId} not retried`);
         }
         if (i < this.MAX_RETRIES - 1) {
           const delay = (2 + Math.random() * 2) * 1000;
@@ -304,7 +312,9 @@ export default class HMSSubscribeConnection extends HMSConnection {
       }
       // the loop can run out of attempts still holding a retryable error, and no caller inspects
       // `error` on a resolved response, so returning it here reads as a request the SFU applied
-      throw Error(`code=${response.error.code}, message=${response.error.message}`);
+      throw Error(
+        `code=${response.error.code}, message=${response.error.message} - ${requestId} after ${this.MAX_RETRIES} tries`,
+      );
     }
     if (response) {
       return response;
@@ -315,7 +325,12 @@ export default class HMSSubscribeConnection extends HMSConnection {
     if (this.closed) {
       throw Error(`Subscribe connection closed before ${requestId} was answered - ${request}`);
     }
-    throw Error(`No response from SFU for ${requestId} after ${this.MAX_RETRIES} tries - ${request}`);
+    throw Error(
+      `No response from SFU for ${requestId} after ${this.MAX_RETRIES} tries - ${request}`,
+      // a malformed reply lands here too, via JSON.parse in waitForResponse - without the cause,
+      // "no response" is a flatly wrong diagnosis for a reply that did arrive
+      { cause: lastAttemptError },
+    );
   };
 
   /**


### PR DESCRIPTION
**1 of 3.** One file plus its tests. Independent of the other two.

The bounded waits added for the silent-recording fix turned a lost SFU reply from a hang into a rejection. Four things in that path then report the wrong outcome:

- A retryable error arriving on the **final** attempt was returned as the resolved value. No caller inspects `error` on a resolved response, so a request the SFU refused read as one it applied.
- `error.code / 100 === 5` is exact division and only ever matched `500` — a `502`/`503`/`504` from a restarting SFU threw on the first attempt with no retry at all.
- The supersession claim was checked *before* the channel-open wait but not after, so a request replaced while parked still put stale desired state on the wire. For `prefer-audio-track-state` that is an audible unsubscribe nobody asked for.
- `close()` left the retry loops running against a dead channel, and the eventemitter2 waits subscribed until their own timeouts on an emitter capped at 60 listeners. Pending requests now settle at once and cancel their waits — reported as *dropped*, not as failures: a leave is not a failure, and nothing survives `clearPeerConnections()` to act on the state. One caveat: the retry backoff is the one wait `close()` cannot cut short, since `workerSleep` has no cancel.

The retry backoff no longer runs after the final attempt, where it only delayed the throw and could not be cut short by `close()`.

On exit: a response the SFU actually sent is the outcome whatever happened to the claim meanwhile, and a superseded request is reported as dropped rather than as a failure — otherwise every normal leave logs an error for requests the code itself declares are not failures.

## Scope
Deliberately just the retry loop. An earlier version of this PR also reworked `HMSRemoteStream` so that a failed request could not poison the equality guards that suppress no-op requests — 65 lines, three fields and two new gates for it. Review found it introduced more failure modes than it removed (a counter that overshot and permanently re-armed the guard it was bypassing; no ground-truth reset on the audio side). That problem is real and still open, but it needs the desired-vs-confirmed split rather than a bypass bolted onto optimistic state, so it is not in this PR.

## Test plan
17 tests. **10 of them fail against `main`**; the other seven are regression guards for the restructure rather than verified-failing bug tests, and are not counted as such. Every production hunk is mutation-checked. 39 suites / 300 tests pass on this branch alone.

## Compatibility with 0.14.7
No behavioural change on the success path. Everything here is reached only when a subscribe request fails, which in 0.14.7 could not happen — that release had no timeouts and the caller hung instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

