### PR TITLE
fix(store): recover the first subscribe request when the SFU drops it

### DIFF
--- a/packages/hms-video-store/src/connection/channel-messages.ts
+++ b/packages/hms-video-store/src/connection/channel-messages.ts
@@ -15,6 +15,11 @@ export interface PreferLayerResponse {
     code: number;
     message: string;
   };
+  /**
+   * Resolved locally without the SFU ever answering - the request was superseded, or skipped. The
+   * caller must not read it as the SFU having applied the state.
+   */
+  dropped?: boolean;
 }
 
 export interface PreferAudioLayerParams {

--- a/packages/hms-video-store/src/connection/subscribe/staleSubscriptionState.test.ts
+++ b/packages/hms-video-store/src/connection/subscribe/staleSubscriptionState.test.ts
@@ -11,9 +11,8 @@ jest.mock('../../utils/timer-utils', () => ({
   workerSleep: () => Promise.resolve(),
 }));
 
-interface WithEventEmitter {
-  eventEmitter: { emit: (event: string, value: string) => void };
-}
+/** the connection reads replies off the native channel, so replies in tests arrive the same way */
+type ChannelWithHandler = RTCDataChannel & { onmessage?: (event: { data: string }) => void };
 
 /**
  * A retry replays the bytes serialised when the request was made. Without a claim on the state it
@@ -25,6 +24,7 @@ describe('a request that a newer one has replaced', () => {
   let connection: HMSSubscribeConnection;
   let stream: HMSRemoteStream;
   let sent: string[];
+  let nativeChannel: ChannelWithHandler;
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -34,11 +34,11 @@ describe('a request that a newer one has replaced', () => {
     const observer = { onApiChannelMessage: jest.fn() } as unknown as ISubscribeConnectionObserver;
     connection = new HMSSubscribeConnection(signal, {}, () => false, observer);
 
-    const nativeChannel = {
+    nativeChannel = {
       label: API_DATA_CHANNEL,
       readyState: 'open',
       send: (message: string) => sent.push(message),
-    } as unknown as RTCDataChannel;
+    } as unknown as ChannelWithHandler;
     connection.nativeConnection.ondatachannel?.({ channel: nativeChannel } as RTCDataChannelEvent);
 
     stream = new HMSRemoteStream({ id: 'stream-1' } as MediaStream, connection);
@@ -50,10 +50,7 @@ describe('a request that a newer one has replaced', () => {
 
   const respondTo = (request: string) => {
     const { id } = JSON.parse(request) as { id: string };
-    (connection as unknown as WithEventEmitter).eventEmitter.emit(
-      'message',
-      JSON.stringify({ id, jsonrpc: '2.0', result: { track_id: 'track-1' } }),
-    );
+    nativeChannel.onmessage?.({ data: JSON.stringify({ id, jsonrpc: '2.0', result: { track_id: 'track-1' } }) });
   };
 
   const paramsOf = (request: string) => (JSON.parse(request) as { params: Record<string, unknown> }).params;
@@ -74,8 +71,9 @@ describe('a request that a newer one has replaced', () => {
     const silenced = stream.setAudio(false, 'track-1').catch((error: Error) => error);
     await flush();
 
-    // the peer unmutes two seconds later. this is a real change, so it has to go out.
-    await jest.advanceTimersByTimeAsync(2000);
+    // the peer unmutes while the first request is still on its first attempt - this is a real
+    // change, so it has to go out. Later than one attempt is the same case with retries in front.
+    await jest.advanceTimersByTimeAsync(200);
     const restored = stream.setAudio(true, 'track-1');
     await flush();
     respondTo(sent[1]);
@@ -93,7 +91,7 @@ describe('a request that a newer one has replaced', () => {
     const low = stream.setVideoLayer(HMSSimulcastLayer.LOW, 'track-1', 'id', 'resize').catch((e: Error) => e);
     await flush();
 
-    await jest.advanceTimersByTimeAsync(2000);
+    await jest.advanceTimersByTimeAsync(200);
     const high = stream.setVideoLayer(HMSSimulcastLayer.HIGH, 'track-1', 'id', 'resize');
     await flush();
     respondTo(sent[1]);
@@ -129,7 +127,7 @@ describe('a request that a newer one has replaced', () => {
   it('resolves rather than failing, and leaves the newer value in place', async () => {
     const silenced = stream.setAudio(false, 'track-1').catch((error: Error) => error);
     await flush();
-    await jest.advanceTimersByTimeAsync(2000);
+    await jest.advanceTimersByTimeAsync(200);
     const restored = stream.setAudio(true, 'track-1');
     await flush();
     respondTo(sent[1]);

--- a/packages/hms-video-store/src/connection/subscribe/staleSubscriptionState.test.ts
+++ b/packages/hms-video-store/src/connection/subscribe/staleSubscriptionState.test.ts
@@ -94,6 +94,30 @@ describe('a request that a newer one has replaced', () => {
     expect(stream.isAudioSubscribed()).toBe(true);
   }, 20_000);
 
+  /**
+   * The first attempt is not the only window that matters - a request that has already replayed its
+   * bytes once is the one most likely to still be retrying when the caller moves on.
+   */
+  it('does not replay the stale unsubscribe once a retry is already in flight', async () => {
+    const silenced = stream.setAudio(false, 'track-1').catch((error: Error) => error);
+    await flush();
+
+    // the first attempt gives up on the unproven channel and replays the same bytes
+    await jest.advanceTimersByTimeAsync(600);
+    expect(sent).toHaveLength(2);
+
+    const restored = stream.setAudio(true, 'track-1');
+    await flush();
+    respondTo(sent[2]);
+    await restored;
+
+    await exhaustRetries();
+    await silenced;
+
+    expect(sent.map(subscribedOf)).toEqual([false, false, true]);
+    expect(stream.isAudioSubscribed()).toBe(true);
+  }, 20_000);
+
   it('does not replay a stale layer when the tile resizes mid-flight', async () => {
     const low = stream.setVideoLayer(HMSSimulcastLayer.LOW, 'track-1', 'id', 'resize').catch((e: Error) => e);
     await flush();
@@ -182,5 +206,36 @@ describe('a request that a newer one has replaced', () => {
     respondWithError(sent[0]);
 
     expect(await failed).toBeInstanceOf(Error);
+  }, 20_000);
+
+  /**
+   * Supersession normally answers this, but a replaced request can still receive a real success -
+   * sendMessage returns a response the SFU actually sent whatever happened to the claim. If that
+   * reply lands after the newer one, confirming it records a layer the SFU has already moved off.
+   */
+  it('does not let a late reply for a replaced request confirm its layer', async () => {
+    const high = stream.setVideoLayer(HMSSimulcastLayer.HIGH, 'track-1', 'id', 'resize').catch((e: Error) => e);
+    await flush();
+    const low = stream.setVideoLayer(HMSSimulcastLayer.LOW, 'track-1', 'id', 'resize');
+    await flush();
+
+    // the newer request is answered first, then the replaced one's own reply arrives
+    respondTo(sent[1]);
+    await low;
+    respondTo(sent[0]);
+    await high;
+
+    expect(stream.isVideoLayerSettled(HMSSimulcastLayer.LOW)).toBe(true);
+    expect(stream.isVideoLayerSettled(HMSSimulcastLayer.HIGH)).toBe(false);
+  }, 20_000);
+
+  /** the SFU telling us where it is outranks a request still on the wire */
+  it('lets a layer pushed by the SFU settle the dedupe while a request is in flight', async () => {
+    stream.setVideoLayer(HMSSimulcastLayer.HIGH, 'track-1', 'id', 'resize').catch(() => undefined);
+    await flush();
+
+    stream.setVideoLayerFromServer(HMSSimulcastLayer.LOW, 'id', 'degradation');
+
+    expect(stream.isVideoLayerSettled(HMSSimulcastLayer.LOW)).toBe(true);
   }, 20_000);
 });

--- a/packages/hms-video-store/src/connection/subscribe/staleSubscriptionState.test.ts
+++ b/packages/hms-video-store/src/connection/subscribe/staleSubscriptionState.test.ts
@@ -53,6 +53,13 @@ describe('a request that a newer one has replaced', () => {
     nativeChannel.onmessage?.({ data: JSON.stringify({ id, jsonrpc: '2.0', result: { track_id: 'track-1' } }) });
   };
 
+  const respondWithError = (request: string) => {
+    const { id } = JSON.parse(request) as { id: string };
+    nativeChannel.onmessage?.({
+      data: JSON.stringify({ id, jsonrpc: '2.0', error: { code: 400, message: 'bad request' } }),
+    });
+  };
+
   const paramsOf = (request: string) => (JSON.parse(request) as { params: Record<string, unknown> }).params;
   const subscribedOf = (request: string) => paramsOf(request).subscribed as boolean;
   const layerOf = (request: string) => paramsOf(request).max_spatial_layer as HMSSimulcastLayer;
@@ -153,11 +160,7 @@ describe('a request that a newer one has replaced', () => {
     await restored;
 
     // the replaced request's own answer finally arrives, carrying a code it would never retry
-    const { id } = JSON.parse(sent[0]) as { id: string };
-    (connection as unknown as WithEventEmitter).eventEmitter.emit(
-      'message',
-      JSON.stringify({ id, jsonrpc: '2.0', error: { code: 400, message: 'bad request' } }),
-    );
+    respondWithError(sent[0]);
 
     expect(await silenced).not.toBeInstanceOf(Error);
     expect(stream.isAudioSubscribed()).toBe(true);
@@ -176,11 +179,7 @@ describe('a request that a newer one has replaced', () => {
     const failed = stream.setAudio(false, 'track-1').catch((error: Error) => error);
     await flush();
 
-    const { id } = JSON.parse(sent[0]) as { id: string };
-    (connection as unknown as WithEventEmitter).eventEmitter.emit(
-      'message',
-      JSON.stringify({ id, jsonrpc: '2.0', error: { code: 400, message: 'bad request' } }),
-    );
+    respondWithError(sent[0]);
 
     expect(await failed).toBeInstanceOf(Error);
   }, 20_000);

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
@@ -14,6 +14,9 @@ interface WithEventEmitter {
   eventEmitter: { emit: (event: string, value: string) => void };
 }
 
+/** the connection reads replies off the native channel, so replies in tests arrive the same way */
+type ChannelWithHandler = RTCDataChannel & { onmessage?: (event: { data: string }) => void };
+
 /**
  * The Aug 2026 silent-recording incident: the SFU never answered the first
  * `prefer-audio-track-state` request of a session, so the caller waited forever.
@@ -21,6 +24,7 @@ interface WithEventEmitter {
 describe('HMSSubscribeConnection api data channel', () => {
   let connection: HMSSubscribeConnection;
   let sent: string[];
+  let nativeChannel: ChannelWithHandler;
 
   beforeEach(() => {
     sent = [];
@@ -32,7 +36,7 @@ describe('HMSSubscribeConnection api data channel', () => {
     connection = new HMSSubscribeConnection(signal, {}, () => false, observer);
 
     let readyState = 'open';
-    const nativeChannel = {
+    nativeChannel = {
       label: API_DATA_CHANNEL,
       get readyState() {
         return readyState;
@@ -46,7 +50,7 @@ describe('HMSSubscribeConnection api data channel', () => {
       close: jest.fn(() => {
         readyState = 'closed';
       }),
-    } as unknown as RTCDataChannel;
+    } as unknown as ChannelWithHandler;
     connection.nativeConnection.ondatachannel?.({ channel: nativeChannel } as RTCDataChannelEvent);
   });
 
@@ -58,13 +62,10 @@ describe('HMSSubscribeConnection api data channel', () => {
     jest.useRealTimers();
   });
 
-  /** the emitter is private; the data channel's onMessage feeds it exactly like this */
+  /** goes through the native channel so a reply marks the channel proven, exactly as in production */
   const emitReply = (request: string, body: Record<string, unknown>) => {
     const { id } = JSON.parse(request) as { id: string };
-    (connection as unknown as WithEventEmitter).eventEmitter.emit(
-      'message',
-      JSON.stringify({ id, jsonrpc: '2.0', ...body }),
-    );
+    nativeChannel.onmessage?.({ data: JSON.stringify({ id, jsonrpc: '2.0', ...body }) });
   };
 
   const respondTo = (request: string) => emitReply(request, { result: { track_id: 'track-1' } });
@@ -93,6 +94,67 @@ describe('HMSSubscribeConnection api data channel', () => {
     const result = await promise;
 
     expect(result).toBeInstanceOf(Error);
+    jest.useRealTimers();
+  }, 10_000);
+
+  /**
+   * The SFU creates this channel, so by DCEP the client's `open` fires a half-RTT before the SFU's
+   * and a request sent in that window is dropped before it arrives. Replies measure single-digit
+   * ms, so the first attempt must not sit on the full timeout - that is a black tile for as long
+   * as it waits.
+   */
+  it('retries an unanswered first request in under a second', async () => {
+    jest.useFakeTimers();
+    const promise = connection
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-audio-track-state',
+        params: { subscribed: true, track_id: 'track-1' },
+      })
+      .catch((error: Error) => error);
+
+    await Promise.resolve();
+    expect(sent).toHaveLength(1);
+
+    await jest.advanceTimersByTimeAsync(600);
+    expect(sent).toHaveLength(2);
+
+    respondTo(sent[1]);
+    await expect(promise).resolves.toBeDefined();
+    jest.useRealTimers();
+  }, 10_000);
+
+  /**
+   * Only the unproven channel gets the short bound. Once the SFU has answered, a slow reply is the
+   * SFU being slow rather than a dropped request, and resending on top of it is pure duplication.
+   */
+  it('keeps the generous timeout once the SFU has answered on this channel', async () => {
+    const first = connection.sendOverApiDataChannelWithResponse({
+      method: 'prefer-audio-track-state',
+      params: { subscribed: true, track_id: 'track-1' },
+    });
+    await Promise.resolve();
+    respondTo(sent[0]);
+    await first;
+
+    jest.useFakeTimers();
+    const second = connection
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-audio-track-state',
+        params: { subscribed: false, track_id: 'track-1' },
+      })
+      .catch((error: Error) => error);
+
+    await Promise.resolve();
+    expect(sent).toHaveLength(2);
+
+    await jest.advanceTimersByTimeAsync(1_000);
+    expect(sent).toHaveLength(2);
+
+    await jest.advanceTimersByTimeAsync(10_000);
+    expect(sent).toHaveLength(3);
+
+    await jest.advanceTimersByTimeAsync(120_000);
+    await second;
     jest.useRealTimers();
   }, 10_000);
 

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
@@ -124,6 +124,34 @@ describe('HMSSubscribeConnection api data channel', () => {
   }, 10_000);
 
   /**
+   * A link slow enough to miss 500ms twice is slow, not dropping. Putting every attempt on the
+   * short bound would hard-fail a high-RTT client at 1.5s, well inside SCTP's ~1s RTO.Min.
+   */
+  it('gives later attempts the full timeout even on an unproven channel', async () => {
+    jest.useFakeTimers();
+    const promise = connection
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-audio-track-state',
+        params: { subscribed: true, track_id: 'track-1' },
+      })
+      .catch((error: Error) => error);
+
+    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(600);
+    expect(sent).toHaveLength(2);
+
+    await jest.advanceTimersByTimeAsync(600);
+    expect(sent).toHaveLength(2);
+
+    await jest.advanceTimersByTimeAsync(10_000);
+    expect(sent).toHaveLength(3);
+
+    await jest.advanceTimersByTimeAsync(120_000);
+    await promise;
+    jest.useRealTimers();
+  }, 10_000);
+
+  /**
    * Only the unproven channel gets the short bound. Once the SFU has answered, a slow reply is the
    * SFU being slow rather than a dropped request, and resending on top of it is pure duplication.
    */

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.test.ts
@@ -152,6 +152,54 @@ describe('HMSSubscribeConnection api data channel', () => {
   }, 10_000);
 
   /**
+   * The open race is about the first bytes on the wire, not the first turn of the retry loop. An
+   * attempt that gave up on the channel-open wait sent nothing, so the attempt that does send is
+   * still the one the SFU can drop - and it has to get the short bound, not the 10s one.
+   */
+  it('gives the short bound to the first send even when an earlier attempt never sent', async () => {
+    const observer = { onApiChannelMessage: jest.fn() } as unknown as ISubscribeConnectionObserver;
+    const late = new HMSSubscribeConnection(
+      { trickle: jest.fn() } as unknown as JsonRpcSignal,
+      {},
+      () => false,
+      observer,
+    );
+    const lateSent: string[] = [];
+    const lateChannel = {
+      label: API_DATA_CHANNEL,
+      readyState: 'open',
+      send: (message: string) => lateSent.push(message),
+      close: jest.fn(),
+    } as unknown as ChannelWithHandler;
+
+    jest.useFakeTimers();
+    const promise = late
+      .sendOverApiDataChannelWithResponse({
+        method: 'prefer-audio-track-state',
+        params: { subscribed: true, track_id: 'track-1' },
+      })
+      .catch((error: Error) => error);
+
+    // the first attempt burns its channel-open wait without ever reaching send
+    await jest.advanceTimersByTimeAsync(11_000);
+    expect(lateSent).toHaveLength(0);
+
+    late.nativeConnection.ondatachannel?.({ channel: lateChannel } as RTCDataChannelEvent);
+    lateChannel.onopen?.(new Event('open'));
+    await jest.advanceTimersByTimeAsync(100);
+    expect(lateSent).toHaveLength(1);
+
+    await jest.advanceTimersByTimeAsync(600);
+    expect(lateSent).toHaveLength(2);
+
+    const { id } = JSON.parse(lateSent[1]) as { id: string };
+    lateChannel.onmessage?.({ data: JSON.stringify({ id, jsonrpc: '2.0', result: { track_id: 'track-1' } }) });
+    await expect(promise).resolves.toBeDefined();
+    late.close();
+    jest.useRealTimers();
+  }, 10_000);
+
+  /**
    * Only the unproven channel gets the short bound. Once the SFU has answered, a slow reply is the
    * SFU being slow rather than a dropped request, and resending on top of it is pure duplication.
    */

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
@@ -176,7 +176,6 @@ export default class HMSSubscribeConnection extends HMSConnection {
    */
   async sendOverApiDataChannelWithResponse<T extends PreferAudioLayerParams | PreferVideoLayerParams>(
     message: T,
-    requestId?: string,
   ): Promise<PreferLayerResponse> {
     const id = uuid();
     if (message.method === 'prefer-video-track-state') {
@@ -187,7 +186,7 @@ export default class HMSSubscribeConnection extends HMSConnection {
       }
     }
     const request = JSON.stringify({
-      id: requestId || id,
+      id,
       jsonrpc: '2.0',
       ...message,
     });
@@ -262,6 +261,12 @@ export default class HMSSubscribeConnection extends HMSConnection {
     let response: PreferLayerResponse | undefined;
     /** the per-attempt detail is a warn, which an app on setLogLevel(ERROR) never sees */
     let lastAttemptError: Error | undefined;
+    /**
+     * Whether these bytes have ever reached the wire - not the loop index. An attempt that gives up
+     * on the channel-open wait, or whose send throws, never put anything in front of the SFU, so
+     * the attempt that does is still the first one and still the one the open race can swallow.
+     */
+    let sentOnce = false;
     for (let i = 0; i < this.MAX_RETRIES; i++) {
       // a previous attempt's error response must not stand in for this attempt's outcome
       response = undefined;
@@ -277,7 +282,9 @@ export default class HMSSubscribeConnection extends HMSConnection {
         }
         // send can throw too - the channel may close between the open check and here
         this.apiChannel!.send(request);
-        response = await this.waitForResponse(requestId, i === 0);
+        const firstSend = !sentOnce;
+        sentOnce = true;
+        response = await this.waitForResponse(requestId, firstSend);
       } catch (error) {
         lastAttemptError = error as Error;
         HMSLogger.w(this.TAG, `Attempt failed for ${requestId}`, { request, try: i + 1, error });
@@ -365,13 +372,13 @@ export default class HMSSubscribeConnection extends HMSConnection {
   };
 
   /**
-   * Only the first attempt on an unproven channel gets the short bound. A request dropped in the
-   * open window is answered by resending at once, but a link slow enough to miss 500ms twice is
-   * slow rather than dropping, and hard-failing it would strand the high-RTT clients the 10s bound
+   * Only the first send on an unproven channel gets the short bound. A request dropped in the open
+   * window is answered by resending at once, but a link slow enough to miss 500ms twice is slow
+   * rather than dropping, and hard-failing it would strand the high-RTT clients the 10s bound
    * exists for.
    */
-  private waitForResponse = async (requestId: string, firstAttempt: boolean): Promise<PreferLayerResponse> => {
-    const unproven = firstAttempt && !this.channelProven;
+  private waitForResponse = async (requestId: string, firstSend: boolean): Promise<PreferLayerResponse> => {
+    const unproven = firstSend && !this.channelProven;
     const res = (await this.abortOnClose(
       this.eventEmitter.waitFor('message', {
         filter: (value: string) => value.includes(requestId),

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
@@ -28,6 +28,18 @@ export default class HMSSubscribeConnection extends HMSConnection {
    * apply stale desired state over a newer request.
    */
   private readonly RESPONSE_TIMEOUT = 10000;
+  /**
+   * The SFU creates this channel, so by DCEP the client's `open` fires a half-RTT before the SFU's
+   * and a request sent in that window is dropped before it arrives. Replies measure single-digit
+   * ms, so a request with no answer by now was lost rather than slow - and every ms spent waiting
+   * is a black tile. Applies only until the SFU has answered once; see `channelProven`.
+   */
+  private readonly UNPROVEN_CHANNEL_TIMEOUT = 500;
+  /**
+   * Any reply proves the SFU's end of the channel is up, so the open race is behind us and a slow
+   * reply is the SFU being slow. Reset per channel: an SFU migration binds a new one.
+   */
+  private channelProven = false;
 
   readonly nativeConnection: RTCPeerConnection;
 
@@ -62,10 +74,12 @@ export default class HMSSubscribeConnection extends HMSConnection {
         return;
       }
 
+      this.channelProven = false;
       this.apiChannel = new HMSDataChannel(
         e.channel,
         {
           onMessage: (value: string) => {
+            this.channelProven = true;
             this.eventEmitter.emit('message', value);
             this.observer.onApiChannelMessage(value);
           },
@@ -354,7 +368,7 @@ export default class HMSSubscribeConnection extends HMSConnection {
     const res = (await this.abortOnClose(
       this.eventEmitter.waitFor('message', {
         filter: (value: string) => value.includes(requestId),
-        timeout: this.RESPONSE_TIMEOUT,
+        timeout: this.channelProven ? this.RESPONSE_TIMEOUT : this.UNPROVEN_CHANNEL_TIMEOUT,
       } as WaitForOptions) as CancelablePromise<unknown>,
     )) as unknown[];
     const response = JSON.parse(res[0] as string);

--- a/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
+++ b/packages/hms-video-store/src/connection/subscribe/subscribeConnection.ts
@@ -183,7 +183,7 @@ export default class HMSSubscribeConnection extends HMSConnection {
       const disableAutoUnsubscribe = this.isFlagEnabled(InitFlags.FLAG_DISABLE_VIDEO_TRACK_AUTO_UNSUBSCRIBE);
       if (disableAutoUnsubscribe && message.params.max_spatial_layer === HMSSimulcastLayer.NONE) {
         HMSLogger.d(this.TAG, 'video auto unsubscribe is disabled, request is ignored');
-        return { id } as PreferLayerResponse;
+        return { id, dropped: true } as PreferLayerResponse;
       }
     }
     const request = JSON.stringify({
@@ -257,7 +257,7 @@ export default class HMSSubscribeConnection extends HMSConnection {
      */
     const dropped = () => {
       HMSLogger.d(this.TAG, `Dropping ${requestId} - ${this.closed ? 'closed' : 'superseded'}`, request);
-      return { id: requestId } as PreferLayerResponse;
+      return { id: requestId, dropped: true } as PreferLayerResponse;
     };
     let response: PreferLayerResponse | undefined;
     /** the per-attempt detail is a warn, which an app on setLogLevel(ERROR) never sees */
@@ -277,7 +277,7 @@ export default class HMSSubscribeConnection extends HMSConnection {
         }
         // send can throw too - the channel may close between the open check and here
         this.apiChannel!.send(request);
-        response = await this.waitForResponse(requestId);
+        response = await this.waitForResponse(requestId, i === 0);
       } catch (error) {
         lastAttemptError = error as Error;
         HMSLogger.w(this.TAG, `Attempt failed for ${requestId}`, { request, try: i + 1, error });
@@ -364,11 +364,18 @@ export default class HMSSubscribeConnection extends HMSConnection {
     );
   };
 
-  private waitForResponse = async (requestId: string): Promise<PreferLayerResponse> => {
+  /**
+   * Only the first attempt on an unproven channel gets the short bound. A request dropped in the
+   * open window is answered by resending at once, but a link slow enough to miss 500ms twice is
+   * slow rather than dropping, and hard-failing it would strand the high-RTT clients the 10s bound
+   * exists for.
+   */
+  private waitForResponse = async (requestId: string, firstAttempt: boolean): Promise<PreferLayerResponse> => {
+    const unproven = firstAttempt && !this.channelProven;
     const res = (await this.abortOnClose(
       this.eventEmitter.waitFor('message', {
         filter: (value: string) => value.includes(requestId),
-        timeout: this.channelProven ? this.RESPONSE_TIMEOUT : this.UNPROVEN_CHANNEL_TIMEOUT,
+        timeout: unproven ? this.UNPROVEN_CHANNEL_TIMEOUT : this.RESPONSE_TIMEOUT,
       } as WaitForOptions) as CancelablePromise<unknown>,
     )) as unknown[];
     const response = JSON.parse(res[0] as string);

--- a/packages/hms-video-store/src/media/streams/HMSRemoteStream.ts
+++ b/packages/hms-video-store/src/media/streams/HMSRemoteStream.ts
@@ -9,13 +9,16 @@ export class HMSRemoteStream extends HMSMediaStream {
   private audio = true;
   private video = HMSSimulcastLayer.NONE;
   /**
-   * `audio` and `video` hold the state we want; these say whether the SFU acknowledged it. Repeat
-   * requests dedupe against the desired value, so without this a request the SFU never applied -
-   * the first of a session is the one at risk - would silently swallow every later attempt to
-   * reach that same state, and the track never recovers.
+   * `audio` and `video` hold the state we want; these two pairs say how far it got. Repeat requests
+   * dedupe against the desired value, so without them a request the SFU never applied - the first
+   * of a session is the one at risk - silently swallows every later attempt to reach that same
+   * state and the track never recovers. Deduping needs both: `confirmed` alone would re-send on
+   * every resize while a request is still in flight.
    */
-  private audioConfirmed = true;
-  private videoConfirmed = true;
+  private confirmedAudio = true;
+  private confirmedVideo = HMSSimulcastLayer.NONE;
+  private inFlightAudio?: boolean;
+  private inFlightVideo?: HMSSimulcastLayer;
 
   constructor(nativeStream: MediaStream, connection: HMSSubscribeConnection) {
     super(nativeStream);
@@ -23,29 +26,40 @@ export class HMSRemoteStream extends HMSMediaStream {
   }
 
   async setAudio(enabled: boolean, trackId: string, identifier?: string) {
-    if (this.audio === enabled && this.audioConfirmed) {
+    if (this.isAudioSettled(enabled)) {
       return;
     }
 
     this.audio = enabled;
-    this.audioConfirmed = false;
+    this.inFlightAudio = enabled;
     HMSLogger.d(
       `[Remote stream] ${identifier || ''}
     streamId=${this.id}
     trackId=${trackId}
     subscribing audio - ${this.audio}`,
     );
-    await this.connection.sendOverApiDataChannelWithResponse({
-      params: {
-        subscribed: this.audio,
-        track_id: trackId,
-      },
-      method: 'prefer-audio-track-state',
-    });
-    // a newer request owns the field by now and will confirm its own value
-    if (this.audio === enabled) {
-      this.audioConfirmed = true;
+    try {
+      const response = await this.connection.sendOverApiDataChannelWithResponse({
+        params: {
+          subscribed: this.audio,
+          track_id: trackId,
+        },
+        method: 'prefer-audio-track-state',
+      });
+      // a dropped response never reached the SFU; the request that replaced this one owns the state
+      if (!response?.dropped) {
+        this.confirmedAudio = enabled;
+      }
+    } finally {
+      if (this.inFlightAudio === enabled) {
+        this.inFlightAudio = undefined;
+      }
     }
+  }
+
+  /** true when the SFU is known to be on `enabled`, or a request for it is already on the wire */
+  private isAudioSettled(enabled: boolean) {
+    return this.inFlightAudio === undefined ? this.confirmedAudio === enabled : this.inFlightAudio === enabled;
   }
 
   /**
@@ -54,6 +68,12 @@ export class HMSRemoteStream extends HMSMediaStream {
    * @param layer is simulcast layer to be set
    * @param identifier is stream identifier to be printed in logs
    */
+  /** the SFU telling us where it already is - authoritative, so no request is needed to reach it */
+  setVideoLayerFromServer(layer: HMSSimulcastLayer, identifier: string, source: string) {
+    this.confirmedVideo = layer;
+    this.setVideoLayerLocally(layer, identifier, source);
+  }
+
   setVideoLayerLocally(layer: HMSSimulcastLayer, identifier: string, source: string) {
     this.video = layer;
     HMSLogger.d(`[Remote stream] ${identifier}
@@ -76,7 +96,12 @@ export class HMSRemoteStream extends HMSMediaStream {
       source: ${source} request ${layer} layer`,
     );
     this.setVideoLayerLocally(layer, identifier, source);
-    this.videoConfirmed = false;
+    this.inFlightVideo = layer;
+    const settle = () => {
+      if (this.inFlightVideo === layer) {
+        this.inFlightVideo = undefined;
+      }
+    };
     return this.connection
       .sendOverApiDataChannelWithResponse({
         params: {
@@ -86,12 +111,22 @@ export class HMSRemoteStream extends HMSMediaStream {
         method: 'prefer-video-track-state',
       })
       .then(response => {
-        // a newer request owns the field by now and will confirm its own layer
-        if (this.video === layer) {
-          this.videoConfirmed = true;
+        // a dropped response never reached the SFU; the request that replaced this one owns the layer
+        if (!response?.dropped) {
+          this.confirmedVideo = layer;
         }
+        settle();
         return response;
+      })
+      .catch(error => {
+        settle();
+        throw error;
       });
+  }
+
+  /** true when the SFU is known to be on `layer`, or a request for it is already on the wire */
+  isVideoLayerSettled(layer: HMSSimulcastLayer) {
+    return this.inFlightVideo === undefined ? this.confirmedVideo === layer : this.inFlightVideo === layer;
   }
 
   /**

--- a/packages/hms-video-store/src/media/streams/HMSRemoteStream.ts
+++ b/packages/hms-video-store/src/media/streams/HMSRemoteStream.ts
@@ -141,11 +141,6 @@ export class HMSRemoteStream extends HMSMediaStream {
     return this.video;
   }
 
-  /** false when the SFU never acknowledged the current layer, so a repeat request must go out */
-  isVideoLayerConfirmed() {
-    return this.videoConfirmed;
-  }
-
   isAudioSubscribed() {
     return this.audio;
   }

--- a/packages/hms-video-store/src/media/streams/HMSRemoteStream.ts
+++ b/packages/hms-video-store/src/media/streams/HMSRemoteStream.ts
@@ -8,6 +8,14 @@ export class HMSRemoteStream extends HMSMediaStream {
   private readonly connection: HMSSubscribeConnection;
   private audio = true;
   private video = HMSSimulcastLayer.NONE;
+  /**
+   * `audio` and `video` hold the state we want; these say whether the SFU acknowledged it. Repeat
+   * requests dedupe against the desired value, so without this a request the SFU never applied -
+   * the first of a session is the one at risk - would silently swallow every later attempt to
+   * reach that same state, and the track never recovers.
+   */
+  private audioConfirmed = true;
+  private videoConfirmed = true;
 
   constructor(nativeStream: MediaStream, connection: HMSSubscribeConnection) {
     super(nativeStream);
@@ -15,13 +23,14 @@ export class HMSRemoteStream extends HMSMediaStream {
   }
 
   async setAudio(enabled: boolean, trackId: string, identifier?: string) {
-    if (this.audio === enabled) {
+    if (this.audio === enabled && this.audioConfirmed) {
       return;
     }
 
     this.audio = enabled;
+    this.audioConfirmed = false;
     HMSLogger.d(
-      `[Remote stream] ${identifier || ''} 
+      `[Remote stream] ${identifier || ''}
     streamId=${this.id}
     trackId=${trackId}
     subscribing audio - ${this.audio}`,
@@ -33,6 +42,10 @@ export class HMSRemoteStream extends HMSMediaStream {
       },
       method: 'prefer-audio-track-state',
     });
+    // a newer request owns the field by now and will confirm its own value
+    if (this.audio === enabled) {
+      this.audioConfirmed = true;
+    }
   }
 
   /**
@@ -63,13 +76,22 @@ export class HMSRemoteStream extends HMSMediaStream {
       source: ${source} request ${layer} layer`,
     );
     this.setVideoLayerLocally(layer, identifier, source);
-    return this.connection.sendOverApiDataChannelWithResponse({
-      params: {
-        max_spatial_layer: this.video,
-        track_id: trackId,
-      },
-      method: 'prefer-video-track-state',
-    });
+    this.videoConfirmed = false;
+    return this.connection
+      .sendOverApiDataChannelWithResponse({
+        params: {
+          max_spatial_layer: this.video,
+          track_id: trackId,
+        },
+        method: 'prefer-video-track-state',
+      })
+      .then(response => {
+        // a newer request owns the field by now and will confirm its own layer
+        if (this.video === layer) {
+          this.videoConfirmed = true;
+        }
+        return response;
+      });
   }
 
   /**
@@ -82,6 +104,11 @@ export class HMSRemoteStream extends HMSMediaStream {
 
   getVideoLayer() {
     return this.video;
+  }
+
+  /** false when the SFU never acknowledged the current layer, so a repeat request must go out */
+  isVideoLayerConfirmed() {
+    return this.videoConfirmed;
   }
 
   isAudioSubscribed() {

--- a/packages/hms-video-store/src/media/streams/HMSRemoteStream.ts
+++ b/packages/hms-video-store/src/media/streams/HMSRemoteStream.ts
@@ -1,4 +1,5 @@
 import { HMSMediaStream } from './HMSMediaStream';
+import { PreferLayerResponse } from '../../connection/channel-messages';
 import HMSSubscribeConnection from '../../connection/subscribe/subscribeConnection';
 import { HMSSimulcastLayer } from '../../interfaces';
 import HMSLogger from '../../utils/logger';
@@ -17,8 +18,13 @@ export class HMSRemoteStream extends HMSMediaStream {
    */
   private confirmedAudio = true;
   private confirmedVideo = HMSSimulcastLayer.NONE;
-  private inFlightAudio?: boolean;
-  private inFlightVideo?: HMSSimulcastLayer;
+  /**
+   * Stamped with a sequence rather than matched by value: two requests for the same value can
+   * overlap, and an older one settling must not clear the claim of a newer one still on the wire.
+   */
+  private audioRequest?: { enabled: boolean; seq: number };
+  private videoRequest?: { layer: HMSSimulcastLayer; seq: number };
+  private seq = 0;
 
   constructor(nativeStream: MediaStream, connection: HMSSubscribeConnection) {
     super(nativeStream);
@@ -26,12 +32,16 @@ export class HMSRemoteStream extends HMSMediaStream {
   }
 
   async setAudio(enabled: boolean, trackId: string, identifier?: string) {
-    if (this.isAudioSettled(enabled)) {
+    // the desired value has to match too: a request that failed after the SFU applied it leaves
+    // `confirmed` on a value the SFU has already moved off, and deduping on that alone would
+    // swallow the very call that corrects it - a peer silent for the rest of the session
+    if (this.audio === enabled && this.isAudioSettled(enabled)) {
       return;
     }
 
     this.audio = enabled;
-    this.inFlightAudio = enabled;
+    const seq = ++this.seq;
+    this.audioRequest = { enabled, seq };
     HMSLogger.d(
       `[Remote stream] ${identifier || ''}
     streamId=${this.id}
@@ -46,20 +56,37 @@ export class HMSRemoteStream extends HMSMediaStream {
         },
         method: 'prefer-audio-track-state',
       });
-      // a dropped response never reached the SFU; the request that replaced this one owns the state
-      if (!response?.dropped) {
+      if (this.isApplied(response, this.audio === enabled)) {
         this.confirmedAudio = enabled;
       }
     } finally {
-      if (this.inFlightAudio === enabled) {
-        this.inFlightAudio = undefined;
+      if (this.audioRequest?.seq === seq) {
+        this.audioRequest = undefined;
       }
     }
   }
 
   /** true when the SFU is known to be on `enabled`, or a request for it is already on the wire */
   private isAudioSettled(enabled: boolean) {
-    return this.inFlightAudio === undefined ? this.confirmedAudio === enabled : this.inFlightAudio === enabled;
+    return this.audioRequest ? this.audioRequest.enabled === enabled : this.confirmedAudio === enabled;
+  }
+
+  /**
+   * A dropped response never reached the SFU and an error - 404 included - is it refusing rather
+   * than applying. `stillDesired` covers the rest: a replaced request can be answered after the
+   * one that replaced it, and confirming then records a state the SFU has already moved off.
+   */
+  private isApplied(response: PreferLayerResponse | undefined, stillDesired: boolean) {
+    return stillDesired && !response?.dropped && !response?.error;
+  }
+
+  /** the SFU telling us where it already is - authoritative, so no request is needed to reach it */
+  setVideoLayerFromServer(layer: HMSSimulcastLayer, identifier: string, source: string) {
+    this.confirmedVideo = layer;
+    // drop any claim still on the wire: it describes a layer the SFU has just contradicted, and
+    // isVideoLayerSettled prefers the claim, which would hide this value from the dedupe
+    this.videoRequest = undefined;
+    this.setVideoLayerLocally(layer, identifier, source);
   }
 
   /**
@@ -68,12 +95,6 @@ export class HMSRemoteStream extends HMSMediaStream {
    * @param layer is simulcast layer to be set
    * @param identifier is stream identifier to be printed in logs
    */
-  /** the SFU telling us where it already is - authoritative, so no request is needed to reach it */
-  setVideoLayerFromServer(layer: HMSSimulcastLayer, identifier: string, source: string) {
-    this.confirmedVideo = layer;
-    this.setVideoLayerLocally(layer, identifier, source);
-  }
-
   setVideoLayerLocally(layer: HMSSimulcastLayer, identifier: string, source: string) {
     this.video = layer;
     HMSLogger.d(`[Remote stream] ${identifier}
@@ -88,45 +109,38 @@ export class HMSRemoteStream extends HMSMediaStream {
    * @param layer is simulcast layer to be set
    * @param identifier is stream identifier to be printed in logs
    */
-  setVideoLayer(layer: HMSSimulcastLayer, trackId: string, identifier: string, source: string) {
+  async setVideoLayer(layer: HMSSimulcastLayer, trackId: string, identifier: string, source: string) {
     HMSLogger.d(
-      `[Remote stream] ${identifier} 
+      `[Remote stream] ${identifier}
       streamId=${this.id}
-      trackId=${trackId} 
+      trackId=${trackId}
       source: ${source} request ${layer} layer`,
     );
     this.setVideoLayerLocally(layer, identifier, source);
-    this.inFlightVideo = layer;
-    const settle = () => {
-      if (this.inFlightVideo === layer) {
-        this.inFlightVideo = undefined;
-      }
-    };
-    return this.connection
-      .sendOverApiDataChannelWithResponse({
+    const seq = ++this.seq;
+    this.videoRequest = { layer, seq };
+    try {
+      const response = await this.connection.sendOverApiDataChannelWithResponse({
         params: {
           max_spatial_layer: this.video,
           track_id: trackId,
         },
         method: 'prefer-video-track-state',
-      })
-      .then(response => {
-        // a dropped response never reached the SFU; the request that replaced this one owns the layer
-        if (!response?.dropped) {
-          this.confirmedVideo = layer;
-        }
-        settle();
-        return response;
-      })
-      .catch(error => {
-        settle();
-        throw error;
       });
+      if (this.isApplied(response, this.video === layer)) {
+        this.confirmedVideo = layer;
+      }
+      return response;
+    } finally {
+      if (this.videoRequest?.seq === seq) {
+        this.videoRequest = undefined;
+      }
+    }
   }
 
   /** true when the SFU is known to be on `layer`, or a request for it is already on the wire */
   isVideoLayerSettled(layer: HMSSimulcastLayer) {
-    return this.inFlightVideo === undefined ? this.confirmedVideo === layer : this.inFlightVideo === layer;
+    return this.videoRequest ? this.videoRequest.layer === layer : this.confirmedVideo === layer;
   }
 
   /**

--- a/packages/hms-video-store/src/media/streams/stream.test.ts
+++ b/packages/hms-video-store/src/media/streams/stream.test.ts
@@ -12,7 +12,7 @@ describe('HMSRemoteStream', () => {
   let stream: HMSRemoteStream;
   let sendOverApiDataChannelWithResponse: jest.Mock;
   beforeEach(() => {
-    sendOverApiDataChannelWithResponse = jest.fn();
+    sendOverApiDataChannelWithResponse = jest.fn().mockResolvedValue({});
     const connection = { sendOverApiDataChannelWithResponse } as unknown as HMSSubscribeConnection;
     stream = new HMSRemoteStream(nativeStream, connection);
   });
@@ -77,6 +77,59 @@ describe('HMSRemoteStream', () => {
     expectVideoSubscriptionMessage({
       track_id: videoTrackId,
       max_spatial_layer: HMSSimulcastLayer.MEDIUM,
+    });
+  });
+
+  /**
+   * Repeat requests dedupe against the desired value, which is set before the request goes out. A
+   * request the SFU never applied must not swallow the next attempt to reach that same state -
+   * the shape behind the Sep 2026 white recordings.
+   */
+  describe('when the request fails', () => {
+    const rejects = () => sendOverApiDataChannelWithResponse.mockRejectedValue(Error('No response from SFU'));
+
+    it('reports the video layer as unconfirmed', async () => {
+      rejects();
+      await expect(stream.setVideoLayer(HMSSimulcastLayer.HIGH, videoTrackId, 'test', 'src')).rejects.toThrow();
+      expect(stream.isVideoLayerConfirmed()).toBe(false);
+    });
+
+    it('sends the same audio state again instead of deduping against it', async () => {
+      rejects();
+      await expect(stream.setAudio(false, audioTrackId)).rejects.toThrow();
+
+      sendOverApiDataChannelWithResponse.mockResolvedValue({});
+      await stream.setAudio(false, audioTrackId);
+
+      expect(sendOverApiDataChannelWithResponse).toHaveBeenCalledTimes(2);
+      expect(stream.isAudioSubscribed()).toBe(false);
+    });
+
+    it('dedupes again once the SFU confirms', async () => {
+      rejects();
+      await expect(stream.setAudio(false, audioTrackId)).rejects.toThrow();
+
+      sendOverApiDataChannelWithResponse.mockResolvedValue({});
+      await stream.setAudio(false, audioTrackId);
+      await stream.setAudio(false, audioTrackId);
+
+      expect(sendOverApiDataChannelWithResponse).toHaveBeenCalledTimes(2);
+    });
+
+    /** a newer request owns the state, so an older one settling must not confirm its layer */
+    it('does not confirm a layer a newer request replaced', async () => {
+      let failFirst!: (error: Error) => void;
+      sendOverApiDataChannelWithResponse
+        .mockImplementationOnce(() => new Promise((_resolve, reject) => (failFirst = reject)))
+        .mockImplementationOnce(() => new Promise(() => undefined));
+
+      const first = stream.setVideoLayer(HMSSimulcastLayer.HIGH, videoTrackId, 'test', 'first').catch(error => error);
+      stream.setVideoLayer(HMSSimulcastLayer.MEDIUM, videoTrackId, 'test', 'second').catch(() => undefined);
+      failFirst(Error('No response from SFU'));
+      await first;
+
+      expect(stream.getVideoLayer()).toBe(HMSSimulcastLayer.MEDIUM);
+      expect(stream.isVideoLayerConfirmed()).toBe(false);
     });
   });
 });

--- a/packages/hms-video-store/src/media/streams/stream.test.ts
+++ b/packages/hms-video-store/src/media/streams/stream.test.ts
@@ -88,10 +88,10 @@ describe('HMSRemoteStream', () => {
   describe('when the request fails', () => {
     const rejects = () => sendOverApiDataChannelWithResponse.mockRejectedValue(Error('No response from SFU'));
 
-    it('reports the video layer as unconfirmed', async () => {
+    it('reports the video layer as unsettled', async () => {
       rejects();
       await expect(stream.setVideoLayer(HMSSimulcastLayer.HIGH, videoTrackId, 'test', 'src')).rejects.toThrow();
-      expect(stream.isVideoLayerConfirmed()).toBe(false);
+      expect(stream.isVideoLayerSettled(HMSSimulcastLayer.HIGH)).toBe(false);
     });
 
     it('sends the same audio state again instead of deduping against it', async () => {
@@ -129,7 +129,41 @@ describe('HMSRemoteStream', () => {
       await first;
 
       expect(stream.getVideoLayer()).toBe(HMSSimulcastLayer.MEDIUM);
-      expect(stream.isVideoLayerConfirmed()).toBe(false);
+      expect(stream.isVideoLayerSettled(HMSSimulcastLayer.HIGH)).toBe(false);
     });
+
+    /**
+     * A superseded request resolves locally without the SFU ever seeing it. Reading that as an
+     * acknowledgement re-creates the swallowed-retry bug for the very case most likely to hit it:
+     * two requests for the same value, neither answered.
+     */
+    it('does not treat a superseded resolution as an acknowledgement', async () => {
+      sendOverApiDataChannelWithResponse.mockResolvedValue({ id: 'req', dropped: true });
+
+      await stream.setAudio(false, audioTrackId);
+      expect(stream.isAudioSubscribed()).toBe(false);
+
+      sendOverApiDataChannelWithResponse.mockClear();
+      await stream.setAudio(false, audioTrackId);
+
+      expect(sendOverApiDataChannelWithResponse).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /** repeated triggers while a request is in flight must not fan out duplicates of it */
+  it('dedupes a repeat request for a layer already on the wire', async () => {
+    sendOverApiDataChannelWithResponse.mockImplementation(() => new Promise(() => undefined));
+
+    stream.setVideoLayer(HMSSimulcastLayer.HIGH, videoTrackId, 'test', 'resize').catch(() => undefined);
+
+    expect(stream.isVideoLayerSettled(HMSSimulcastLayer.HIGH)).toBe(true);
+    expect(stream.isVideoLayerSettled(HMSSimulcastLayer.LOW)).toBe(false);
+  });
+
+  /** a layer the SFU reports is already applied - no request needed to reach it */
+  it('treats a server-sent layer as settled', () => {
+    stream.setVideoLayerFromServer(HMSSimulcastLayer.LOW, 'test', 'setLayerFromServer');
+
+    expect(stream.isVideoLayerSettled(HMSSimulcastLayer.LOW)).toBe(true);
   });
 });

--- a/packages/hms-video-store/src/media/streams/stream.test.ts
+++ b/packages/hms-video-store/src/media/streams/stream.test.ts
@@ -105,6 +105,33 @@ describe('HMSRemoteStream', () => {
       expect(stream.isAudioSubscribed()).toBe(false);
     });
 
+    /**
+     * A failure is not proof the SFU stayed where it was - the reply is the only thing known to be
+     * lost. Deduping the correcting call against `confirmed` alone leaves the peer silent for the
+     * rest of the session, which is the bug this whole pair exists to prevent.
+     */
+    it('sends the opposite audio state again after a failure', async () => {
+      rejects();
+      await expect(stream.setAudio(false, audioTrackId)).rejects.toThrow();
+
+      sendOverApiDataChannelWithResponse.mockResolvedValue({});
+      await stream.setAudio(true, audioTrackId);
+
+      expect(sendOverApiDataChannelWithResponse).toHaveBeenCalledTimes(2);
+      expect(stream.isAudioSubscribed()).toBe(true);
+    });
+
+    /** an error reply is the SFU refusing, not applying - confirming it swallows the next attempt */
+    it('does not treat an error response as an acknowledgement', async () => {
+      sendOverApiDataChannelWithResponse.mockResolvedValue({ id: 'req', error: { code: 404, message: 'gone' } });
+      await stream.setAudio(false, audioTrackId);
+
+      sendOverApiDataChannelWithResponse.mockClear();
+      await stream.setAudio(false, audioTrackId);
+
+      expect(sendOverApiDataChannelWithResponse).toHaveBeenCalledTimes(1);
+    });
+
     it('dedupes again once the SFU confirms', async () => {
       rejects();
       await expect(stream.setAudio(false, audioTrackId)).rejects.toThrow();
@@ -158,6 +185,24 @@ describe('HMSRemoteStream', () => {
 
     expect(stream.isVideoLayerSettled(HMSSimulcastLayer.HIGH)).toBe(true);
     expect(stream.isVideoLayerSettled(HMSSimulcastLayer.LOW)).toBe(false);
+  });
+
+  /** two requests can ask for the same layer; an older one settling must not free the newer's claim */
+  it('keeps the newer claim when an older request for the same layer settles', async () => {
+    let settleFirst!: (value: unknown) => void;
+    sendOverApiDataChannelWithResponse
+      .mockImplementationOnce(() => new Promise(resolve => (settleFirst = resolve)))
+      .mockImplementation(() => new Promise(() => undefined));
+
+    const first = stream.setVideoLayer(HMSSimulcastLayer.HIGH, videoTrackId, 'test', 'first');
+    stream.setVideoLayer(HMSSimulcastLayer.LOW, videoTrackId, 'test', 'second').catch(() => undefined);
+    stream.setVideoLayer(HMSSimulcastLayer.HIGH, videoTrackId, 'test', 'third').catch(() => undefined);
+
+    settleFirst({ id: 'req', dropped: true });
+    await first;
+
+    // the third request is still on the wire asking for HIGH
+    expect(stream.isVideoLayerSettled(HMSSimulcastLayer.HIGH)).toBe(true);
   });
 
   /** a layer the SFU reports is already applied - no request needed to reach it */

--- a/packages/hms-video-store/src/media/tracks/HMSRemoteVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSRemoteVideoTrack.ts
@@ -163,7 +163,7 @@ export class HMSRemoteVideoTrack extends HMSVideoTrack {
       isDegraded=${this._degraded}`,
     );
     // No need to send preferLayer update, as server has done it already
-    (this.stream as HMSRemoteStream).setVideoLayerLocally(currentLayer, this.logIdentifier, 'setLayerFromServer');
+    (this.stream as HMSRemoteStream).setVideoLayerFromServer(currentLayer, this.logIdentifier, 'setLayerFromServer');
     this.pushInHistory(`sfuLayerUpdate-${currentLayer}`);
     return this._degraded;
   }
@@ -240,8 +240,9 @@ export class HMSRemoteVideoTrack extends HMSVideoTrack {
     if (this.degraded && targetLayer === HMSSimulcastLayer.NONE) {
       return true;
     }
-    // only dedupe against a layer the SFU acknowledged - one it never applied has to be re-sent
-    if (currLayer === targetLayer && (this.stream as HMSRemoteStream).isVideoLayerConfirmed()) {
+    // dedupe against the layer the SFU acknowledged or is being asked for - one it never applied
+    // has to be re-sent, or the track stays on a layer nobody is sending
+    if (currLayer === targetLayer && (this.stream as HMSRemoteStream).isVideoLayerSettled(targetLayer)) {
       HMSLogger.d(
         `[Remote Track] ${this.logIdentifier}`,
         `Not sending update, already on layer ${targetLayer}, source=${source}`,

--- a/packages/hms-video-store/src/media/tracks/HMSRemoteVideoTrack.ts
+++ b/packages/hms-video-store/src/media/tracks/HMSRemoteVideoTrack.ts
@@ -240,7 +240,8 @@ export class HMSRemoteVideoTrack extends HMSVideoTrack {
     if (this.degraded && targetLayer === HMSSimulcastLayer.NONE) {
       return true;
     }
-    if (currLayer === targetLayer) {
+    // only dedupe against a layer the SFU acknowledged - one it never applied has to be re-sent
+    if (currLayer === targetLayer && (this.stream as HMSRemoteStream).isVideoLayerConfirmed()) {
       HMSLogger.d(
         `[Remote Track] ${this.logIdentifier}`,
         `Not sending update, already on layer ${targetLayer}, source=${source}`,

--- a/packages/hms-video-store/src/media/tracks/RemoteVideoTrack.test.ts
+++ b/packages/hms-video-store/src/media/tracks/RemoteVideoTrack.test.ts
@@ -16,7 +16,7 @@ describe('remoteVideoTrack', () => {
   let nativeTrack: MediaStreamTrack;
   beforeEach(() => {
     videoElement = document.createElement('video');
-    sendOverApiDataChannelWithResponse = jest.fn();
+    sendOverApiDataChannelWithResponse = jest.fn().mockResolvedValue({});
     const connection = { sendOverApiDataChannelWithResponse } as unknown as HMSSubscribeConnection;
     stream = new HMSRemoteStream(nativeStream, connection);
     nativeTrack = { id: trackId, kind: 'video', enabled: true } as MediaStreamTrack;
@@ -168,7 +168,7 @@ describe('HMSRemoteVideoTrack with disableNoneLayerRequest', () => {
 
   beforeEach(() => {
     videoElement = document.createElement('video');
-    sendOverApiDataChannelWithResponse = jest.fn();
+    sendOverApiDataChannelWithResponse = jest.fn().mockResolvedValue({});
     const connection = { sendOverApiDataChannelWithResponse } as unknown as HMSSubscribeConnection;
     const nativeStream = new MediaStream();
     stream = new HMSRemoteStream(nativeStream, connection);

--- a/packages/hms-video-store/src/media/tracks/videoLayerFailure.test.ts
+++ b/packages/hms-video-store/src/media/tracks/videoLayerFailure.test.ts
@@ -141,6 +141,9 @@ describe('VideoElementManager layer request failures', () => {
  * no-op, so the tile stays black for the rest of the session.
  */
 describe('HMSRemoteVideoTrack after a failed layer request', () => {
+  // the spies below are on globals, so leaving them in place would follow the next suite
+  afterEach(() => jest.restoreAllMocks());
+
   it('sends the same layer again instead of deduping against the failed one', async () => {
     window.MediaStream = jest.fn().mockImplementation(() => ({ addTrack: jest.fn() })) as unknown as typeof MediaStream;
     jest.spyOn(window.HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);

--- a/packages/hms-video-store/src/media/tracks/videoLayerFailure.test.ts
+++ b/packages/hms-video-store/src/media/tracks/videoLayerFailure.test.ts
@@ -1,6 +1,7 @@
 import { HMSRemoteVideoTrack } from './HMSRemoteVideoTrack';
 import { VideoElementManager } from './VideoElementManager';
 import HMSSubscribeConnection from '../../connection/subscribe/subscribeConnection';
+import { HMSSimulcastLayer } from '../../interfaces';
 import HMSLogger from '../../utils/logger';
 import { HMSRemoteStream } from '../streams/HMSRemoteStream';
 
@@ -130,5 +131,41 @@ describe('VideoElementManager layer request failures', () => {
     );
 
     await expect(emptyTrack.addSink(videoElement, true)).rejects.toThrow('No response from SFU');
+  });
+});
+
+/**
+ * shouldSendVideoLayer dedupes against the stream's local layer, and that layer is set
+ * optimistically before the request goes out. Leaving it on a value the SFU never applied makes
+ * the app's next attempt - a resize, a re-intersection, an explicit setPreferredLayer - a silent
+ * no-op, so the tile stays black for the rest of the session.
+ */
+describe('HMSRemoteVideoTrack after a failed layer request', () => {
+  it('sends the same layer again instead of deduping against the failed one', async () => {
+    window.MediaStream = jest.fn().mockImplementation(() => ({ addTrack: jest.fn() })) as unknown as typeof MediaStream;
+    jest.spyOn(window.HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+    const send = jest.fn().mockResolvedValue({});
+    const stream = new HMSRemoteStream(
+      { id: 'stream-1' } as MediaStream,
+      {
+        sendOverApiDataChannelWithResponse: send,
+      } as unknown as HMSSubscribeConnection,
+    );
+    const track = new HMSRemoteVideoTrack(
+      stream,
+      { id: 'track-1', kind: 'video', enabled: true, addEventListener: jest.fn() } as unknown as MediaStreamTrack,
+      'regular',
+    );
+    // setPreferredLayer is a no-op without a sink; this also settles the default HIGH request, so
+    // the state under test is the rejection below rather than anything left over from attaching
+    await track.addSink(document.createElement('video'));
+    send.mockClear();
+    send.mockRejectedValueOnce(Error('No response from SFU'));
+
+    await expect(track.setPreferredLayer(HMSSimulcastLayer.MEDIUM)).rejects.toThrow('No response from SFU');
+    await track.setPreferredLayer(HMSSimulcastLayer.MEDIUM);
+
+    expect(send).toHaveBeenCalledTimes(2);
+    track.videoHandler.cleanup();
   });
 });


### PR DESCRIPTION
The SFU creates the api data channel, so by DCEP the client's `open` fires a half-RTT before the SFU's, and the first `prefer-audio-track-state` / `prefer-video-track-state` of a session can be discarded before it arrives. Two things then kept it lost: the reply timeout is 10s even though the SFU answers in single-digit ms, and `audio`/`video` hold the desired state that repeat requests dedupe against, so a request the SFU never applied silently swallowed every later attempt to reach that same state.

A request on a channel that has not yet been answered is now retried after 500ms instead of 10s, and subscription state is deduped only against a value the SFU acknowledged or one already on the wire.

Seen in production as a remote peer silent for a whole session, or a recording with no video at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)