### PR TITLE
fix: whiteboard token fetch for duplicate tabs and stream teardown

### DIFF
--- a/packages/hms-video-store/src/interfaces/session-store/whiteboard.ts
+++ b/packages/hms-video-store/src/interfaces/session-store/whiteboard.ts
@@ -32,4 +32,10 @@ export interface HMSWhiteboard {
    * @internal
    */
   token?: string;
+  /**
+   * whether this client is the one that opened the whiteboard. `owner` is a customerUserId, which
+   * every tab of the same user shares, so it cannot tell this client apart from its duplicates.
+   * @internal
+   */
+  isLocalOwner?: boolean;
 }

--- a/packages/hms-video-store/src/notification-manager/managers/WhiteboardManager.test.ts
+++ b/packages/hms-video-store/src/notification-manager/managers/WhiteboardManager.test.ts
@@ -32,7 +32,7 @@ const buildManager = (localCustomerUserId: string, getWhiteboard: jest.Mock) => 
 };
 
 describe('WhiteboardManager', () => {
-  it('fetches a token when the local peer shares the owner customerUserId but has no whiteboard state', async () => {
+  it('fetches a token when the local peer shares the owner customerUserId but never opened it', async () => {
     const getWhiteboard = buildGetWhiteboard();
     const { store, manager } = buildManager(OWNER_USER_ID, getWhiteboard);
 
@@ -51,7 +51,7 @@ describe('WhiteboardManager', () => {
     });
   });
 
-  it('reuses the existing token when the local peer already holds whiteboard state', async () => {
+  it('reuses the existing token for the client that opened the whiteboard', async () => {
     const getWhiteboard = buildGetWhiteboard();
     const { store, manager } = buildManager(OWNER_USER_ID, getWhiteboard);
     store.setWhiteboard({
@@ -61,6 +61,7 @@ describe('WhiteboardManager', () => {
       token: 'locally-created-token',
       addr: 'store-prod-in3-grpc.100ms.live',
       permissions: ['read', 'write', 'admin'],
+      isLocalOwner: true,
     });
 
     manager.handleNotification(HMSNotificationMethod.WHITEBOARD_UPDATE, {
@@ -74,12 +75,12 @@ describe('WhiteboardManager', () => {
     expect(store.getWhiteboard(WHITEBOARD_ID)).toMatchObject({ open: true, token: 'locally-created-token' });
   });
 
-  // Guards the local-close intent: the owner drops its token on close, so keying the owner
-  // shortcut off a stored token would let a stale open echo reopen the board.
-  it('keeps the whiteboard closed for an owner that closed it locally', async () => {
+  // The opener drops its token on close, so keying the opener shortcut off a stored token
+  // would let a stale open echo reopen the board.
+  it('keeps the whiteboard closed for the client that closed it locally', async () => {
     const getWhiteboard = buildGetWhiteboard();
     const { store, manager } = buildManager(OWNER_USER_ID, getWhiteboard);
-    store.setWhiteboard({ id: WHITEBOARD_ID, open: false });
+    store.setWhiteboard({ id: WHITEBOARD_ID, open: false, isLocalOwner: true });
 
     manager.handleNotification(HMSNotificationMethod.WHITEBOARD_UPDATE, {
       id: WHITEBOARD_ID,
@@ -90,6 +91,55 @@ describe('WhiteboardManager', () => {
 
     expect(getWhiteboard).not.toHaveBeenCalled();
     expect(store.getWhiteboard(WHITEBOARD_ID)).toMatchObject({ open: false });
+  });
+
+  it('closes for a duplicate tab that shares the owner customerUserId', async () => {
+    const getWhiteboard = buildGetWhiteboard();
+    const { store, manager } = buildManager(OWNER_USER_ID, getWhiteboard);
+    // The duplicate tab fetched its own access on the open update - it is a viewer, not the opener.
+    store.setWhiteboard({
+      id: WHITEBOARD_ID,
+      open: true,
+      owner: OWNER_USER_ID,
+      token: 'fetched-whiteboard-token',
+      addr: 'store-prod-in3-grpc.100ms.live',
+      permissions: ['read', 'write'],
+    });
+
+    manager.handleNotification(HMSNotificationMethod.WHITEBOARD_UPDATE, {
+      id: WHITEBOARD_ID,
+      owner: OWNER_USER_ID,
+      state: 'closed',
+    });
+    await flushMicrotasks();
+
+    expect(store.getWhiteboard(WHITEBOARD_ID)).toMatchObject({ open: false });
+  });
+
+  // buildWhiteboard rebuilds the record per notification, so the opener would decay into a
+  // viewer on the first remote update if the flag were not carried forward.
+  it('keeps the opener flag across remote updates', async () => {
+    const getWhiteboard = buildGetWhiteboard();
+    const { store, manager } = buildManager(OWNER_USER_ID, getWhiteboard);
+    store.setWhiteboard({
+      id: WHITEBOARD_ID,
+      open: true,
+      owner: OWNER_USER_ID,
+      token: 'locally-created-token',
+      isLocalOwner: true,
+    });
+
+    for (let i = 0; i < 2; i++) {
+      manager.handleNotification(HMSNotificationMethod.WHITEBOARD_UPDATE, {
+        id: WHITEBOARD_ID,
+        owner: OWNER_USER_ID,
+        state: 'open',
+      });
+      await flushMicrotasks();
+    }
+
+    expect(getWhiteboard).not.toHaveBeenCalled();
+    expect(store.getWhiteboard(WHITEBOARD_ID)).toMatchObject({ token: 'locally-created-token' });
   });
 
   it('fetches a token for a peer that is not the owner', async () => {

--- a/packages/hms-video-store/src/notification-manager/managers/WhiteboardManager.test.ts
+++ b/packages/hms-video-store/src/notification-manager/managers/WhiteboardManager.test.ts
@@ -1,0 +1,109 @@
+import { WhiteboardManager } from './WhiteboardManager';
+import { HMSUpdateListener } from '../../interfaces';
+import { HMSPeerType } from '../../interfaces/peer/hms-peer';
+import { HMSLocalPeer } from '../../sdk/models/peer';
+import { Store } from '../../sdk/store';
+import HMSTransport from '../../transport';
+import { HMSNotificationMethod } from '../HMSNotificationMethod';
+
+const WHITEBOARD_ID = '68c1e2a04944f067313a7338-whiteboard';
+const OWNER_USER_ID = 'shared-customer-user-id';
+const OTHER_USER_ID = 'some-other-customer-user-id';
+
+const flushMicrotasks = () => new Promise(resolve => setTimeout(resolve, 0));
+
+const buildGetWhiteboard = () =>
+  jest.fn().mockResolvedValue({
+    id: WHITEBOARD_ID,
+    token: 'fetched-whiteboard-token',
+    addr: 'store-prod-in3-grpc.100ms.live',
+    owner: OWNER_USER_ID,
+    permissions: ['read', 'write'],
+  });
+
+const buildManager = (localCustomerUserId: string, getWhiteboard: jest.Mock) => {
+  const store = new Store();
+  store.addPeer(
+    new HMSLocalPeer({ name: 'second-tab', customerUserId: localCustomerUserId, type: HMSPeerType.REGULAR }),
+  );
+  const listener = { onWhiteboardUpdate: jest.fn() } as unknown as HMSUpdateListener;
+  const transport = { signal: { getWhiteboard } } as unknown as HMSTransport;
+  return { store, listener, manager: new WhiteboardManager(store, transport, listener) };
+};
+
+describe('WhiteboardManager', () => {
+  it('fetches a token when the local peer shares the owner customerUserId but has no whiteboard state', async () => {
+    const getWhiteboard = buildGetWhiteboard();
+    const { store, manager } = buildManager(OWNER_USER_ID, getWhiteboard);
+
+    manager.handleNotification(HMSNotificationMethod.WHITEBOARD_UPDATE, {
+      id: WHITEBOARD_ID,
+      owner: OWNER_USER_ID,
+      state: 'open',
+    });
+    await flushMicrotasks();
+
+    expect(getWhiteboard).toHaveBeenCalledWith({ id: WHITEBOARD_ID });
+    expect(store.getWhiteboard(WHITEBOARD_ID)).toMatchObject({
+      open: true,
+      token: 'fetched-whiteboard-token',
+      addr: 'store-prod-in3-grpc.100ms.live',
+    });
+  });
+
+  it('reuses the existing token when the local peer already holds whiteboard state', async () => {
+    const getWhiteboard = buildGetWhiteboard();
+    const { store, manager } = buildManager(OWNER_USER_ID, getWhiteboard);
+    store.setWhiteboard({
+      id: WHITEBOARD_ID,
+      open: true,
+      owner: OWNER_USER_ID,
+      token: 'locally-created-token',
+      addr: 'store-prod-in3-grpc.100ms.live',
+      permissions: ['read', 'write', 'admin'],
+    });
+
+    manager.handleNotification(HMSNotificationMethod.WHITEBOARD_UPDATE, {
+      id: WHITEBOARD_ID,
+      owner: OWNER_USER_ID,
+      state: 'open',
+    });
+    await flushMicrotasks();
+
+    expect(getWhiteboard).not.toHaveBeenCalled();
+    expect(store.getWhiteboard(WHITEBOARD_ID)).toMatchObject({ open: true, token: 'locally-created-token' });
+  });
+
+  // Guards the local-close intent: the owner drops its token on close, so keying the owner
+  // shortcut off a stored token would let a stale open echo reopen the board.
+  it('keeps the whiteboard closed for an owner that closed it locally', async () => {
+    const getWhiteboard = buildGetWhiteboard();
+    const { store, manager } = buildManager(OWNER_USER_ID, getWhiteboard);
+    store.setWhiteboard({ id: WHITEBOARD_ID, open: false });
+
+    manager.handleNotification(HMSNotificationMethod.WHITEBOARD_UPDATE, {
+      id: WHITEBOARD_ID,
+      owner: OWNER_USER_ID,
+      state: 'open',
+    });
+    await flushMicrotasks();
+
+    expect(getWhiteboard).not.toHaveBeenCalled();
+    expect(store.getWhiteboard(WHITEBOARD_ID)).toMatchObject({ open: false });
+  });
+
+  it('fetches a token for a peer that is not the owner', async () => {
+    const getWhiteboard = buildGetWhiteboard();
+    const { store, manager } = buildManager(OTHER_USER_ID, getWhiteboard);
+
+    manager.handleNotification(HMSNotificationMethod.WHITEBOARD_UPDATE, {
+      id: WHITEBOARD_ID,
+      owner: OWNER_USER_ID,
+      state: 'open',
+    });
+    await flushMicrotasks();
+
+    expect(getWhiteboard).toHaveBeenCalledWith({ id: WHITEBOARD_ID });
+    expect(store.getWhiteboard(WHITEBOARD_ID)).toMatchObject({ open: true, token: 'fetched-whiteboard-token' });
+  });
+});

--- a/packages/hms-video-store/src/notification-manager/managers/WhiteboardManager.ts
+++ b/packages/hms-video-store/src/notification-manager/managers/WhiteboardManager.ts
@@ -21,7 +21,9 @@ export class WhiteboardManager {
 
   private async handleWhiteboardUpdate(notification: WhiteboardInfo) {
     const prev = this.store.getWhiteboard(notification.id);
-    const isOwner = this.isOwnedLocally(notification, prev);
+    // Only this client calling open() sets isLocalOwner - `owner` is a customerUserId and is
+    // shared by every tab of the same user, so it cannot tell us apart from a duplicate tab.
+    const isOwner = !!prev?.isLocalOwner;
     const whiteboard = this.buildWhiteboard(notification, prev, isOwner);
 
     if (whiteboard.open) {
@@ -36,20 +38,8 @@ export class WhiteboardManager {
     this.listener?.onWhiteboardUpdate(whiteboard);
   }
 
-  /**
-   * `owner` is a customerUserId, which duplicate tabs of the same user share, so it can't identify
-   * this client alone - only prior local state proves we're the peer that opened the whiteboard.
-   */
-  private isOwnedLocally(notification: WhiteboardInfo, prev?: HMSWhiteboard) {
-    if (!prev) {
-      return false;
-    }
-    const localPeer = this.store.getLocalPeer();
-    return notification.owner === localPeer?.peerId || notification.owner === localPeer?.customerUserId;
-  }
-
   private buildWhiteboard(notification: WhiteboardInfo, prev: HMSWhiteboard | undefined, isOwner: boolean) {
-    // The owner's local state wins, so a remote update can't reopen a board it just closed.
+    // The opener's local state wins, so a remote update can't reopen a board it just closed.
     const open = isOwner ? prev?.open : notification.state === 'open';
     return {
       id: notification.id,
@@ -57,6 +47,7 @@ export class WhiteboardManager {
       attributes: notification.attributes,
       open,
       owner: open ? notification.owner : undefined,
+      isLocalOwner: prev?.isLocalOwner,
     } as HMSWhiteboard;
   }
 

--- a/packages/hms-video-store/src/notification-manager/managers/WhiteboardManager.ts
+++ b/packages/hms-video-store/src/notification-manager/managers/WhiteboardManager.ts
@@ -20,35 +20,58 @@ export class WhiteboardManager {
   }
 
   private async handleWhiteboardUpdate(notification: WhiteboardInfo) {
-    const localPeer = this.store.getLocalPeer();
     const prev = this.store.getWhiteboard(notification.id);
-    const isOwner = notification.owner === localPeer?.peerId || notification.owner === localPeer?.customerUserId;
-    const open = notification.state === 'open';
-    const whiteboard: HMSWhiteboard = {
-      id: notification.id,
-      title: notification.title,
-      attributes: notification.attributes,
-    };
-    whiteboard.open = isOwner ? prev?.open : open;
-    whiteboard.owner = whiteboard.open ? notification.owner : undefined;
+    const isOwner = this.isOwnedLocally(notification, prev);
+    const whiteboard = this.buildWhiteboard(notification, prev, isOwner);
 
     if (whiteboard.open) {
       if (isOwner) {
-        whiteboard.url = prev?.url;
-        whiteboard.token = prev?.token;
-        whiteboard.addr = prev?.addr;
-        whiteboard.permissions = prev?.permissions;
+        Object.assign(whiteboard, this.reuseLocalAccess(prev));
       } else {
-        const response = await this.transport.signal.getWhiteboard({ id: notification.id });
-        whiteboard.url = constructWhiteboardURL(response.token, response.addr, this.store.getEnv());
-        whiteboard.token = response.token;
-        whiteboard.addr = response.addr;
-        whiteboard.permissions = response.permissions;
-        whiteboard.open = response.permissions.length > 0;
+        Object.assign(whiteboard, await this.fetchAccess(notification.id));
       }
     }
 
     this.store.setWhiteboard(whiteboard);
     this.listener?.onWhiteboardUpdate(whiteboard);
+  }
+
+  /**
+   * `owner` is a customerUserId, which duplicate tabs of the same user share, so it can't identify
+   * this client alone - only prior local state proves we're the peer that opened the whiteboard.
+   */
+  private isOwnedLocally(notification: WhiteboardInfo, prev?: HMSWhiteboard) {
+    if (!prev) {
+      return false;
+    }
+    const localPeer = this.store.getLocalPeer();
+    return notification.owner === localPeer?.peerId || notification.owner === localPeer?.customerUserId;
+  }
+
+  private buildWhiteboard(notification: WhiteboardInfo, prev: HMSWhiteboard | undefined, isOwner: boolean) {
+    // The owner's local state wins, so a remote update can't reopen a board it just closed.
+    const open = isOwner ? prev?.open : notification.state === 'open';
+    return {
+      id: notification.id,
+      title: notification.title,
+      attributes: notification.attributes,
+      open,
+      owner: open ? notification.owner : undefined,
+    } as HMSWhiteboard;
+  }
+
+  private reuseLocalAccess(prev?: HMSWhiteboard) {
+    return { url: prev?.url, token: prev?.token, addr: prev?.addr, permissions: prev?.permissions };
+  }
+
+  private async fetchAccess(id: string) {
+    const response = await this.transport.signal.getWhiteboard({ id });
+    return {
+      url: constructWhiteboardURL(response.token, response.addr, this.store.getEnv()),
+      token: response.token,
+      addr: response.addr,
+      permissions: response.permissions,
+      open: response.permissions.length > 0,
+    };
   }
 }

--- a/packages/hms-video-store/src/session-store/interactivity-center/HMSWhiteboardCenter.test.ts
+++ b/packages/hms-video-store/src/session-store/interactivity-center/HMSWhiteboardCenter.test.ts
@@ -1,0 +1,47 @@
+import { WhiteboardInteractivityCenter } from './HMSWhiteboardCenter';
+import { InteractivityListener } from '../../interfaces';
+import { Store } from '../../sdk/store';
+import HMSTransport from '../../transport';
+
+const WHITEBOARD_ID = '68c1e2a04944f067313a7338-whiteboard';
+const OWNER_USER_ID = 'shared-customer-user-id';
+
+const buildCenter = () => {
+  const store = new Store();
+  const transport = {
+    isFlagEnabled: () => true,
+    signal: {
+      createWhiteboard: jest.fn().mockResolvedValue({ id: WHITEBOARD_ID }),
+      getWhiteboard: jest.fn().mockResolvedValue({
+        id: WHITEBOARD_ID,
+        token: 'locally-created-token',
+        addr: 'store-prod-in3-grpc.100ms.live',
+        owner: OWNER_USER_ID,
+        permissions: ['read', 'write', 'admin'],
+      }),
+    },
+  } as unknown as HMSTransport;
+  const listener = { onWhiteboardUpdate: jest.fn() } as unknown as InteractivityListener;
+  return { store, center: new WhiteboardInteractivityCenter(transport, store, listener) };
+};
+
+describe('WhiteboardInteractivityCenter', () => {
+  it('marks the whiteboard as opened by this client', async () => {
+    const { store, center } = buildCenter();
+
+    await center.open();
+
+    expect(store.getWhiteboard(WHITEBOARD_ID)).toMatchObject({ open: true, isLocalOwner: true });
+  });
+
+  // close() drops the token, so the flag is the only thing left that identifies this client as
+  // the opener - losing it would let a stale open notification reopen the board.
+  it('keeps the opener flag after closing', async () => {
+    const { store, center } = buildCenter();
+
+    await center.open();
+    await center.close(WHITEBOARD_ID);
+
+    expect(store.getWhiteboard(WHITEBOARD_ID)).toMatchObject({ open: false, isLocalOwner: true });
+  });
+});

--- a/packages/hms-video-store/src/session-store/interactivity-center/HMSWhiteboardCenter.ts
+++ b/packages/hms-video-store/src/session-store/interactivity-center/HMSWhiteboardCenter.ts
@@ -47,6 +47,7 @@ export class WhiteboardInteractivityCenter implements HMSWhiteboardInteractivity
       owner: response.owner,
       permissions: response.permissions || [],
       open: true,
+      isLocalOwner: true,
     };
 
     this.store.setWhiteboard(whiteboard);
@@ -62,7 +63,12 @@ export class WhiteboardInteractivityCenter implements HMSWhiteboardInteractivity
     if (!prevWhiteboard) {
       throw new Error(`Whiteboard ID: ${id} not found`);
     }
-    const whiteboard: HMSWhiteboard = { id: prevWhiteboard.id, title: prevWhiteboard.title, open: false };
+    const whiteboard: HMSWhiteboard = {
+      id: prevWhiteboard.id,
+      title: prevWhiteboard.title,
+      open: false,
+      isLocalOwner: prevWhiteboard.isLocalOwner,
+    };
 
     this.store.setWhiteboard(whiteboard);
     this.listener?.onWhiteboardUpdate(whiteboard);
@@ -79,9 +85,9 @@ export class WhiteboardInteractivityCenter implements HMSWhiteboardInteractivity
       if (whiteboard.url) {
         const response = await this.transport.signal.getWhiteboard({ id: whiteboard.id });
         const localPeer = this.store.getLocalPeer();
-        const isOwner = localPeer?.customerUserId === response.owner;
+        const isOwner = !!whiteboard.isLocalOwner;
         const open = isOwner
-          ? localPeer.role?.permissions.whiteboard?.includes('admin')
+          ? localPeer?.role?.permissions.whiteboard?.includes('admin')
           : response.permissions.length > 0;
         const newWhiteboard: HMSWhiteboard = {
           ...whiteboard,

--- a/packages/hms-whiteboard/jest.config.js
+++ b/packages/hms-whiteboard/jest.config.js
@@ -1,0 +1,20 @@
+const config = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          esModuleInterop: true,
+          jsx: 'react-jsx',
+        },
+      },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  collectCoverageFrom: ['src/**/*.{ts,tsx}'],
+  testMatch: ['<rootDir>/src/**/*.(test).{ts,tsx}'],
+};
+
+module.exports = config;

--- a/packages/hms-whiteboard/package.json
+++ b/packages/hms-whiteboard/package.json
@@ -29,6 +29,7 @@
     "build": "node ../../scripts/build.js && yarn types:build",
     "types:build": "tsc -p tsconfig.json",
     "build:proto": "protoc --ts_opt long_type_string  --ts_out ./src/grpc -I=./proto proto/*proto",
+    "test": "jest --maxWorkers=1",
     "lint": "eslint -c .eslintrc src",
     "lint:fix": "eslint -c .eslintrc src --fix",
     "format": "prettier -w src/**"

--- a/packages/hms-whiteboard/src/constants.ts
+++ b/packages/hms-whiteboard/src/constants.ts
@@ -4,6 +4,8 @@ export const PAGES_DEBOUNCE_TIME = 200;
 export const OPEN_WAIT_TIMEOUT = 1000;
 
 export const WHITEBOARD_CLOSE_MESSAGE = 'client whiteboard abort';
+export const WHITEBOARD_RECONNECT_MESSAGE = 'reconnecting due to online event';
+export const WHITEBOARD_REOPEN_MESSAGE = 'closing to open new conn';
 export const RETRY_ERROR_MESSAGES = ['network error', 'failed to fetch'];
 
 // Exponential backoff configuration

--- a/packages/hms-whiteboard/src/hooks/StoreClient.test.ts
+++ b/packages/hms-whiteboard/src/hooks/StoreClient.test.ts
@@ -58,11 +58,15 @@ beforeEach(() => {
   openHandles.length = 0;
   countResponse = () => Promise.resolve({ response: { count: '0' } });
   jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 });
 
 afterEach(() => {
   openHandles.forEach(close => close());
-  jest.runOnlyPendingTimers();
+  // A test that needs the real count delay swaps to real timers, so only drain fake ones.
+  if (jest.isMockFunction(setTimeout)) {
+    jest.runOnlyPendingTimers();
+  }
   jest.useRealTimers();
   jest.restoreAllMocks();
 });
@@ -146,11 +150,13 @@ describe('SessionStore.open', () => {
   });
 
   it('does not report a count failure that lands after close', async () => {
+    // Real timers: the count rejection has to settle through its own promise chain.
+    jest.useRealTimers();
     countResponse = () => Promise.reject(new Error('network error'));
     const { close, callbacks } = openSessionStore();
 
     close();
-    await jest.advanceTimersByTimeAsync(COUNT_RETRY_DELAY_MS);
+    await new Promise(resolve => setTimeout(resolve, COUNT_RETRY_DELAY_MS + 100));
 
     expect(callbacks.handleError).not.toHaveBeenCalled();
     expect(console.error).not.toHaveBeenCalled();

--- a/packages/hms-whiteboard/src/hooks/StoreClient.test.ts
+++ b/packages/hms-whiteboard/src/hooks/StoreClient.test.ts
@@ -31,6 +31,9 @@ jest.mock('../grpc/sessionstore.client', () => ({
   })),
 }));
 
+// Matches the delay getKeysCountWithDelay waits before its first count call.
+const COUNT_RETRY_DELAY_MS = 200;
+
 const buildCallbacks = () => ({
   handleOpen: jest.fn(),
   handleChange: jest.fn(),
@@ -123,6 +126,34 @@ describe('SessionStore.open', () => {
 
     expect(streams).toHaveLength(2);
     expect(callbacks.handleError).not.toHaveBeenCalled();
+  });
+
+  it('does not log an error when the stream ends because we closed it', () => {
+    const { close } = openSessionStore();
+
+    close();
+    streams[0].emitError(new Error('BodyStreamBuffer was aborted'));
+
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('logs a genuine stream failure', () => {
+    openSessionStore();
+
+    streams[0].emitError(new Error('network error'));
+
+    expect(console.error).toHaveBeenCalledWith('GRPCOpenStreamError: ', expect.any(Error));
+  });
+
+  it('does not report a count failure that lands after close', async () => {
+    countResponse = () => Promise.reject(new Error('network error'));
+    const { close, callbacks } = openSessionStore();
+
+    close();
+    await jest.advanceTimersByTimeAsync(COUNT_RETRY_DELAY_MS);
+
+    expect(callbacks.handleError).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
   });
 
   it('reports a genuine stream failure and reconnects', () => {

--- a/packages/hms-whiteboard/src/hooks/StoreClient.test.ts
+++ b/packages/hms-whiteboard/src/hooks/StoreClient.test.ts
@@ -1,0 +1,137 @@
+import { SessionStore } from './StoreClient';
+import { INITIAL_BACKOFF_MS } from '../constants';
+
+jest.mock('@protobuf-ts/grpcweb-transport', () => ({
+  GrpcWebFetchTransport: jest.fn().mockImplementation(() => ({})),
+}));
+
+interface FakeStream {
+  signal: AbortSignal;
+  emitError: (error: Error) => void;
+}
+
+const streams: FakeStream[] = [];
+let countResponse: () => Promise<{ response: { count: string } }>;
+
+jest.mock('../grpc/sessionstore.client', () => ({
+  StoreClient: jest.fn().mockImplementation(() => ({
+    open: (_input: unknown, options: { abort: AbortSignal }) => {
+      const stream: FakeStream = { signal: options.abort, emitError: () => undefined };
+      streams.push(stream);
+      return {
+        responses: {
+          onMessage: () => undefined,
+          onError: (callback: (error: Error) => void) => {
+            stream.emitError = callback;
+          },
+        },
+      };
+    },
+    count: () => countResponse(),
+  })),
+}));
+
+const buildCallbacks = () => ({
+  handleOpen: jest.fn(),
+  handleChange: jest.fn(),
+  handleError: jest.fn(),
+});
+
+// Every store is closed in afterEach - an open one keeps an 'online' listener on window and
+// would reconnect during a later test's 'online' event.
+const openHandles: (() => void)[] = [];
+
+// A real JWT is not needed - SessionStore only forwards the token as a metadata header.
+const openSessionStore = (callbacks = buildCallbacks()) => {
+  const sessionStore = new SessionStore<unknown>('https://store-qa-in2-grpc.100ms.live', 'whiteboard-token');
+  const close = sessionStore.open(callbacks);
+  openHandles.push(close);
+  return { close, callbacks, sessionStore };
+};
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  streams.length = 0;
+  openHandles.length = 0;
+  countResponse = () => Promise.resolve({ response: { count: '0' } });
+  jest.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  openHandles.forEach(close => close());
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+describe('SessionStore.open', () => {
+  it('returns the close handle synchronously so callers cannot miss it', () => {
+    const { close } = openSessionStore();
+
+    expect(typeof close).toBe('function');
+  });
+
+  it('aborts the live stream on close', () => {
+    const { close } = openSessionStore();
+
+    close();
+
+    expect(streams).toHaveLength(1);
+    expect(streams[0].signal.aborted).toBe(true);
+  });
+
+  it('aborts the reconnected stream on close, not the stream it replaced', () => {
+    const { close } = openSessionStore();
+
+    streams[0].emitError(new Error('network error'));
+    jest.advanceTimersByTime(INITIAL_BACKOFF_MS);
+    expect(streams).toHaveLength(2);
+
+    close();
+
+    expect(streams[1].signal.aborted).toBe(true);
+  });
+
+  it('does not reconnect after close when a retry is already scheduled', () => {
+    const { close } = openSessionStore();
+
+    streams[0].emitError(new Error('network error'));
+    close();
+    jest.advanceTimersByTime(INITIAL_BACKOFF_MS * 10);
+
+    expect(streams).toHaveLength(1);
+  });
+
+  it('replaces the live stream when opened again without an explicit close', () => {
+    const { sessionStore, callbacks } = openSessionStore();
+
+    openHandles.push(sessionStore.open(callbacks));
+
+    expect(streams).toHaveLength(2);
+    expect(streams[0].signal.aborted).toBe(true);
+  });
+
+  it('treats an abort surfaced as the abort reason as intentional, not as a failure', () => {
+    const { callbacks } = openSessionStore();
+
+    // Reconnect on 'online' aborts the stream. Chrome rejects a not-yet-streaming fetch with the
+    // abort reason itself, so the old stream reports that string rather than an AbortError.
+    window.dispatchEvent(new Event('online'));
+    expect(streams).toHaveLength(2);
+    streams[0].emitError(new Error('reconnecting due to online event'));
+    jest.advanceTimersByTime(INITIAL_BACKOFF_MS * 10);
+
+    expect(streams).toHaveLength(2);
+    expect(callbacks.handleError).not.toHaveBeenCalled();
+  });
+
+  it('reports a genuine stream failure and reconnects', () => {
+    const { callbacks } = openSessionStore();
+
+    streams[0].emitError(new Error('network error'));
+
+    expect(callbacks.handleError).toHaveBeenCalled();
+    jest.advanceTimersByTime(INITIAL_BACKOFF_MS);
+    expect(streams).toHaveLength(2);
+  });
+});

--- a/packages/hms-whiteboard/src/hooks/StoreClient.ts
+++ b/packages/hms-whiteboard/src/hooks/StoreClient.ts
@@ -88,13 +88,14 @@ export class SessionStore<T> {
     window.addEventListener('online', handleOnline);
 
     call.responses.onError(error => {
-      console.error('GRPCOpenStreamError: ', error);
-      // Our own teardown, not a connection failure. The signal is authoritative where the message
-      // is not: Chrome reports the abort reason before streaming starts and an AbortError after.
+      // Our own teardown, not a connection failure - closing the whiteboard ends the stream this
+      // way every time. The signal is authoritative where the message is not: Chrome reports the
+      // abort reason before streaming starts and an AbortError after.
       if (abortController.signal.aborted) {
         return;
       }
 
+      console.error('GRPCOpenStreamError: ', error);
       handleError(error);
 
       const nextState: BackoffState = {
@@ -118,6 +119,10 @@ export class SessionStore<T> {
         handleOpen(count ? initialValues : []);
       })
       .catch(error => {
+        // The whiteboard is already gone - reporting now would surface a connection error on it.
+        if (abortController.signal.aborted) {
+          return;
+        }
         console.error('GRPCCountError: ', error);
         const canRecover = RETRY_ERROR_MESSAGES.includes((error as unknown as Error).message.toLowerCase());
         handleError(error as unknown as Error, canRecover);

--- a/packages/hms-whiteboard/src/hooks/StoreClient.ts
+++ b/packages/hms-whiteboard/src/hooks/StoreClient.ts
@@ -2,7 +2,13 @@ import { GrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport';
 import { Value_Type } from '../grpc/sessionstore';
 import { StoreClient } from '../grpc/sessionstore.client';
 import { BackoffState, calculateBackoff } from '../utils';
-import { INITIAL_BACKOFF_MS, RETRY_ERROR_MESSAGES, WHITEBOARD_CLOSE_MESSAGE } from '../constants';
+import {
+  INITIAL_BACKOFF_MS,
+  RETRY_ERROR_MESSAGES,
+  WHITEBOARD_CLOSE_MESSAGE,
+  WHITEBOARD_RECONNECT_MESSAGE,
+  WHITEBOARD_REOPEN_MESSAGE,
+} from '../constants';
 interface OpenCallbacks<T> {
   handleOpen: (values: T[]) => void;
   handleChange: (key: string, value?: T) => void;
@@ -10,6 +16,10 @@ interface OpenCallbacks<T> {
 }
 export class SessionStore<T> {
   private storeClient: StoreClient;
+  /** Teardown state for the stream generation that is currently live. */
+  private abortController?: AbortController;
+  private reconnectTimer?: ReturnType<typeof setTimeout>;
+  private onlineHandler?: () => void;
 
   constructor(endpoint: string, token: string) {
     const transport = new GrpcWebFetchTransport({
@@ -20,11 +30,19 @@ export class SessionStore<T> {
     this.storeClient = new StoreClient(transport);
   }
 
-  async open(
+  /**
+   * Starts streaming session store changes and returns the handle that closes it.
+   * The handle is returned synchronously so a caller can never unmount without it.
+   */
+  open(
     { handleOpen, handleChange, handleError }: OpenCallbacks<T>,
     backoffState: BackoffState = { attempt: 0, currentDelay: INITIAL_BACKOFF_MS },
   ) {
+    // open() is the only place a stream is created, so replacing any still-live generation here
+    // means no stream can be orphaned by a caller that opens twice.
+    this.teardown();
     const abortController = new AbortController();
+    this.abortController = abortController;
     const call = this.storeClient.open(
       {
         changeId: '',
@@ -62,51 +80,67 @@ export class SessionStore<T> {
 
     // Reconnect immediately when the browser comes back online
     const handleOnline = () => {
-      window.removeEventListener('online', handleOnline);
-      abortController.abort('reconnecting due to online event');
+      this.teardown(WHITEBOARD_RECONNECT_MESSAGE);
       this.open({ handleOpen, handleChange, handleError }); // reset backoff
     };
 
+    this.onlineHandler = handleOnline;
     window.addEventListener('online', handleOnline);
 
     call.responses.onError(error => {
       console.error('GRPCOpenStreamError: ', error);
-      // Don't retry if this was an abort - either intentional close or already reconnecting
-      if (error.message.includes('abort')) {
+      // Our own teardown, not a connection failure. The signal is authoritative where the message
+      // is not: Chrome reports the abort reason before streaming starts and an AbortError after.
+      if (abortController.signal.aborted) {
         return;
       }
 
       handleError(error);
 
-      const nextDelay = calculateBackoff(backoffState);
       const nextState: BackoffState = {
         attempt: backoffState.attempt + 1,
-        currentDelay: nextDelay,
-      };
-
-      const openCallback = () => {
-        window.removeEventListener('online', handleOnline);
-        abortController.abort(`closing to open new conn`);
-        this.open({ handleOpen, handleChange, handleError }, nextState);
+        currentDelay: calculateBackoff(backoffState),
       };
 
       // Apply exponential backoff before reconnecting
-      setTimeout(openCallback, backoffState.currentDelay);
+      this.reconnectTimer = setTimeout(() => {
+        this.open({ handleOpen, handleChange, handleError }, nextState);
+      }, backoffState.currentDelay);
     });
 
-    try {
-      count = await this.getKeysCountWithDelay();
-      handleOpen(count ? initialValues : []);
-    } catch (error) {
-      console.error('GRPCCountError: ', error);
-      const canRecover = RETRY_ERROR_MESSAGES.includes((error as unknown as Error).message.toLowerCase());
-      handleError(error as unknown as Error, canRecover);
+    this.getKeysCountWithDelay()
+      .then(keysCount => {
+        // A close or reconnect landed while the count was in flight - its records are stale now.
+        if (abortController.signal.aborted) {
+          return;
+        }
+        count = keysCount;
+        handleOpen(count ? initialValues : []);
+      })
+      .catch(error => {
+        console.error('GRPCCountError: ', error);
+        const canRecover = RETRY_ERROR_MESSAGES.includes((error as unknown as Error).message.toLowerCase());
+        handleError(error as unknown as Error, canRecover);
+      });
+
+    return () => this.teardown(WHITEBOARD_CLOSE_MESSAGE);
+  }
+
+  /**
+   * Closes the live stream generation and cancels any reconnect it had scheduled.
+   * `reason` is diagnostic only - Chrome drops it once the response body is streaming.
+   */
+  private teardown(reason: string = WHITEBOARD_REOPEN_MESSAGE) {
+    clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = undefined;
+
+    if (this.onlineHandler) {
+      window.removeEventListener('online', this.onlineHandler);
+      this.onlineHandler = undefined;
     }
 
-    return () => {
-      window.removeEventListener('online', handleOnline);
-      abortController.abort(WHITEBOARD_CLOSE_MESSAGE);
-    };
+    this.abortController?.abort(reason);
+    this.abortController = undefined;
   }
 
   set(key: string, value?: T) {

--- a/packages/hms-whiteboard/src/hooks/useCollaboration.ts
+++ b/packages/hms-whiteboard/src/hooks/useCollaboration.ts
@@ -153,13 +153,13 @@ export function useCollaboration({
     const unsubs: (() => void)[] = [];
 
     // Open session and sync the session store changes to the store
-    sessionStore
-      .open({
+    unsubs.push(
+      sessionStore.open({
         handleOpen,
         handleChange,
         handleError,
-      })
-      .then(unsub => unsubs.push(unsub));
+      }),
+    );
 
     // Sync store changes to the yjs doc
     unsubs.push(

--- a/packages/hms-whiteboard/tsconfig.json
+++ b/packages/hms-whiteboard/tsconfig.json
@@ -11,5 +11,5 @@
     "noUnusedParameters": false
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/packages/react-sdk/src/hooks/useWhiteboard.ts
+++ b/packages/react-sdk/src/hooks/useWhiteboard.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState } from 'react';
 import {
   selectAppData,
   selectIsConnectedToRoom,
-  selectLocalPeer,
   selectPermissions,
   selectWhiteboard,
 } from '@100mslive/hms-video-store';
@@ -10,11 +9,12 @@ import { useHMSActions, useHMSStore } from '../primitives/HmsRoomProvider';
 
 export const useWhiteboard = (isMobile = false) => {
   const isConnected = useHMSStore(selectIsConnectedToRoom);
-  const localPeerUserId = useHMSStore(selectLocalPeer)?.customerUserId;
   const whiteboard = useHMSStore(selectWhiteboard);
   const isHeadless = useHMSStore(selectAppData('disableNotifications'));
   const open = !!whiteboard?.open;
-  const isOwner = whiteboard?.owner === localPeerUserId;
+  // Set only by this client opening the whiteboard. Comparing `owner` to the local customerUserId
+  // would also match a duplicate tab, which must not be offered the close control.
+  const isOwner = !!whiteboard?.isLocalOwner;
   const actions = useHMSActions();
   const [isEnabled, setIsEnabled] = useState(false);
   const permissions = useHMSStore(selectPermissions)?.whiteboard;


### PR DESCRIPTION
A duplicated tab reuses the `user_id` Chrome clones from sessionStorage, so both tabs share a `customerUserId` — the whiteboard code read that as ownership, leaving the duplicate with no token and, once it had one, ignoring the close notification while still offering it the close control. The opener is now recorded when a client calls `open()`, which is the only event that proves it, and `WhiteboardManager`, `handleLocalRoleUpdate` and `useWhiteboard` all read that instead of comparing `owner` to the local `customerUserId`.

`SessionStore` reconnects also discarded the close handle they created, leaving the live stream and its `online` listener unreachable, and detected aborts by substring-matching the error message. Teardown is now owned per instance, `open()` returns its close handle synchronously, and aborts are detected via `signal.aborted`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)