### PR TITLE
fix(store): say why a subscribe request was dropped, and handle setVolume failures in the hooks

### DIFF
--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
@@ -525,7 +525,7 @@ describe('HMSSubscribeConnection api data channel', () => {
     await pending;
 
     const reasons = debug.mock.calls.map(c => String(c[1])).filter(m => m.startsWith('Dropping'));
-    expect(reasons.some(m => m.includes('connection closed'))).toBe(true);
+    expect(reasons.some(m => m.includes('closed'))).toBe(true);
     expect(reasons.some(m => m.includes('superseded'))).toBe(false);
   }, 10_000);
 

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
@@ -2,6 +2,7 @@ import ISubscribeConnectionObserver from './ISubscribeConnectionObserver';
 import HMSSubscribeConnection from './subscribeConnection';
 import JsonRpcSignal from '../../signal/jsonrpc';
 import { API_DATA_CHANNEL } from '../../utils/constants';
+import HMSLogger from '../../utils/logger';
 
 // the retry backoff sleeps on a worker timer, which fake timers do not advance
 jest.mock('../../utils/timer-utils', () => ({
@@ -501,6 +502,31 @@ describe('HMSSubscribeConnection api data channel', () => {
 
     expect(settled).toBe(true);
     await expect(promise).resolves.not.toHaveProperty('error');
+  }, 10_000);
+
+  /**
+   * The SDK runs at VERBOSE by default and beam's chrome logs are how these are diagnosed, so the
+   * reason has to be right: two of dropped()'s call sites fire on close(), which is not
+   * supersession. Saying "superseded" on every leave sends the next reader somewhere wrong.
+   */
+  it('says why a request was dropped', async () => {
+    jest.useFakeTimers();
+    const debug = jest.spyOn(HMSLogger, 'd').mockImplementation(() => undefined);
+    const pending = connection
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-audio-track-state',
+        params: { subscribed: true, track_id: 'track-1' },
+      })
+      .catch((error: Error) => error);
+    await jest.advanceTimersByTimeAsync(10);
+
+    connection.close();
+    await jest.advanceTimersByTimeAsync(100);
+    await pending;
+
+    const reasons = debug.mock.calls.map(c => String(c[1])).filter(m => m.startsWith('Dropping'));
+    expect(reasons.some(m => m.includes('connection closed'))).toBe(true);
+    expect(reasons.some(m => m.includes('superseded'))).toBe(false);
   }, 10_000);
 
   /** a channel that opens after the first attempt gave up should still get the request through */

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
@@ -241,8 +241,8 @@ export default class HMSSubscribeConnection extends HMSConnection {
      * Resolve the way the disableAutoUnsubscribe skip does rather than reporting an error nobody
      * can act on - the newer request owns the outcome. Every exit path has to agree on this.
      */
-    const dropped = () => {
-      HMSLogger.d(this.TAG, `Superseded, dropping ${requestId}`, request);
+    const dropped = (reason: 'superseded' | 'connection closed') => {
+      HMSLogger.d(this.TAG, `Dropping ${requestId} - ${reason}`, request);
       return { id: requestId } as PreferLayerResponse;
     };
     let response: PreferLayerResponse | undefined;
@@ -252,14 +252,14 @@ export default class HMSSubscribeConnection extends HMSConnection {
       // a previous attempt's error response must not stand in for this attempt's outcome
       response = undefined;
       if (superseded()) {
-        return dropped();
+        return dropped('superseded');
       }
       try {
         await this.waitForChannelOpen();
         // the claim can change hands while parked on the open wait, and a retry replays the bytes
         // serialised at request time - checking only before the wait still lets stale state out
         if (superseded()) {
-          return dropped();
+          return dropped('superseded');
         }
         // send can throw too - the channel may close between the open check and here
         this.apiChannel!.send(request);
@@ -286,7 +286,7 @@ export default class HMSSubscribeConnection extends HMSConnection {
         const shouldRetry = Math.floor(error.code / 100) === 5 || error.code === 429;
         if (!shouldRetry) {
           if (superseded()) {
-            return dropped();
+            return dropped('superseded');
           }
           throw Error(`code=${error.code}, message=${error.message} - ${requestId} not retried`);
         }
@@ -306,7 +306,7 @@ export default class HMSSubscribeConnection extends HMSConnection {
      */
     if (response?.error) {
       if (superseded()) {
-        return dropped();
+        return dropped('superseded');
       }
       // the loop can run out of attempts still holding a retryable error, and no caller inspects
       // `error` on a resolved response, so returning it here reads as a request the SFU applied
@@ -324,7 +324,7 @@ export default class HMSSubscribeConnection extends HMSConnection {
      * wrote one error per in-flight track on every normal leave, through the logIfRejected chain.
      */
     if (superseded() || this.closed) {
-      return dropped();
+      return dropped(superseded() ? 'superseded' : 'connection closed');
     }
     throw Error(
       `No response from SFU for ${requestId} after ${this.MAX_RETRIES} tries - ${request}`,

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
@@ -241,8 +241,8 @@ export default class HMSSubscribeConnection extends HMSConnection {
      * Resolve the way the disableAutoUnsubscribe skip does rather than reporting an error nobody
      * can act on - the newer request owns the outcome. Every exit path has to agree on this.
      */
-    const dropped = (reason: 'superseded' | 'connection closed') => {
-      HMSLogger.d(this.TAG, `Dropping ${requestId} - ${reason}`, request);
+    const dropped = () => {
+      HMSLogger.d(this.TAG, `Dropping ${requestId} - ${this.closed ? 'closed' : 'superseded'}`, request);
       return { id: requestId } as PreferLayerResponse;
     };
     let response: PreferLayerResponse | undefined;
@@ -252,14 +252,14 @@ export default class HMSSubscribeConnection extends HMSConnection {
       // a previous attempt's error response must not stand in for this attempt's outcome
       response = undefined;
       if (superseded()) {
-        return dropped('superseded');
+        return dropped();
       }
       try {
         await this.waitForChannelOpen();
         // the claim can change hands while parked on the open wait, and a retry replays the bytes
         // serialised at request time - checking only before the wait still lets stale state out
         if (superseded()) {
-          return dropped('superseded');
+          return dropped();
         }
         // send can throw too - the channel may close between the open check and here
         this.apiChannel!.send(request);
@@ -286,7 +286,7 @@ export default class HMSSubscribeConnection extends HMSConnection {
         const shouldRetry = Math.floor(error.code / 100) === 5 || error.code === 429;
         if (!shouldRetry) {
           if (superseded()) {
-            return dropped('superseded');
+            return dropped();
           }
           throw Error(`code=${error.code}, message=${error.message} - ${requestId} not retried`);
         }
@@ -306,7 +306,7 @@ export default class HMSSubscribeConnection extends HMSConnection {
      */
     if (response?.error) {
       if (superseded()) {
-        return dropped('superseded');
+        return dropped();
       }
       // the loop can run out of attempts still holding a retryable error, and no caller inspects
       // `error` on a resolved response, so returning it here reads as a request the SFU applied
@@ -324,7 +324,7 @@ export default class HMSSubscribeConnection extends HMSConnection {
      * wrote one error per in-flight track on every normal leave, through the logIfRejected chain.
      */
     if (superseded() || this.closed) {
-      return dropped(superseded() ? 'superseded' : 'connection closed');
+      return dropped();
     }
     throw Error(
       `No response from SFU for ${requestId} after ${this.MAX_RETRIES} tries - ${request}`,

--- a/packages/react-sdk/src/hooks/useRemoteAVToggle.ts
+++ b/packages/react-sdk/src/hooks/useRemoteAVToggle.ts
@@ -83,12 +83,19 @@ export const useRemoteAVToggle = (
   }, [actions, handleError, videoTrack]);
 
   const setVolume = useCallback(
-    (volume: number) => {
+    async (volume: number) => {
       if (audioTrack) {
-        actions.setVolume(volume, audioTrack.id);
+        // muting or unmuting a peer for yourself rides the api data channel, so it can reject the
+        // same way toggleAudio can - and unlike the element volume, a failed resubscribe leaves
+        // that peer inaudible with no retry
+        try {
+          await actions.setVolume(volume, audioTrack.id);
+        } catch (err) {
+          handleError(err as Error, 'setVolume');
+        }
       }
     },
-    [actions, audioTrack],
+    [actions, audioTrack, handleError],
   );
 
   return {

--- a/packages/roomkit-react/src/Prebuilt/components/hooks/usePlaylistMusic.js
+++ b/packages/roomkit-react/src/Prebuilt/components/hooks/usePlaylistMusic.js
@@ -26,7 +26,7 @@ export const usePlaylistMusic = () => {
 
   const setVolume = useCallback(
     value => {
-      hmsActions.setVolume(value, track?.id);
+      hmsActions.setVolume(value, track?.id).catch(console.error);
     },
     [hmsActions, track],
   );

--- a/packages/roomkit-react/src/Prebuilt/components/hooks/useScreenshareAudio.js
+++ b/packages/roomkit-react/src/Prebuilt/components/hooks/useScreenshareAudio.js
@@ -13,7 +13,8 @@ export const useScreenshareAudio = () => {
 
   const handleMute = useCallback(() => {
     if (!peer.isLocal) {
-      hmsActions.setVolume(!track.volume ? 100 : 0, track.id);
+      // toggles across 0, so it always reaches the SFU and can reject
+      hmsActions.setVolume(!track.volume ? 100 : 0, track.id).catch(console.error);
     } else {
       hmsActions.setEnabledTrack(track.id, !track.enabled).catch(console.error);
     }


### PR DESCRIPTION
`dropped()` hardcoded `Superseded, dropping` at all six call sites, but two of them fire on `close()` — a request dropped because the connection went away is not superseded. The SDK defaults to `VERBOSE`, so as written every leave and every SFU migration claims supersession in the logs.

`useRemoteAVToggle.setVolume` was the only one of the hook's three actions not using the `handleError` it already takes — `toggleAudio` and `toggleVideo` both do. Muting a peer for yourself crosses the subscribe state, so it rides the api data channel and can reject the same way they can. `usePlaylistMusic` and `useScreenshareAudio` get the same treatment.