### PR TITLE
fix(prebuilt): hide first-to-join chip when empty

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
@@ -45,7 +45,8 @@ import { APP_DATA, UI_SETTINGS } from '../../common/constants';
 
 const getParticipantChipContent = (peerCount = 0) => {
   if (peerCount === 0) {
-    return 'You are the first to join';
+    // Hide on empty rooms: "You are the first to join" is read as already in-call.
+    return '';
   }
   const formattedNum = getFormattedCount(peerCount);
   return `${formattedNum} other${parseInt(formattedNum) === 1 ? '' : 's'} in the session`;


### PR DESCRIPTION
Honeit candidates read "You are the first to join" as already in the call and skip Join Now. Chip already hides empty content.

# Description

_Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots._

_List which issues are fixed by this PR. You must list at least one issue._

<
